### PR TITLE
Use local commify function from ethers v5

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,6 +1,5 @@
 import { useState, useContext, lazy, FC, memo } from "react";
 import { NavLink } from "react-router-dom";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQrcode } from "@fortawesome/free-solid-svg-icons";
 import Logo from "./Logo";
@@ -10,6 +9,7 @@ import { useLatestBlockHeader } from "./useLatestBlock";
 import { blockURL, slotURL } from "./url";
 import { useGenericSearch } from "./search/search";
 import { useFinalizedSlotNumber, useSlotTimestamp } from "./useConsensus";
+import { commify } from "./utils/utils";
 
 const CameraScanner = lazy(() => import("./search/CameraScanner"));
 

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useContext } from "react";
-import { commify, formatUnits } from "@ethersproject/units";
+import { formatUnits } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGasPump } from "@fortawesome/free-solid-svg-icons";
 import { RuntimeContext } from "./useRuntime";
@@ -7,6 +7,7 @@ import { formatValue } from "./components/formatter";
 import { useLatestBlockHeader } from "./useLatestBlock";
 import { useChainInfo } from "./useChainInfo";
 import { useETHUSDRawOracle, useFastGasRawOracle } from "./usePriceOracle";
+import { commify } from "./utils/utils";
 
 // TODO: encapsulate this magic number
 const ETH_FEED_DECIMALS = 8;

--- a/src/components/BlockConfirmations.tsx
+++ b/src/components/BlockConfirmations.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { commify } from "@ethersproject/units";
+import { commify } from "../utils/utils";
 
 type BlockConfirmationsProps = {
   confirmations: number;

--- a/src/components/BlockLink.tsx
+++ b/src/components/BlockLink.tsx
@@ -1,10 +1,10 @@
 import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
 import { BlockTag } from "@ethersproject/abstract-provider";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCube } from "@fortawesome/free-solid-svg-icons";
 import { blockURL } from "../url";
+import { commify } from "../utils/utils";
 
 type BlockLinkProps = {
   blockTag: BlockTag;

--- a/src/components/Nonce.tsx
+++ b/src/components/Nonce.tsx
@@ -1,7 +1,7 @@
 import { FC, memo } from "react";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUp } from "@fortawesome/free-solid-svg-icons";
+import { commify } from "../utils/utils";
 
 type NonceProps = {
   value: number;

--- a/src/components/formatter.ts
+++ b/src/components/formatter.ts
@@ -1,5 +1,6 @@
 import { BigNumberish } from "@ethersproject/bignumber";
-import { commify, formatUnits } from "@ethersproject/units";
+import { formatUnits } from "@ethersproject/units";
+import { commify } from "../utils/utils";
 
 export const formatValue = (value: BigNumberish, decimals: number): string => {
   const formatted = commify(formatUnits(value, decimals));

--- a/src/consensus/components/EpochLink.tsx
+++ b/src/consensus/components/EpochLink.tsx
@@ -1,10 +1,10 @@
 import { FC } from "react";
 import { NavLink } from "react-router-dom";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faList } from "@fortawesome/free-solid-svg-icons";
 import { EpochAwareComponentProps } from "../types";
 import { epochURL } from "../../url";
+import { commify } from "../../utils/utils";
 
 const EpochLink: FC<EpochAwareComponentProps> = ({ epochNumber }) => {
   let text = commify(epochNumber);

--- a/src/consensus/components/SlotLink.tsx
+++ b/src/consensus/components/SlotLink.tsx
@@ -1,11 +1,11 @@
 import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSquare } from "@fortawesome/free-solid-svg-icons";
 import { faSquare as faSquareRegular } from "@fortawesome/free-regular-svg-icons";
 import { SlotAwareComponentProps } from "../types";
 import { slotURL } from "../../url";
+import { commify } from "../../utils/utils";
 
 type SlotLinkProps = SlotAwareComponentProps & {
   missed?: boolean;

--- a/src/consensus/components/ValidatorLink.tsx
+++ b/src/consensus/components/ValidatorLink.tsx
@@ -1,9 +1,9 @@
 import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
-import { commify } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faUser, faUserSlash } from "@fortawesome/free-solid-svg-icons";
 import { validatorURL } from "../../url";
+import { commify } from "../../utils/utils";
 
 type ValidatorLinkProps = {
   validatorIndex: number;

--- a/src/consensus/epoch/StoredSlotItem.tsx
+++ b/src/consensus/epoch/StoredSlotItem.tsx
@@ -1,5 +1,4 @@
 import { FC, memo } from "react";
-import { commify } from "@ethersproject/units";
 import { SlotAwareComponentProps } from "../types";
 import SlotLink from "../components/SlotLink";
 import BlockLink from "../../components/BlockLink";
@@ -11,6 +10,7 @@ import AggregationParticipation from "../slot/AggregationParticipation";
 import RelevantNumericValue from "../../components/RelevantNumericValue";
 import SlashingCount from "../components/SlashingCount";
 import { useSlot } from "../../useConsensus";
+import { commify } from "../../utils/utils";
 
 const StoredSlotItem: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
   const { slot } = useSlot(slotNumber);

--- a/src/consensus/slot/Attestation.tsx
+++ b/src/consensus/slot/Attestation.tsx
@@ -1,11 +1,11 @@
 import { FC } from "react";
-import { commify } from "@ethersproject/units";
 import { useInView } from "react-intersection-observer";
 import InfoRow from "../../components/InfoRow";
 import HexValue from "../../components/HexValue";
 import AggregationBits from "./AggregationBits";
 import ValidatorList from "./ValidatorList";
 import EpochLink from "../components/EpochLink";
+import { commify } from "../../utils/utils";
 
 type AttestationProps = {
   idx: number;

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { commify } from "@ethersproject/units";
 import { toUtf8String } from "@ethersproject/strings";
 import ContentFrame from "../../components/ContentFrame";
 import OverviewSkeleton from "./OverviewSkeleton";
@@ -17,6 +16,7 @@ import AggregationParticipation from "./AggregationParticipation";
 import AggregationBits from "./AggregationBits";
 import SlashingCount from "../components/SlashingCount";
 import { slot2Epoch, useSlot, useSlotTimestamp } from "../../useConsensus";
+import { commify } from "../../utils/utils";
 
 const Overview: FC = () => {
   const { slotNumber } = useParams();

--- a/src/consensus/slot/SlotNotFound.tsx
+++ b/src/consensus/slot/SlotNotFound.tsx
@@ -1,8 +1,8 @@
 import { FC, memo } from "react";
-import { commify } from "@ethersproject/units";
 import { SlotAwareComponentProps } from "../types";
 import SlotLink from "../components/SlotLink";
 import { useHeadSlotNumber } from "../../useConsensus";
+import { commify } from "../../utils/utils";
 
 const SlotNotFound: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
   const headSlotNumber = useHeadSlotNumber();

--- a/src/consensus/validator/Overview.tsx
+++ b/src/consensus/validator/Overview.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect } from "react";
 import { BigNumber } from "@ethersproject/bignumber";
-import { commify } from "@ethersproject/units";
 import ContentFrame from "../../components/ContentFrame";
 import InfoRow from "../../components/InfoRow";
 import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
@@ -9,6 +8,7 @@ import Timestamp from "../../components/Timestamp";
 import HexValue from "../../components/HexValue";
 import EpochLink from "../components/EpochLink";
 import { useEpochTimestamp, useValidator } from "../../useConsensus";
+import { commify } from "../../utils/utils";
 
 const GWEI = BigNumber.from(10).pow(9);
 

--- a/src/execution/Block.tsx
+++ b/src/execution/Block.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useContext, FC } from "react";
 import { useParams, NavLink } from "react-router-dom";
-import { commify, formatUnits } from "@ethersproject/units";
+import { formatUnits } from "@ethersproject/units";
 import { toUtf8String, Utf8ErrorFuncs } from "@ethersproject/strings";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBurn } from "@fortawesome/free-solid-svg-icons";
@@ -26,6 +26,7 @@ import { blockTxsURL, blockURL } from "../url";
 import { useBlockPageTitle } from "../useTitle";
 import { useBlockData } from "../useErigonHooks";
 import { useChainInfo } from "../useChainInfo";
+import { commify } from "../utils/utils";
 
 const Block: FC = () => {
   const { provider } = useContext(RuntimeContext);

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useContext } from "react";
-import { commify } from "@ethersproject/units";
 import { Menu } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
@@ -12,6 +11,7 @@ import { Match, MatchType } from "../../sourcify/useSourcify";
 import ExternalLink from "../../components/ExternalLink";
 import { openInRemixURL } from "../../url";
 import ContractABI from "./contract/ContractABI";
+import { commify } from "../../utils/utils";
 
 type ContractsProps = {
   checksummedAddress: string;

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, useContext, useState } from "react";
-import { commify, formatUnits } from "@ethersproject/units";
+import { formatUnits } from "@ethersproject/units";
 import { Tab } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -52,6 +52,7 @@ import {
   useTransactionError,
 } from "../../useErigonHooks";
 import { useChainInfo } from "../../useChainInfo";
+import { commify } from "../../utils/utils";
 
 type DetailsProps = {
   txData: TransactionData;

--- a/src/execution/transaction/decoder/Uint256Decoder.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.tsx
@@ -1,9 +1,10 @@
 import { FC, memo, useState } from "react";
 import { BigNumber } from "@ethersproject/bignumber";
 import { hexlify, hexZeroPad } from "@ethersproject/bytes";
-import { commify, formatEther } from "@ethersproject/units";
+import { formatEther } from "@ethersproject/units";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSync } from "@fortawesome/free-solid-svg-icons";
+import { commify } from "../../../utils/utils";
 
 type Uint256DecoderProps = {
   r: any;

--- a/src/search/PageControl.tsx
+++ b/src/search/PageControl.tsx
@@ -1,6 +1,6 @@
 import { FC, memo } from "react";
 import PageButton from "./PageButton";
-import { commify } from "@ethersproject/units";
+import { commify } from "../utils/utils";
 
 type PageControlProps = {
   pageNumber: number;

--- a/src/search/TransactionItemFiatFee.tsx
+++ b/src/search/TransactionItemFiatFee.tsx
@@ -1,9 +1,9 @@
 import React, { useContext } from "react";
 import { BlockTag } from "@ethersproject/providers";
 import { BigNumber, FixedNumber } from "@ethersproject/bignumber";
-import { commify } from "@ethersproject/units";
 import { RuntimeContext } from "../useRuntime";
 import { useETHUSDOracle } from "../usePriceOracle";
+import { commify } from "../utils/utils";
 
 type TransactionItemFiatFeeProps = {
   blockTag: BlockTag;

--- a/src/search/messages.ts
+++ b/src/search/messages.ts
@@ -1,4 +1,4 @@
-import { commify } from "@ethersproject/units";
+import { commify } from "../utils/utils";
 
 export const totalTransactionsFormatter = (total: number) =>
   `A total of ${commify(total)} ${

--- a/src/special/london/BlockRow.tsx
+++ b/src/special/london/BlockRow.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { FixedNumber } from "@ethersproject/bignumber";
-import { commify, formatEther } from "@ethersproject/units";
+import { formatEther } from "@ethersproject/units";
 import BlockLink from "../../components/BlockLink";
 import TimestampAge from "../../components/TimestampAge";
 import Blip from "./Blip";
 import { ExtendedBlock } from "../../useErigonHooks";
 import { useChainInfo } from "../../useChainInfo";
+import { commify } from "../../utils/utils";
 
 const ELASTICITY_MULTIPLIER = 2;
 

--- a/src/special/london/Countdown.tsx
+++ b/src/special/london/Countdown.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { JsonRpcProvider, Block } from "@ethersproject/providers";
-import { commify } from "@ethersproject/units";
+import { commify } from "../../utils/utils";
 
 type CountdownProps = {
   provider: JsonRpcProvider;

--- a/src/special/london/chart.ts
+++ b/src/special/london/chart.ts
@@ -1,4 +1,4 @@
-import { commify } from "@ethersproject/units";
+import { commify } from "../../utils/utils";
 import { ChartData, ChartOptions } from "chart.js";
 import { ExtendedBlock } from "../../useErigonHooks";
 

--- a/src/usePriceOracle.ts
+++ b/src/usePriceOracle.ts
@@ -2,7 +2,6 @@ import { JsonRpcProvider, BlockTag } from "@ethersproject/providers";
 import { Contract } from "@ethersproject/contracts";
 import { BigNumber, FixedNumber } from "@ethersproject/bignumber";
 import { AddressZero } from "@ethersproject/constants";
-import { commify } from "@ethersproject/units";
 import AggregatorV3Interface from "@chainlink/contracts/abi/v0.8/AggregatorV3Interface.json";
 import FeedRegistryInterface from "@chainlink/contracts/abi/v0.8/FeedRegistryInterface.json";
 import { Fetcher } from "swr";
@@ -10,6 +9,7 @@ import useSWRImmutable from "swr/immutable";
 import { ChecksummedAddress } from "./types";
 import { useContext } from "react";
 import { RuntimeContext } from "./useRuntime";
+import { commify } from "./utils/utils";
 
 const FEED_REGISTRY_MAINNET: ChecksummedAddress =
   "0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf";

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { commify } from "@ethersproject/units";
+import { commify } from "./utils/utils";
 
 /**
  * Title for main block page.

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -40,3 +40,79 @@ export const ageString = (durationInSecs: number) => {
 
   return desc;
 };
+
+/*
+  MIT License
+
+  Copyright (c) 2019 Richard Moore
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+*/
+export function commify(value: string | number | bigint): string {
+  const comps = String(value).split(".");
+
+  if (
+    comps.length > 2 ||
+    !comps[0].match(/^-?[0-9]*$/) ||
+    (comps[1] && !comps[1].match(/^[0-9]*$/)) ||
+    value === "." ||
+    value === "-."
+  ) {
+    throw new Error("invalid commify value: " + value);
+  }
+
+  // Make sure we have at least one whole digit (0 if none)
+  let whole = comps[0];
+
+  let negative = "";
+  if (whole.substring(0, 1) === "-") {
+    negative = "-";
+    whole = whole.substring(1);
+  }
+
+  // Make sure we have at least 1 whole digit with no leading zeros
+  while (whole.substring(0, 1) === "0") {
+    whole = whole.substring(1);
+  }
+  if (whole === "") {
+    whole = "0";
+  }
+
+  let suffix = "";
+  if (comps.length === 2) {
+    suffix = "." + (comps[1] || "0");
+  }
+  while (suffix.length > 2 && suffix[suffix.length - 1] === "0") {
+    suffix = suffix.substring(0, suffix.length - 1);
+  }
+
+  const formatted = [];
+  while (whole.length) {
+    if (whole.length <= 3) {
+      formatted.unshift(whole);
+      break;
+    } else {
+      const index = whole.length - 3;
+      formatted.unshift(whole.substring(index));
+      whole = whole.substring(0, index);
+    }
+  }
+
+  return negative + formatted.join(",") + suffix;
+}


### PR DESCRIPTION
Adds the `commify` function from ethers v5 in preparation for upgrading to ethers v6, which removed it. Other alternatives, such as the locale-specific `Intl.NumberFormat.format` function, work with plain JavaScript numbers and are subject to floating point number precision issues.

Part of #1184.