### PR TITLE
Ignore 4bytes when function data fails to parse

### DIFF
--- a/src/use4Bytes.ts
+++ b/src/use4Bytes.ts
@@ -137,7 +137,11 @@ export const useTransactionDescription = (
     const sig = fourBytesEntry?.signature;
     const functionFragment = Fragment.fromString(`function ${sig}`);
     const intf = new Interface([functionFragment]);
-    return intf.parseTransaction({ data, value });
+    try {
+      return intf.parseTransaction({ data, value });
+    } catch {
+      return undefined;
+    }
   }, [fourBytesEntry, data, value]);
 
   return txDesc;


### PR DESCRIPTION
Fixes #950 

It also prevents #854 from crashing, but the offending function signature is still shown in the tracer.