### PR TITLE
Update block gas target formatting

### DIFF
--- a/src/special/london/BlockRow.tsx
+++ b/src/special/london/BlockRow.tsx
@@ -52,8 +52,8 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
           <span>
             {FixedNumber.fromValue(block.baseFeePerGas ?? 0n)
               .divUnsafe(FixedNumber.fromValue(1_000_000_000n))
-              .round(0)
-              .toUnsafeFloat()}{" "}
+              .toUnsafeFloat()
+              .toFixed(2)}{" "}
             Gwei
           </span>
           <Blip value={baseFeeDelta} />

--- a/src/special/london/BlockRow.tsx
+++ b/src/special/london/BlockRow.tsx
@@ -29,7 +29,7 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
         <BlockLink blockTag={block.number} />
       </div>
       <div
-        className={`text-right ${
+        className={`col-span-2 text-right ${
           block.gasUsed > gasTarget
             ? "text-emerald-500"
             : block.gasUsed < gasTarget
@@ -37,10 +37,15 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
             : ""
         }`}
       >
-        {commify(block.gasUsed.toString())}
-      </div>
-      <div className="text-right text-gray-400">
-        {commify(gasTarget.toString())}
+        {commify(block.gasUsed.toString())} (
+        {block.gasUsed > gasTarget ? "+" : ""}
+        {FixedNumber.fromValue(block.gasUsed)
+          .subUnsafe(FixedNumber.fromValue(gasTarget))
+          .mulUnsafe(FixedNumber.fromValue(100))
+          .divUnsafe(FixedNumber.fromValue(gasTarget))
+          .round(2)
+          .toUnsafeFloat()}
+        %)
       </div>
       <div className="text-right">
         <div className="relative">

--- a/src/special/london/Blocks.tsx
+++ b/src/special/london/Blocks.tsx
@@ -154,13 +154,12 @@ const Blocks: React.FC<BlocksProps> = ({ latestBlock, targetBlockNumber }) => {
             </span>
             <span>Block</span>
           </div>
-          <div className="flex items-baseline justify-end space-x-1 text-right">
+          <div className="col-span-2 flex items-baseline justify-end space-x-1 text-right">
             <span className="text-gray-500">
               <FontAwesomeIcon icon={faGasPump} />
             </span>
             <span>Gas used</span>
           </div>
-          <div className="text-right">Gas target</div>
           <div className="text-right">Base fee</div>
           <div className="col-span-2 flex items-baseline justify-end space-x-1 text-right">
             <span className="text-amber-400">


### PR DESCRIPTION
On the London screen, show the percentage of the gas usage relative to the gas target, like "18,450,975 (+23.01%)" and remove the gas target column.

Use two decimal places when showing the basefee.