### PR TITLE
Migrate to ethers v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@types/react-highlight": "^0.12.5",
         "@types/react-syntax-highlighter": "^15.5.7",
         "chart.js": "^4.3.3",
-        "ethers": "^5.7.2",
+        "ethers": "^6.7.1",
         "highlightjs-solidity": "^2.0.6",
         "react": "^18.2.0",
         "react-blockies": "^1.4.1",
@@ -79,6 +79,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g=="
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -2296,6 +2301,67 @@
         "@openzeppelin/contracts-v0.7": "npm:@openzeppelin/contracts@v3.4.2"
       }
     },
+    "node_modules/@chainlink/contracts/node_modules/@eth-optimism/contracts": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.5.40.tgz",
+      "integrity": "sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==",
+      "dependencies": {
+        "@eth-optimism/core-utils": "0.12.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/abstract-signer": "^5.7.0"
+      },
+      "peerDependencies": {
+        "ethers": "^5"
+      }
+    },
+    "node_modules/@chainlink/contracts/node_modules/ethers": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "@ethersproject/abi": "5.7.0",
+        "@ethersproject/abstract-provider": "5.7.0",
+        "@ethersproject/abstract-signer": "5.7.0",
+        "@ethersproject/address": "5.7.0",
+        "@ethersproject/base64": "5.7.0",
+        "@ethersproject/basex": "5.7.0",
+        "@ethersproject/bignumber": "5.7.0",
+        "@ethersproject/bytes": "5.7.0",
+        "@ethersproject/constants": "5.7.0",
+        "@ethersproject/contracts": "5.7.0",
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/hdnode": "5.7.0",
+        "@ethersproject/json-wallets": "5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/logger": "5.7.0",
+        "@ethersproject/networks": "5.7.1",
+        "@ethersproject/pbkdf2": "5.7.0",
+        "@ethersproject/properties": "5.7.0",
+        "@ethersproject/providers": "5.7.2",
+        "@ethersproject/random": "5.7.0",
+        "@ethersproject/rlp": "5.7.0",
+        "@ethersproject/sha2": "5.7.0",
+        "@ethersproject/signing-key": "5.7.0",
+        "@ethersproject/solidity": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
+        "@ethersproject/units": "5.7.0",
+        "@ethersproject/wallet": "5.7.0",
+        "@ethersproject/web": "5.7.1",
+        "@ethersproject/wordlists": "5.7.0"
+      }
+    },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -2698,30 +2764,27 @@
         "node": ">=12"
       }
     },
-    "node_modules/@eth-optimism/contracts": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.5.31.tgz",
-      "integrity": "sha512-I07EeyBBWwSsB6I/GodOLRydDtefWx4sdL3wCvNLSoCIUl2hUyisMmtTojOBXeT6vvfbiYkWc8jZlfXdbyJ7fA==",
-      "dependencies": {
-        "@eth-optimism/core-utils": "0.9.2",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2"
-      },
-      "peerDependencies": {
-        "ethers": "^5"
-      }
-    },
     "node_modules/@eth-optimism/core-utils": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.9.2.tgz",
-      "integrity": "sha512-wUP75gZu1rZ+taXwUtcw00qCUbDkcn16JcIIK/j7XnzgaEnyXExn+ivz3rivFbr5Ool4c5M+iVzVF99sPZrCPA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz",
+      "integrity": "sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==",
       "dependencies": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/providers": "^5.6.8",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/providers": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bufio": "^1.0.7",
-        "chai": "^4.3.4",
-        "ethers": "^5.6.8"
+        "chai": "^4.3.4"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -2983,6 +3046,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -3012,6 +3076,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -3027,6 +3092,12 @@
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
+    },
+    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+      "peer": true
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
@@ -3094,6 +3165,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -3274,6 +3346,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3343,6 +3416,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -3363,6 +3437,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -3417,6 +3492,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -4101,6 +4177,28 @@
         "pump": "^3.0.0",
         "tar-fs": "^2.1.1"
       }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7500,9 +7598,9 @@
       }
     },
     "node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -8212,9 +8310,9 @@
       "dev": true
     },
     "node_modules/bufio": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -8398,13 +8496,13 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -9035,14 +9133,14 @@
       }
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-equal": {
@@ -9711,13 +9809,13 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -9725,36 +9823,46 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "18.15.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/execa": {
@@ -12360,9 +12468,9 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
@@ -14649,7 +14757,8 @@
     "node_modules/scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -16704,6 +16813,11 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.1.tgz",
       "integrity": "sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g=="
     },
+    "@adraffy/ens-normalize": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.2.tgz",
+      "integrity": "sha512-0h+FrQDqe2Wn+IIGFkTCd4aAwTJ+7834Ek1COohCyV26AXhwQ7WQaz+4F/nLOeVl/3BtWHOHLPsq46V8YB46Eg=="
+    },
     "@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -18255,6 +18369,56 @@
         "@openzeppelin/contracts": "~4.3.3",
         "@openzeppelin/contracts-upgradeable": "^4.7.3",
         "@openzeppelin/contracts-v0.7": "npm:@openzeppelin/contracts@v3.4.2"
+      },
+      "dependencies": {
+        "@eth-optimism/contracts": {
+          "version": "0.5.40",
+          "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.5.40.tgz",
+          "integrity": "sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==",
+          "requires": {
+            "@eth-optimism/core-utils": "0.12.0",
+            "@ethersproject/abstract-provider": "^5.7.0",
+            "@ethersproject/abstract-signer": "^5.7.0"
+          }
+        },
+        "ethers": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
+          "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+          "peer": true,
+          "requires": {
+            "@ethersproject/abi": "5.7.0",
+            "@ethersproject/abstract-provider": "5.7.0",
+            "@ethersproject/abstract-signer": "5.7.0",
+            "@ethersproject/address": "5.7.0",
+            "@ethersproject/base64": "5.7.0",
+            "@ethersproject/basex": "5.7.0",
+            "@ethersproject/bignumber": "5.7.0",
+            "@ethersproject/bytes": "5.7.0",
+            "@ethersproject/constants": "5.7.0",
+            "@ethersproject/contracts": "5.7.0",
+            "@ethersproject/hash": "5.7.0",
+            "@ethersproject/hdnode": "5.7.0",
+            "@ethersproject/json-wallets": "5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/logger": "5.7.0",
+            "@ethersproject/networks": "5.7.1",
+            "@ethersproject/pbkdf2": "5.7.0",
+            "@ethersproject/properties": "5.7.0",
+            "@ethersproject/providers": "5.7.2",
+            "@ethersproject/random": "5.7.0",
+            "@ethersproject/rlp": "5.7.0",
+            "@ethersproject/sha2": "5.7.0",
+            "@ethersproject/signing-key": "5.7.0",
+            "@ethersproject/solidity": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "@ethersproject/transactions": "5.7.0",
+            "@ethersproject/units": "5.7.0",
+            "@ethersproject/wallet": "5.7.0",
+            "@ethersproject/web": "5.7.1",
+            "@ethersproject/wordlists": "5.7.0"
+          }
+        }
       }
     },
     "@colors/colors": {
@@ -18452,27 +18616,27 @@
       "dev": true,
       "optional": true
     },
-    "@eth-optimism/contracts": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/@eth-optimism/contracts/-/contracts-0.5.31.tgz",
-      "integrity": "sha512-I07EeyBBWwSsB6I/GodOLRydDtefWx4sdL3wCvNLSoCIUl2hUyisMmtTojOBXeT6vvfbiYkWc8jZlfXdbyJ7fA==",
-      "requires": {
-        "@eth-optimism/core-utils": "0.9.2",
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/abstract-signer": "^5.6.2"
-      }
-    },
     "@eth-optimism/core-utils": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.9.2.tgz",
-      "integrity": "sha512-wUP75gZu1rZ+taXwUtcw00qCUbDkcn16JcIIK/j7XnzgaEnyXExn+ivz3rivFbr5Ool4c5M+iVzVF99sPZrCPA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.12.0.tgz",
+      "integrity": "sha512-qW+7LZYCz7i8dRa7SRlUKIo1VBU8lvN0HeXCxJR+z+xtMzMQpPds20XJNCMclszxYQHkXY00fOT6GvFw9ZL6nw==",
       "requires": {
-        "@ethersproject/abstract-provider": "^5.6.1",
-        "@ethersproject/providers": "^5.6.8",
-        "@ethersproject/transactions": "^5.6.2",
+        "@ethersproject/abi": "^5.7.0",
+        "@ethersproject/abstract-provider": "^5.7.0",
+        "@ethersproject/address": "^5.7.0",
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/constants": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/properties": "^5.7.0",
+        "@ethersproject/providers": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/web": "^5.7.0",
         "bufio": "^1.0.7",
-        "chai": "^4.3.4",
-        "ethers": "^5.6.8"
+        "chai": "^4.3.4"
       }
     },
     "@ethersproject/abi": {
@@ -18616,6 +18780,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
       "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
+      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/basex": "^5.7.0",
@@ -18635,6 +18800,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
       "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
+      "peer": true,
       "requires": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -18649,6 +18815,14 @@
         "@ethersproject/transactions": "^5.7.0",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
+      },
+      "dependencies": {
+        "aes-js": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+          "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==",
+          "peer": true
+        }
       }
     },
     "@ethersproject/keccak256": {
@@ -18677,6 +18851,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
       "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
+      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/sha2": "^5.7.0"
@@ -18777,6 +18952,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
       "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
+      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -18816,6 +18992,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
       "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
+      "peer": true,
       "requires": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -18826,6 +19003,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
       "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
+      "peer": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -18860,6 +19038,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
       "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
+      "peer": true,
       "requires": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/hash": "^5.7.0",
@@ -19387,6 +19566,16 @@
         "pump": "^3.0.0",
         "tar-fs": "^2.1.1"
       }
+    },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA=="
+    },
+    "@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -21763,9 +21952,9 @@
       "dev": true
     },
     "aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "agent-base": {
       "version": "6.0.2",
@@ -22284,9 +22473,9 @@
       "dev": true
     },
     "bufio": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.2.0.tgz",
+      "integrity": "sha512-UlFk8z/PwdhYQTXSQQagwGAdtRI83gib2n4uy4rQnenxUM2yQi8lBDzF230BNk+3wAoZDxYRoBwVVUPgHa9MCA=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -22410,13 +22599,13 @@
       "dev": true
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -22901,9 +23090,9 @@
       "requires": {}
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -23423,40 +23612,35 @@
       "dev": true
     },
     "ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.7.1.tgz",
+      "integrity": "sha512-qX5kxIFMfg1i+epfgb0xF4WM7IqapIIu50pOJ17aebkxxa4BacW5jFrQRmCJpDEg2ZK2oNtR5QjrQ1WDBF29dA==",
       "requires": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@adraffy/ens-normalize": "1.9.2",
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.7.1",
+        "@types/node": "18.15.13",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.4.0",
+        "ws": "8.5.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "18.15.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
+          "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "requires": {}
+        }
       }
     },
     "execa": {
@@ -25375,9 +25559,9 @@
       }
     },
     "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "requires": {
         "get-func-name": "^2.0.0"
       }
@@ -26944,7 +27128,8 @@
     "scrypt-js": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "peer": true
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/react-highlight": "^0.12.5",
     "@types/react-syntax-highlighter": "^15.5.7",
     "chart.js": "^4.3.3",
-    "ethers": "^5.7.2",
+    "ethers": "^6.7.1",
     "highlightjs-solidity": "^2.0.6",
     "react": "^18.2.0",
     "react-blockies": "^1.4.1",

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -2,18 +2,18 @@ import React, { useContext } from "react";
 import { RuntimeContext } from "./useRuntime";
 
 const Footer: React.FC = () => {
-  const { provider } = useContext(RuntimeContext);
+  const { provider, config } = useContext(RuntimeContext);
 
   return (
     <div
       className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
-        provider?.network.chainId === 1
+        provider?._network.chainId === 1n
           ? "bg-link-blue text-gray-200"
           : "bg-orange-400 text-white"
       } text-center`}
     >
       {provider ? (
-        <>Using Erigon node at {provider.connection.url}</>
+        <>Using Erigon node at {config?.erigonURL}</>
       ) : (
         <>Waiting for the provider...</>
       )}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -42,11 +42,15 @@ const Header: FC = () => {
             spellCheck={false}
           >
             <input
-              className="w-full rounded-l border-t border-b border-l px-2 py-1 text-sm focus:outline-none"
+              className="w-full rounded-l border-b border-l border-t px-2 py-1 text-sm focus:outline-none"
               type="text"
               size={60}
               placeholder={`Type "/" to search by address / txn hash / block number${
-                provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null ? " / ENS name" : ""
+                provider?._network.getPlugin(
+                  "org.ethers.plugins.network.Ens"
+                ) !== null
+                  ? " / ENS name"
+                  : ""
               }`}
               onChange={handleChange}
               ref={searchRef}
@@ -60,7 +64,7 @@ const Header: FC = () => {
               <FontAwesomeIcon icon={faQrcode} />
             </button>
             <button
-              className="rounded-r border-t border-b border-r bg-skin-button-fill px-2 py-1 text-sm text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"
+              className="rounded-r border-b border-r border-t bg-skin-button-fill px-2 py-1 text-sm text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"
               type="submit"
             >
               Search

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -34,7 +34,7 @@ const Header: FC = () => {
           </div>
         </Link>
         <div className="flex items-baseline space-x-3">
-          {provider?.network.chainId === 1 && <PriceBox />}
+          {provider?._network.chainId === 1n && <PriceBox />}
           <form
             className="flex"
             onSubmit={handleSubmit}
@@ -46,7 +46,7 @@ const Header: FC = () => {
               type="text"
               size={60}
               placeholder={`Type "/" to search by address / txn hash / block number${
-                provider?.network.ensAddress ? " / ENS name" : ""
+                provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null ? " / ENS name" : ""
               }`}
               onChange={handleChange}
               ref={searchRef}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -42,7 +42,7 @@ const Home: FC = () => {
             type="text"
             size={50}
             placeholder={`Search by address / txn hash / block number${
-              provider?.network.ensAddress ? " / ENS name" : ""
+              provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null ? " / ENS name" : ""
             }`}
             onChange={handleChange}
             ref={searchRef}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -42,7 +42,10 @@ const Home: FC = () => {
             type="text"
             size={50}
             placeholder={`Search by address / txn hash / block number${
-              provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null ? " / ENS name" : ""
+              provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
+              null
+                ? " / ENS name"
+                : ""
             }`}
             onChange={handleChange}
             ref={searchRef}

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -10,7 +10,7 @@ import { useETHUSDRawOracle, useFastGasRawOracle } from "./usePriceOracle";
 import { commify } from "./utils/utils";
 
 // TODO: encapsulate this magic number
-const ETH_FEED_DECIMALS = 8;
+const ETH_FEED_DECIMALS = 8n;
 
 const PriceBox: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
@@ -29,10 +29,11 @@ const PriceBox: React.FC = () => {
       return [undefined, undefined];
     }
 
-    const price = latestPriceData.answer.div(10 ** (ETH_FEED_DECIMALS - 2));
+    const price: bigint =
+      latestPriceData.answer / 10n ** (ETH_FEED_DECIMALS - 2n);
     const formattedPrice = commify(formatUnits(price, 2));
 
-    const timestamp = new Date(latestPriceData.updatedAt * 1000);
+    const timestamp = new Date(Number(latestPriceData.updatedAt) * 1000);
     return [formattedPrice, timestamp];
   }, [latestPriceData]);
 
@@ -43,7 +44,7 @@ const PriceBox: React.FC = () => {
     }
 
     const formattedGas = formatValue(latestGasData.answer, 9);
-    const timestamp = new Date(latestGasData.updatedAt * 1000);
+    const timestamp = new Date(Number(latestGasData.updatedAt) * 1000);
     return [formattedGas, timestamp];
   }, [latestGasData]);
 

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useContext } from "react";
-import { formatUnits } from "@ethersproject/units";
+import { formatUnits } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGasPump } from "@fortawesome/free-solid-svg-icons";
 import { RuntimeContext } from "./useRuntime";

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -51,7 +51,7 @@ const SourcifyMenuItem: React.FC<PropsWithChildren<SourcifyMenuItemProps>> = ({
       <button
         className={`px-2 py-1 text-left text-sm ${
           active ? "border-orange-200 text-gray-500" : "text-gray-400"
-        } transition-transform transition-colors duration-75 ${
+        } transition-colors transition-transform duration-75 ${
           checked ? "text-gray-900" : ""
         }`}
         onClick={onClick}

--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -3,21 +3,21 @@ import { RuntimeContext } from "./useRuntime";
 
 const WarningHeader: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
-  const chainId = provider?.network.chainId;
-  if (chainId === 1) {
+  const chainId = provider?._network.chainId;
+  if (chainId === 1n) {
     return <></>;
   }
 
   let chainMsg = `ChainID: ${chainId}`;
-  if (chainId === 3) {
+  if (chainId === 3n) {
     chainMsg = "Ropsten Testnet";
-  } else if (chainId === 4) {
+  } else if (chainId === 4n) {
     chainMsg = "Rinkeby Testnet";
-  } else if (chainId === 5) {
+  } else if (chainId === 5n) {
     chainMsg = "Görli Testnet";
-  } else if (chainId === 42) {
+  } else if (chainId === 42n) {
     chainMsg = "Kovan Testnet";
-  } else if (chainId === 11155111) {
+  } else if (chainId === 11155111n) {
     chainMsg = "Sepolia Testnet";
   }
   return (

--- a/src/api/address-resolver/CompositeAddressResolver.ts
+++ b/src/api/address-resolver/CompositeAddressResolver.ts
@@ -1,4 +1,4 @@
-import { BaseProvider } from "@ethersproject/providers";
+import { AbstractProvider } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 
 export type SelectedResolvedName<T> = [IAddressResolver<T>, T] | null;
@@ -13,7 +13,7 @@ export class CompositeAddressResolver<T = any>
   }
 
   async resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<SelectedResolvedName<T> | undefined> {
     for (const r of this.resolvers) {

--- a/src/api/address-resolver/ENSAddressResolver.ts
+++ b/src/api/address-resolver/ENSAddressResolver.ts
@@ -1,9 +1,9 @@
-import { BaseProvider } from "@ethersproject/providers";
+import { AbstractProvider } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 
 export class ENSAddressResolver implements IAddressResolver<string> {
   async resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<string | undefined> {
     const name = await provider.lookupAddress(address);

--- a/src/api/address-resolver/ERCTokenResolver.ts
+++ b/src/api/address-resolver/ERCTokenResolver.ts
@@ -1,18 +1,19 @@
-import { BaseProvider } from "@ethersproject/providers";
-import { Contract } from "@ethersproject/contracts";
-import { AddressZero } from "@ethersproject/constants";
+import { AbstractProvider } from "ethers";
+import { Contract } from "ethers";
+import { ZeroAddress } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 import erc20 from "../../erc20.json";
 import { TokenMeta } from "../../types";
 
-const ERC20_PROTOTYPE = new Contract(AddressZero, erc20);
+const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
 
 export class ERCTokenResolver implements IAddressResolver<TokenMeta> {
   async resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<TokenMeta | undefined> {
-    const erc20Contract = ERC20_PROTOTYPE.connect(provider).attach(address);
+    // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
+    const erc20Contract = ERC20_PROTOTYPE.connect(provider).attach(address) as Contract;
     try {
       const name = (await erc20Contract.name()) as string;
       if (!name.trim()) {

--- a/src/api/address-resolver/ERCTokenResolver.ts
+++ b/src/api/address-resolver/ERCTokenResolver.ts
@@ -13,7 +13,9 @@ export class ERCTokenResolver implements IAddressResolver<TokenMeta> {
     address: string
   ): Promise<TokenMeta | undefined> {
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const erc20Contract = ERC20_PROTOTYPE.connect(provider).attach(address) as Contract;
+    const erc20Contract = ERC20_PROTOTYPE.connect(provider).attach(
+      address
+    ) as Contract;
     try {
       const name = (await erc20Contract.name()) as string;
       if (!name.trim()) {

--- a/src/api/address-resolver/HardcodedAddressResolver.ts
+++ b/src/api/address-resolver/HardcodedAddressResolver.ts
@@ -9,9 +9,9 @@ export class HardcodedAddressResolver implements IAddressResolver<string> {
     address: string
   ): Promise<string | undefined> {
     try {
-      const addressMap: HardcodedAddressMap = (await import(
-        `./hardcoded-addresses/${provider._network.chainId}.json`
-      )).default;
+      const addressMap: HardcodedAddressMap = (
+        await import(`./hardcoded-addresses/${provider._network.chainId}.json`)
+      ).default;
 
       return addressMap[address];
     } catch (err) {

--- a/src/api/address-resolver/HardcodedAddressResolver.ts
+++ b/src/api/address-resolver/HardcodedAddressResolver.ts
@@ -1,16 +1,16 @@
-import { BaseProvider } from "@ethersproject/providers";
+import { JsonRpcApiProvider } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 
 type HardcodedAddressMap = Record<string, string | undefined>;
 
 export class HardcodedAddressResolver implements IAddressResolver<string> {
   async resolveAddress(
-    provider: BaseProvider,
+    provider: JsonRpcApiProvider,
     address: string
   ): Promise<string | undefined> {
     try {
       const addressMap: HardcodedAddressMap = (await import(
-        `./hardcoded-addresses/${provider.network.chainId}.json`
+        `./hardcoded-addresses/${provider._network.chainId}.json`
       )).default;
 
       return addressMap[address];

--- a/src/api/address-resolver/UniswapV1Resolver.ts
+++ b/src/api/address-resolver/UniswapV1Resolver.ts
@@ -1,5 +1,5 @@
-import { BaseProvider } from "@ethersproject/providers";
-import { Contract } from "@ethersproject/contracts";
+import { AbstractProvider } from "ethers";
+import { Contract } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 import { ChecksummedAddress, TokenMeta } from "../../types";
 import { ERCTokenResolver } from "./ERCTokenResolver";
@@ -30,10 +30,11 @@ const ercResolver = new ERCTokenResolver();
 
 export class UniswapV1Resolver implements IAddressResolver<UniswapV1PairMeta> {
   async resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<UniswapV1PairMeta | undefined> {
-    const factoryContract = UNISWAP_V1_FACTORY_PROTOTYPE.connect(provider);
+    // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
+    const factoryContract = UNISWAP_V1_FACTORY_PROTOTYPE.connect(provider) as Contract;
 
     try {
       // First, probe the getToken() function; if it responds with an UniswapV1 exchange

--- a/src/api/address-resolver/UniswapV1Resolver.ts
+++ b/src/api/address-resolver/UniswapV1Resolver.ts
@@ -34,7 +34,9 @@ export class UniswapV1Resolver implements IAddressResolver<UniswapV1PairMeta> {
     address: string
   ): Promise<UniswapV1PairMeta | undefined> {
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const factoryContract = UNISWAP_V1_FACTORY_PROTOTYPE.connect(provider) as Contract;
+    const factoryContract = UNISWAP_V1_FACTORY_PROTOTYPE.connect(
+      provider
+    ) as Contract;
 
     try {
       // First, probe the getToken() function; if it responds with an UniswapV1 exchange

--- a/src/api/address-resolver/UniswapV2Resolver.ts
+++ b/src/api/address-resolver/UniswapV2Resolver.ts
@@ -45,10 +45,13 @@ export class UniswapV2Resolver implements IAddressResolver<UniswapV2PairMeta> {
     address: string
   ): Promise<UniswapV2PairMeta | undefined> {
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const pairContract =
-      UNISWAP_V2_PAIR_PROTOTYPE.connect(provider).attach(address) as Contract;
+    const pairContract = UNISWAP_V2_PAIR_PROTOTYPE.connect(provider).attach(
+      address
+    ) as Contract;
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const factoryContract = UNISWAP_V2_FACTORY_PROTOTYPE.connect(provider) as Contract;
+    const factoryContract = UNISWAP_V2_FACTORY_PROTOTYPE.connect(
+      provider
+    ) as Contract;
 
     try {
       // First, probe the factory() function; if it responds with UniswapV2 factory

--- a/src/api/address-resolver/UniswapV3Resolver.ts
+++ b/src/api/address-resolver/UniswapV3Resolver.ts
@@ -1,6 +1,6 @@
-import { BaseProvider } from "@ethersproject/providers";
-import { Contract } from "@ethersproject/contracts";
-import { AddressZero } from "@ethersproject/constants";
+import { AbstractProvider } from "ethers";
+import { Contract } from "ethers";
+import { ZeroAddress } from "ethers";
 import { IAddressResolver } from "./address-resolver";
 import { ChecksummedAddress, TokenMeta } from "../../types";
 import { ERCTokenResolver } from "./ERCTokenResolver";
@@ -24,7 +24,7 @@ const UNISWAP_V3_FACTORY_PROTOTYPE = new Contract(
 );
 
 const UNISWAP_V3_PAIR_PROTOTYPE = new Contract(
-  AddressZero,
+  ZeroAddress,
   UNISWAP_V3_PAIR_ABI
 );
 
@@ -43,12 +43,14 @@ const ercResolver = new ERCTokenResolver();
 
 export class UniswapV3Resolver implements IAddressResolver<UniswapV3PairMeta> {
   async resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<UniswapV3PairMeta | undefined> {
+    // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
     const poolContract =
-      UNISWAP_V3_PAIR_PROTOTYPE.connect(provider).attach(address);
-    const factoryContract = UNISWAP_V3_FACTORY_PROTOTYPE.connect(provider);
+      UNISWAP_V3_PAIR_PROTOTYPE.connect(provider).attach(address) as Contract;
+    // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
+    const factoryContract = UNISWAP_V3_FACTORY_PROTOTYPE.connect(provider) as Contract;
 
     try {
       // First, probe the factory() function; if it responds with UniswapV2 factory
@@ -60,9 +62,9 @@ export class UniswapV3Resolver implements IAddressResolver<UniswapV3PairMeta> {
 
       // Probe the token0/token1/fee
       const [token0, token1, fee] = await Promise.all([
-        poolContract.token0() as string,
-        poolContract.token1() as string,
-        poolContract.fee() as number,
+        poolContract.token0() as Promise<string>,
+        poolContract.token1() as Promise<string>,
+        poolContract.fee() as Promise<number>,
       ]);
 
       // Probe the factory to ensure it is a legit pair

--- a/src/api/address-resolver/UniswapV3Resolver.ts
+++ b/src/api/address-resolver/UniswapV3Resolver.ts
@@ -47,10 +47,13 @@ export class UniswapV3Resolver implements IAddressResolver<UniswapV3PairMeta> {
     address: string
   ): Promise<UniswapV3PairMeta | undefined> {
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const poolContract =
-      UNISWAP_V3_PAIR_PROTOTYPE.connect(provider).attach(address) as Contract;
+    const poolContract = UNISWAP_V3_PAIR_PROTOTYPE.connect(provider).attach(
+      address
+    ) as Contract;
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const factoryContract = UNISWAP_V3_FACTORY_PROTOTYPE.connect(provider) as Contract;
+    const factoryContract = UNISWAP_V3_FACTORY_PROTOTYPE.connect(
+      provider
+    ) as Contract;
 
     try {
       // First, probe the factory() function; if it responds with UniswapV2 factory

--- a/src/api/address-resolver/address-resolver.ts
+++ b/src/api/address-resolver/address-resolver.ts
@@ -1,15 +1,15 @@
 import React from "react";
-import { BaseProvider } from "@ethersproject/providers";
+import { AbstractProvider } from "ethers";
 
 export interface IAddressResolver<T> {
   resolveAddress(
-    provider: BaseProvider,
+    provider: AbstractProvider,
     address: string
   ): Promise<T | undefined>;
 }
 
 export type ResolvedAddressRenderer<T> = (
-  chainId: number,
+  chainId: bigint,
   address: string,
   resolvedAddress: T,
   linkable: boolean,

--- a/src/api/address-resolver/index.ts
+++ b/src/api/address-resolver/index.ts
@@ -38,17 +38,17 @@ const _defaultResolver = new CompositeAddressResolver();
 _defaultResolver.addResolver(ercTokenResolver);
 _defaultResolver.addResolver(hardcodedResolver);
 
-const resolvers: Record<number, IAddressResolver<SelectedResolvedName<any>>> = {
-  1: _mainnetResolver,
-  0: _defaultResolver,
+const resolvers: Record<string, IAddressResolver<SelectedResolvedName<any>>> = {
+  "1": _mainnetResolver,
+  "0": _defaultResolver,
 };
 
 export const getResolver = (
-  chainId: number
+  chainId: bigint
 ): IAddressResolver<SelectedResolvedName<any>> => {
-  const res = resolvers[chainId];
+  const res = resolvers[chainId.toString()];
   if (res === undefined) {
-    return resolvers[0]; // default MAGIC NUMBER
+    return resolvers["0"]; // default MAGIC NUMBER
   }
   return res;
 };

--- a/src/components/BlockLink.tsx
+++ b/src/components/BlockLink.tsx
@@ -1,6 +1,6 @@
 import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
-import { BlockTag } from "@ethersproject/abstract-provider";
+import { BlockTag } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCube } from "@fortawesome/free-solid-svg-icons";
 import { blockURL } from "../url";
@@ -11,8 +11,8 @@ type BlockLinkProps = {
 };
 
 const BlockLink: FC<BlockLinkProps> = ({ blockTag }) => {
-  const isNum = typeof blockTag === "number";
   let text = blockTag;
+  let isNum = typeof blockTag === "bigint";
   if (isNum) {
     text = commify(blockTag);
   }
@@ -27,7 +27,7 @@ const BlockLink: FC<BlockLinkProps> = ({ blockTag }) => {
       <span className="text-orange-500">
         <FontAwesomeIcon className="self-center" icon={faCube} size="1x" />
       </span>
-      <span>{text}</span>
+      <span>{text.toString()}</span>
     </NavLink>
   );
 };

--- a/src/components/BlockLink.tsx
+++ b/src/components/BlockLink.tsx
@@ -12,7 +12,7 @@ type BlockLinkProps = {
 
 const BlockLink: FC<BlockLinkProps> = ({ blockTag }) => {
   let text = blockTag;
-  let isNum = typeof blockTag === "bigint";
+  let isNum = typeof blockTag === "bigint" || typeof blockTag === "number";
   if (isNum) {
     text = commify(blockTag);
   }

--- a/src/components/FiatValue.tsx
+++ b/src/components/FiatValue.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { FixedNumber } from "@ethersproject/bignumber";
+import { FixedNumber } from "ethers";
 import { formatFiatValue } from "../usePriceOracle";
 
 const DEFAULT_DECIMALS = 2;

--- a/src/components/FormattedBalance.stories.tsx
+++ b/src/components/FormattedBalance.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { BigNumber } from "@ethersproject/bignumber";
 import FormattedBalance from "./FormattedBalance";
 
 const meta = {
@@ -11,13 +10,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Zero: Story = {
   args: {
-    value: BigNumber.from(0),
+    value: 0n,
   },
 };
 
 export const OneGweiAsEther: Story = {
   args: {
-    value: BigNumber.from("1000000000"),
+    value: 1000000000n,
   },
 };
 
@@ -31,7 +30,7 @@ export const OneGweiWithSymbol: Story = {
 
 export const OneEther: Story = {
   args: {
-    value: BigNumber.from("1000000000000000000"),
+    value: 1000000000000000000n,
   },
 };
 
@@ -44,7 +43,7 @@ export const OneEtherWithSymbol: Story = {
 
 export const OneMillionEther: Story = {
   args: {
-    value: BigNumber.from("1000000000000000000000000"),
+    value: 1000000000000000000000000n,
     symbol: "ETH",
   },
 };

--- a/src/components/FormattedBalance.tsx
+++ b/src/components/FormattedBalance.tsx
@@ -1,11 +1,10 @@
 import { FC, memo } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import { formatValue } from "./formatter";
 
 const DEFAULT_DECIMALS = 18;
 
 export type FormattedBalanceProps = {
-  value: BigNumber;
+  value: bigint;
   decimals?: number;
   symbol?: string | undefined;
 };

--- a/src/components/InternalSelfDestruct.tsx
+++ b/src/components/InternalSelfDestruct.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { formatEther } from "@ethersproject/units";
+import { formatEther } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faAngleRight } from "@fortawesome/free-solid-svg-icons";
 import AddressHighlighter from "./AddressHighlighter";
@@ -37,13 +37,13 @@ const InternalSelfDestruct: React.FC<InternalSelfDestructProps> = ({
             <DecoratedAddressLink address={internalOp.from} selfDestruct />
           </AddressHighlighter>
         </div>
-        {internalOp.value.isZero() && (
+        {internalOp.value === 0n && (
           <div className="flex items-baseline text-gray-400">
             (To: <TransactionAddress address={internalOp.to} />)
           </div>
         )}
       </div>
-      {!internalOp.value.isZero() && (
+      {internalOp.value !== 0n && (
         <div className="ml-5 flex items-baseline space-x-1">
           <span className="text-gray-500">
             <FontAwesomeIcon icon={faAngleRight} size="1x" /> TRANSFER

--- a/src/components/InternalTransfer.tsx
+++ b/src/components/InternalTransfer.tsx
@@ -101,7 +101,7 @@ const InternalTransfer: FC<InternalTransferProps> = ({
           <span>
             {formatEther(internalOp.value)} {symbol}
           </span>
-          {(blockETHUSDPrice !== undefined) && (
+          {blockETHUSDPrice !== undefined && (
             <USDAmount
               amount={internalOp.value}
               amountDecimals={decimals}

--- a/src/components/InternalTransfer.tsx
+++ b/src/components/InternalTransfer.tsx
@@ -1,5 +1,5 @@
 import { FC, useContext } from "react";
-import { formatEther } from "@ethersproject/units";
+import { formatEther } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faAngleRight,
@@ -34,7 +34,7 @@ const InternalTransfer: FC<InternalTransferProps> = ({
     block?.miner !== undefined && internalOp.from === block.miner;
   const toMiner = block?.miner !== undefined && internalOp.to === block.miner;
 
-  const blockETHUSDPrice = useETHUSDOracle(
+  const blockETHUSDPrice: bigint | undefined = useETHUSDOracle(
     provider,
     txData.confirmedData?.blockNumber
   );
@@ -101,7 +101,7 @@ const InternalTransfer: FC<InternalTransferProps> = ({
           <span>
             {formatEther(internalOp.value)} {symbol}
           </span>
-          {blockETHUSDPrice && (
+          {(blockETHUSDPrice !== undefined) && (
             <USDAmount
               amount={internalOp.value}
               amountDecimals={decimals}

--- a/src/components/NativeTokenAmount.tsx
+++ b/src/components/NativeTokenAmount.tsx
@@ -1,10 +1,9 @@
 import { FC, memo } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import { useChainInfo } from "../useChainInfo";
 import FormattedBalance from "./FormattedBalance";
 
 type NativeTokenAmountProps = {
-  value: BigNumber;
+  value: bigint;
   hideUnit?: boolean;
 };
 
@@ -23,7 +22,7 @@ const NativeTokenAmount: FC<NativeTokenAmountProps> = ({ value, hideUnit }) => {
   } = useChainInfo();
 
   return (
-    <span className={`text-sm ${value.isZero() ? "opacity-30" : ""}`}>
+    <span className={`text-sm ${value === 0n ? "opacity-30" : ""}`}>
       <FormattedBalance
         value={value}
         decimals={decimals}

--- a/src/components/NativeTokenAmountAndFiat.tsx
+++ b/src/components/NativeTokenAmountAndFiat.tsx
@@ -1,12 +1,11 @@
 import { FC } from "react";
-import { BlockTag } from "@ethersproject/providers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BlockTag } from "ethers";
 import NativeTokenAmount from "./NativeTokenAmount";
 import FiatValue, { FiatBoxProps } from "./FiatValue";
 import { useFiatValue } from "../usePriceOracle";
 
 type NativeTokenAmountAndFiatProps = FiatBoxProps & {
-  value: BigNumber;
+  value: bigint;
   blockTag?: BlockTag;
 };
 

--- a/src/components/NativeTokenPrice.tsx
+++ b/src/components/NativeTokenPrice.tsx
@@ -1,10 +1,7 @@
 import { FC, memo } from "react";
-import { BlockTag } from "@ethersproject/providers";
-import { BigNumber } from "@ethersproject/bignumber";
+import { BlockTag } from "ethers";
 import { useChainInfo } from "../useChainInfo";
 import { formatFiatValue, useFiatValue } from "../usePriceOracle";
-
-const TEN = BigNumber.from(10);
 
 type NativeTokenPriceProps = {
   blockTag: BlockTag | undefined;
@@ -22,7 +19,7 @@ const NativeTokenPrice: FC<NativeTokenPriceProps> = ({ blockTag }) => {
   } = useChainInfo();
 
   // One unit of native token, considering decimals
-  const nativeTokenPrice = useFiatValue(TEN.pow(decimals), blockTag);
+  const nativeTokenPrice = useFiatValue(10n ** BigInt(decimals), blockTag);
   const value = formatFiatValue(nativeTokenPrice);
 
   return (

--- a/src/components/Nonce.stories.tsx
+++ b/src/components/Nonce.stories.tsx
@@ -10,18 +10,18 @@ type Story = StoryObj<typeof meta>;
 
 export const NeverSent: Story = {
   args: {
-    value: 0,
+    value: 0n,
   },
 };
 
 export const BigNonce: Story = {
   args: {
-    value: 1_000,
+    value: 1_000n,
   },
 };
 
 export const ProbablyBot: Story = {
   args: {
-    value: 1_234_567,
+    value: 1_234_567n,
   },
 };

--- a/src/components/Nonce.tsx
+++ b/src/components/Nonce.tsx
@@ -4,7 +4,7 @@ import { faArrowUp } from "@fortawesome/free-solid-svg-icons";
 import { commify } from "../utils/utils";
 
 type NonceProps = {
-  value: number;
+  value: bigint;
 };
 
 const Nonce: FC<NonceProps> = ({ value }) => (

--- a/src/components/PercentageBar.tsx
+++ b/src/components/PercentageBar.tsx
@@ -9,7 +9,7 @@ const PercentageBar: FC<PercentageBarProps> = ({ perc }) => (
   <div className="w-40 self-center rounded border border-gray-200">
     <div className="relative h-5 w-full rounded bg-gradient-to-r from-red-400 via-amber-300 to-emerald-400">
       <div
-        className="absolute top-0 right-0 h-full rounded-r bg-white"
+        className="absolute right-0 top-0 h-full rounded-r bg-white"
         style={{ width: `${100 - perc}%` }}
       ></div>
       <div className="text-sans absolute flex h-full w-full text-gray-600 mix-blend-multiply">

--- a/src/components/RelevantNumericValue.tsx
+++ b/src/components/RelevantNumericValue.tsx
@@ -1,5 +1,4 @@
 import { FC, memo } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import FormattedBalance from "./FormattedBalance";
 
 type RelevantNumericValueProps = {
@@ -13,7 +12,7 @@ type RelevantNumericValueProps = {
  * - Light gray absolute zero values
  */
 const RelevantNumericValue: FC<RelevantNumericValueProps> = ({ value }) => (
-  <FormattedBalance value={BigNumber.from(value)} decimals={0} />
+  <FormattedBalance value={BigInt(value)} decimals={0} />
 );
 
 export default memo(RelevantNumericValue);

--- a/src/components/StandardFrame.tsx
+++ b/src/components/StandardFrame.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from "react";
 
 const StandardFrame: React.FC<PropsWithChildren> = ({ children }) => (
-  <div className="grow bg-gray-100 px-9 pt-3 pb-12">{children}</div>
+  <div className="grow bg-gray-100 px-9 pb-12 pt-3">{children}</div>
 );
 
 export default StandardFrame;

--- a/src/components/StandardTBody.tsx
+++ b/src/components/StandardTBody.tsx
@@ -1,7 +1,7 @@
 import { FC, PropsWithChildren } from "react";
 
 const StandardTBody: FC<PropsWithChildren> = ({ children }) => (
-  <tbody className="[&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover [&>tr>td]:truncate [&>tr>td]:px-2 [&>tr>td]:py-3">
+  <tbody className="[&>tr>td]:truncate [&>tr>td]:px-2 [&>tr>td]:py-3 [&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover">
     {children}
   </tbody>
 );

--- a/src/components/StandardTable.tsx
+++ b/src/components/StandardTable.tsx
@@ -1,7 +1,7 @@
 import { FC, PropsWithChildren } from "react";
 
 const StandardTable: FC<PropsWithChildren> = ({ children }) => (
-  <table className="w-full table-fixed border-t border-b border-gray-200 px-2 py-2 text-left text-sm [&>*>tr]:items-baseline">
+  <table className="w-full table-fixed border-b border-t border-gray-200 px-2 py-2 text-left text-sm [&>*>tr]:items-baseline">
     {children}
   </table>
 );

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -10,7 +10,7 @@ type TransactionLinkProps = {
 };
 
 const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail }) => (
-  <span className="flex flex-no-wrap space-x-1">
+  <span className="flex-no-wrap flex space-x-1">
     {fail && (
       <span className="text-red-600" title="Transaction reverted">
         <FontAwesomeIcon icon={faExclamationCircle} />

--- a/src/components/USDAmount.tsx
+++ b/src/components/USDAmount.tsx
@@ -1,11 +1,11 @@
 import { FC, memo } from "react";
-import { BigNumber, FixedNumber } from "@ethersproject/bignumber";
+import { FixedNumber } from "ethers";
 import FiatValue, { neutralPreset } from "./FiatValue";
 
 type USDAmountProps = {
-  amount: BigNumber;
+  amount: bigint;
   amountDecimals: number;
-  quote: BigNumber;
+  quote: bigint;
   quoteDecimals: number;
 };
 
@@ -21,7 +21,7 @@ const USDAmount: FC<USDAmountProps> = ({
   quote,
   quoteDecimals,
 }) => {
-  const value = amount.mul(quote);
+  const value = amount * quote;
   const decimals = amountDecimals + quoteDecimals;
   const fiatAmount = FixedNumber.fromValue(
     value,

--- a/src/components/formatter.ts
+++ b/src/components/formatter.ts
@@ -1,5 +1,5 @@
-import { BigNumberish } from "@ethersproject/bignumber";
-import { formatUnits } from "@ethersproject/units";
+import { BigNumberish } from "ethers";
+import { formatUnits } from "ethers";
 import { commify } from "../utils/utils";
 
 export const formatValue = (value: BigNumberish, decimals: number): string => {

--- a/src/consensus/Validator.tsx
+++ b/src/consensus/Validator.tsx
@@ -1,7 +1,7 @@
 import { FC, Suspense } from "react";
 import { Route, Routes, useParams } from "react-router-dom";
 import { Tab } from "@headlessui/react";
-import { isHexString } from "@ethersproject/bytes";
+import { isHexString } from "ethers";
 import StandardFrame from "../components/StandardFrame";
 import StandardSelectionBoundary from "../selection/StandardSelectionBoundary";
 import ValidatorSubtitle from "./validator/ValidatorSubtitle";

--- a/src/consensus/epoch/StoredSlotItem.tsx
+++ b/src/consensus/epoch/StoredSlotItem.tsx
@@ -40,7 +40,9 @@ const StoredSlotItem: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
         <SlotTimestamp slotNumber={slotNumber} />
       </td>
       <td>
-        <CheckedValidatorLink validatorIndex={slot.data.message.proposer_index} />
+        <CheckedValidatorLink
+          validatorIndex={slot.data.message.proposer_index}
+        />
       </td>
       <td>
         <BlockRoot slotNumber={slotNumber} />

--- a/src/consensus/slot/AggregationBits.tsx
+++ b/src/consensus/slot/AggregationBits.tsx
@@ -1,12 +1,12 @@
 import { FC } from "react";
-import { arrayify } from "@ethersproject/bytes";
+import { getBytes } from "ethers";
 
 type AggregationBitsProps = {
   hex: string;
 };
 
 const AggregationBits: FC<AggregationBitsProps> = ({ hex }) => {
-  const bm = Array.from(arrayify(hex));
+  const bm = Array.from(getBytes(hex));
   return (
     <div className="grid w-fit grid-cols-8 gap-2 font-hash">
       {bm.map((b, i) => (

--- a/src/consensus/slot/AggregationParticipation.tsx
+++ b/src/consensus/slot/AggregationParticipation.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { arrayify } from "@ethersproject/bytes";
+import { getBytes } from "ethers";
 import PercentageBar from "../../components/PercentageBar";
 
 type AggregationParticipationProps = {
@@ -9,7 +9,7 @@ type AggregationParticipationProps = {
 const AggregationParticipation: FC<AggregationParticipationProps> = ({
   hex,
 }) => {
-  const bm = Array.from(arrayify(hex));
+  const bm = Array.from(getBytes(hex));
   const total = bm.length * 8;
   let participation = 0;
 

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { toUtf8String } from "@ethersproject/strings";
+import { toUtf8String } from "ethers";
 import ContentFrame from "../../components/ContentFrame";
 import OverviewSkeleton from "./OverviewSkeleton";
 import SlotNotFound from "./SlotNotFound";

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -65,7 +65,9 @@ const Overview: FC = () => {
             </InfoRow>
           )}
           <InfoRow title="Proposer">
-            <CheckedValidatorLink validatorIndex={slot.data.message.proposer_index} />
+            <CheckedValidatorLink
+              validatorIndex={slot.data.message.proposer_index}
+            />
           </InfoRow>
           <InfoRow title="Block Root">
             <BlockRoot slotNumber={slotAsNumber} />

--- a/src/consensus/validator/Overview.tsx
+++ b/src/consensus/validator/Overview.tsx
@@ -1,5 +1,4 @@
 import { FC, useEffect } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import ContentFrame from "../../components/ContentFrame";
 import InfoRow from "../../components/InfoRow";
 import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
@@ -10,7 +9,7 @@ import EpochLink from "../components/EpochLink";
 import { useEpochTimestamp, useValidator } from "../../useConsensus";
 import { commify } from "../../utils/utils";
 
-const GWEI = BigNumber.from(10).pow(9);
+const GWEI = 10n ** 9n;
 
 type OverviewProps = {
   validatorIndex: string;
@@ -48,15 +47,15 @@ const Overview: FC<OverviewProps> = ({ validatorIndex }) => {
           </InfoRow>
           <InfoRow title="Balance">
             <NativeTokenAmountAndFiat
-              value={BigNumber.from(validator.data.balance).mul(GWEI)}
+              value={BigInt(validator.data.balance) * GWEI}
               {...balancePreset}
             />
           </InfoRow>
           <InfoRow title="Effective Balance">
             <NativeTokenAmountAndFiat
-              value={BigNumber.from(
+              value={BigInt(
                 validator.data.validator.effective_balance
-              ).mul(GWEI)}
+              ) * GWEI}
               {...balancePreset}
             />
           </InfoRow>

--- a/src/consensus/validator/Overview.tsx
+++ b/src/consensus/validator/Overview.tsx
@@ -53,9 +53,7 @@ const Overview: FC<OverviewProps> = ({ validatorIndex }) => {
           </InfoRow>
           <InfoRow title="Effective Balance">
             <NativeTokenAmountAndFiat
-              value={BigInt(
-                validator.data.validator.effective_balance
-              ) * GWEI}
+              value={BigInt(validator.data.validator.effective_balance) * GWEI}
               {...balancePreset}
             />
           </InfoRow>

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -73,7 +73,10 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
       {error ? (
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
-          supportsENS={provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null}
+          supportsENS={
+            provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
+            null
+          }
         />
       ) : (
         checksummedAddress && (

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -57,7 +57,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
   const hasCode = useHasCode(provider, checksummedAddress);
   const match = useSourcifyMetadata(
     hasCode ? checksummedAddress : undefined,
-    provider?.network.chainId
+    provider?._network.chainId
   );
 
   useEffect(() => {
@@ -73,7 +73,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
       {error ? (
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
-          supportsENS={provider?.network.ensAddress !== undefined}
+          supportsENS={provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null}
         />
       ) : (
         checksummedAddress && (

--- a/src/execution/AddressTransactionByNonce.tsx
+++ b/src/execution/AddressTransactionByNonce.tsx
@@ -51,7 +51,9 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
     }
 
     const readTxCount = async () => {
-      const count = BigInt(await provider.getTransactionCount(checksummedAddress));
+      const count = BigInt(
+        await provider.getTransactionCount(checksummedAddress)
+      );
       setTxCount(count);
     };
     readTxCount();
@@ -85,7 +87,10 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
       <StandardFrame>
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
-          supportsENS={provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null}
+          supportsENS={
+            provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
+            null
+          }
         />
       </StandardFrame>
     );

--- a/src/execution/AddressTransactionByNonce.tsx
+++ b/src/execution/AddressTransactionByNonce.tsx
@@ -43,7 +43,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
   );
 
   // Calculate txCount ONLY when asked for latest nonce
-  const [txCount, setTxCount] = useState<number | undefined>();
+  const [txCount, setTxCount] = useState<bigint | undefined>();
   useEffect(() => {
     if (!provider || !checksummedAddress || rawNonce !== "latest") {
       setTxCount(undefined);
@@ -51,7 +51,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
     }
 
     const readTxCount = async () => {
-      const count = await provider.getTransactionCount(checksummedAddress);
+      const count = BigInt(await provider.getTransactionCount(checksummedAddress));
       setTxCount(count);
     };
     readTxCount();
@@ -59,15 +59,16 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
 
   // Determine desired nonce from parse int query param or txCount - 1 nonce
   // in case of latest
-  let nonce: number | undefined;
+  // TODO: Double check behavior
+  let nonce: bigint | undefined | null;
   if (rawNonce === "latest") {
     if (txCount !== undefined) {
-      nonce = txCount - 1;
+      nonce = txCount - 1n;
     }
   } else {
-    nonce = parseInt(rawNonce, 10);
-    if (nonce < 0) {
-      nonce = NaN;
+    nonce = BigInt(parseInt(rawNonce, 10));
+    if (nonce < 0n) {
+      nonce = null;
     }
   }
 
@@ -75,7 +76,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
   const txHash = useTransactionBySenderAndNonce(
     provider,
     checksummedAddress,
-    nonce !== undefined && isNaN(nonce) ? undefined : nonce
+    nonce !== undefined && nonce === null ? undefined : nonce
   );
 
   // Invalid ENS
@@ -84,7 +85,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
       <StandardFrame>
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
-          supportsENS={provider?.network.ensAddress !== undefined}
+          supportsENS={provider?._network.getPlugin("org.ethers.plugins.network.Ens") !== null}
         />
       </StandardFrame>
     );
@@ -96,7 +97,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
   }
 
   // Address hasn't made the first outbound tx yet
-  if (nonce < 0) {
+  if (nonce !== null && nonce !== undefined && nonce < 0n) {
     return (
       <StandardFrame>
         <AddressOrENSNameNoTx addressOrENSName={checksummedAddress} />
@@ -105,7 +106,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
   }
 
   // Garbage nonce
-  if (isNaN(nonce)) {
+  if (nonce === null) {
     return (
       <StandardFrame>
         <AddressOrENSNameInvalidNonce

--- a/src/execution/Block.tsx
+++ b/src/execution/Block.tsx
@@ -44,10 +44,9 @@ const Block: FC = () => {
   const extraStr = useMemo(() => {
     return block && toUtf8String(block.extraData, Utf8ErrorFuncs.replace);
   }, [block]);
-  const burntFees =
-    block?.baseFeePerGas && (block.baseFeePerGas * block.gasUsed);
+  const burntFees = block?.baseFeePerGas && block.baseFeePerGas * block.gasUsed;
   const gasUsedPerc =
-    block && Number(block.gasUsed * 10000n / block.gasLimit) / 100;
+    block && Number((block.gasUsed * 10000n) / block.gasLimit) / 100;
 
   const latestBlockNumber = useLatestBlockNumber(provider);
 
@@ -101,25 +100,26 @@ const Block: FC = () => {
             <NativeTokenAmount value={block.unclesReward} />
           </InfoRow>
           <InfoRow title="Size">{commify(block.size)} bytes</InfoRow>
-          {(block.baseFeePerGas !== null && block.baseFeePerGas !== undefined) && (
-            <InfoRow title="Base Fee">
-              <span>
-                <FormattedBalance
-                  value={block.baseFeePerGas}
-                  decimals={9}
-                  symbol="Gwei"
-                />{" "}
-                (
-                <FormattedBalance
-                  value={block.baseFeePerGas}
-                  decimals={0}
-                  symbol="wei"
-                />
-                )
-              </span>
-            </InfoRow>
-          )}
-          {(burntFees !== null && burntFees !== undefined) && (
+          {block.baseFeePerGas !== null &&
+            block.baseFeePerGas !== undefined && (
+              <InfoRow title="Base Fee">
+                <span>
+                  <FormattedBalance
+                    value={block.baseFeePerGas}
+                    decimals={9}
+                    symbol="Gwei"
+                  />{" "}
+                  (
+                  <FormattedBalance
+                    value={block.baseFeePerGas}
+                    decimals={0}
+                    symbol="wei"
+                  />
+                  )
+                </span>
+              </InfoRow>
+            )}
+          {burntFees !== null && burntFees !== undefined && (
             <InfoRow title="Burnt Fees">
               <div className="flex items-baseline space-x-1">
                 <span className="flex space-x-1 text-orange-500">

--- a/src/execution/Block.tsx
+++ b/src/execution/Block.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useContext, FC } from "react";
 import { useParams, NavLink } from "react-router-dom";
-import { formatUnits } from "@ethersproject/units";
-import { toUtf8String, Utf8ErrorFuncs } from "@ethersproject/strings";
+import { formatUnits } from "ethers";
+import { toUtf8String, Utf8ErrorFuncs } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBurn } from "@fortawesome/free-solid-svg-icons";
 import StandardFrame from "../components/StandardFrame";
@@ -45,9 +45,9 @@ const Block: FC = () => {
     return block && toUtf8String(block.extraData, Utf8ErrorFuncs.replace);
   }, [block]);
   const burntFees =
-    block?.baseFeePerGas && block.baseFeePerGas.mul(block.gasUsed);
+    block?.baseFeePerGas && (block.baseFeePerGas * block.gasUsed);
   const gasUsedPerc =
-    block && block.gasUsed.mul(10000).div(block.gasLimit).toNumber() / 100;
+    block && Number(block.gasUsed * 10000n / block.gasLimit) / 100;
 
   const latestBlockNumber = useLatestBlockNumber(provider);
 
@@ -101,7 +101,7 @@ const Block: FC = () => {
             <NativeTokenAmount value={block.unclesReward} />
           </InfoRow>
           <InfoRow title="Size">{commify(block.size)} bytes</InfoRow>
-          {block.baseFeePerGas && (
+          {(block.baseFeePerGas !== null && block.baseFeePerGas !== undefined) && (
             <InfoRow title="Base Fee">
               <span>
                 <FormattedBalance
@@ -119,7 +119,7 @@ const Block: FC = () => {
               </span>
             </InfoRow>
           )}
-          {burntFees && (
+          {(burntFees !== null && burntFees !== undefined) && (
             <InfoRow title="Burnt Fees">
               <div className="flex items-baseline space-x-1">
                 <span className="flex space-x-1 text-orange-500">
@@ -155,13 +155,13 @@ const Block: FC = () => {
             <NativeTokenPrice blockTag={block.number} />
           </InfoRow>
           <InfoRow title="Difficulty">
-            {commify(block._difficulty.toString())}
+            {commify(block.difficulty.toString())}
           </InfoRow>
           <InfoRow title="Total Difficulty">
             {commify(block.totalDifficulty.toString())}
           </InfoRow>
           <InfoRow title="Hash">
-            <HexValue value={block.hash} />
+            <HexValue value={block.hash ?? "<unknown>"} />
           </InfoRow>
           <InfoRow title="Parent Hash">
             <BlockLink blockTag={block.parentHash} />

--- a/src/execution/address/AddressTokens.tsx
+++ b/src/execution/address/AddressTokens.tsx
@@ -1,6 +1,6 @@
 import { FC, useContext, useMemo, useState } from "react";
 import { Switch } from "@headlessui/react";
-import { getAddress } from "@ethersproject/address";
+import { getAddress } from "ethers";
 import { AddressAwareComponentProps } from "../types";
 import ContentFrame from "../../components/ContentFrame";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
@@ -18,7 +18,7 @@ const AddressTokens: FC<AddressAwareComponentProps> = ({ address }) => {
   const erc20List = useERC20Holdings(provider, address);
 
   const [enabled, setEnabled] = useState<boolean>(true);
-  const tokenSet = useTokenSet(provider?.network.chainId);
+  const tokenSet = useTokenSet(provider?._network.chainId);
   const filteredList = useMemo(() => {
     if (erc20List === undefined) {
       return undefined;

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -98,7 +98,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
     <ContentFrame tabs>
       <StandardSelectionBoundary>
         <BlockNumberContext.Provider value="latest">
-          {balance && (
+          {balance !== null && balance !== undefined && (
             <InfoRow title="Balance">
               <NativeTokenAmountAndFiat value={balance} {...balancePreset} />
             </InfoRow>

--- a/src/execution/address/ContractFromRepo.tsx
+++ b/src/execution/address/ContractFromRepo.tsx
@@ -5,7 +5,7 @@ import { useAppConfigContext } from "../../useAppConfig";
 
 type ContractFromRepoProps = {
   checksummedAddress: string;
-  networkId: number;
+  networkId: bigint;
   filename: string;
   type: MatchType;
 };

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -86,7 +86,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
                       <ExternalLink
                         href={openInRemixURL(
                           checksummedAddress,
-                          provider.network.chainId
+                          provider._network.chainId
                         )}
                       >
                         Open in Remix
@@ -122,7 +122,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
                   ) : (
                     <ContractFromRepo
                       checksummedAddress={checksummedAddress}
-                      networkId={provider!.network.chainId}
+                      networkId={provider!._network.chainId}
                       filename={selected}
                       type={match.type}
                     />

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -1,5 +1,4 @@
 import { FC, memo } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import TransactionLink from "../../components/TransactionLink";
 import MethodName from "../../components/MethodName";
 import BlockLink from "../../components/BlockLink";
@@ -18,7 +17,7 @@ export type ERC20ItemProps = AddressAwareComponentProps & {
   data: string;
   from: string | undefined;
   to: string | null;
-  value: BigNumber;
+  value: bigint;
 };
 
 const ERC20Item: FC<ERC20ItemProps> = ({

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -34,7 +34,8 @@ const TokenBalance: FC<TokenBalanceProps> = ({
             decimals={metadata?.decimals ?? 0}
           />
         )}
-        {balance !== null && balance !== undefined &&
+        {balance !== null &&
+          balance !== undefined &&
           metadata &&
           quote !== undefined &&
           decimals !== undefined && (

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -28,13 +28,13 @@ const TokenBalance: FC<TokenBalanceProps> = ({
         <DecoratedAddressLink address={tokenAddress} />
       </td>
       <td>
-        {balance && (
+        {balance !== null && balance !== undefined && (
           <FormattedBalanceHighlighter
             value={balance}
             decimals={metadata?.decimals ?? 0}
           />
         )}
-        {balance &&
+        {balance !== null && balance !== undefined &&
           metadata &&
           quote !== undefined &&
           decimals !== undefined && (

--- a/src/execution/address/contract/DecodedABI.tsx
+++ b/src/execution/address/contract/DecodedABI.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { Interface } from "@ethersproject/abi";
+import { Interface } from "ethers";
 import DecodedFragment from "./DecodedFragment";
 import { ABIAwareComponentProps } from "../../types";
 

--- a/src/execution/address/contract/DecodedFragment.stories.tsx
+++ b/src/execution/address/contract/DecodedFragment.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { Interface } from "@ethersproject/abi";
+import { Interface } from "ethers";
 import DecodedFragment from "./DecodedFragment";
 
 const meta = {

--- a/src/execution/address/contract/DecodedFragment.tsx
+++ b/src/execution/address/contract/DecodedFragment.tsx
@@ -5,7 +5,7 @@ import {
   Fragment,
   FunctionFragment,
   Interface,
-} from "@ethersproject/abi";
+} from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCaretRight } from "@fortawesome/free-solid-svg-icons";
 
@@ -21,19 +21,19 @@ const DecodedFragment: FC<DecodedFragmentProps> = ({ intf, fragment }) => {
   let letterBg: string | undefined;
   let hashBg: string | undefined;
 
-  if (FunctionFragment.isFunctionFragment(fragment)) {
+  if (FunctionFragment.isFunction(fragment)) {
     fragmentType = "function";
-    sig = intf.getSighash(fragment);
+    sig = fragment.selector;
     letter = "F";
     letterBg = "bg-violet-500";
     hashBg = "bg-violet-50";
-  } else if (EventFragment.isEventFragment(fragment)) {
+  } else if (EventFragment.isEvent(fragment)) {
     fragmentType = "event";
-    sig = intf.getEventTopic(fragment);
+    sig = fragment.topicHash;
     letter = "E";
     letterBg = "bg-emerald-300";
     hashBg = "bg-emerald-50";
-  } else if (ConstructorFragment.isConstructorFragment(fragment)) {
+  } else if (ConstructorFragment.isConstructor(fragment)) {
     fragmentType = "constructor";
     letter = "C";
     letterBg = "bg-blue-500";

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -47,11 +47,12 @@ const ReadContract: React.FC<ContractsProps> = ({
             <div>
               <ul className="list-inside list-decimal">
                 {match.metadata.output.abi.map(
-                  (fn) =>
+                  (fn, i) =>
                     isReadFunction(fn) && (
                       <ReadFunction
                         func={FunctionFragment.from(fn)}
                         address={checksummedAddress}
+                        key={i}
                       />
                     )
                 )}

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useContext } from "react";
-import { commify } from "@ethersproject/units";
-import { FunctionFragment } from "@ethersproject/abi";
+import { FunctionFragment } from "ethers";
 import { Menu } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
@@ -11,6 +10,7 @@ import { Match, MatchType } from "../../../sourcify/useSourcify";
 import ContractABI from "../contract/ContractABI";
 import ReadFunction from "./ReadFunction";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
+import { commify } from "../../../utils/utils";
 
 type ContractsProps = {
   checksummedAddress: string;

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -1,11 +1,6 @@
 import { FC, memo, useContext, useState, FormEvent } from "react";
 import { SyntaxHighlighter, docco } from "../../../highlight-init";
-import {
-  FunctionFragment,
-  Result,
-  Interface,
-  type ParamType,
-} from "@ethersproject/abi";
+import { FunctionFragment, Result, Interface, type ParamType } from "ethers";
 import { RuntimeContext } from "../../../useRuntime";
 import { parse } from "./contractInputDataParser";
 import DecodedParamsTable from "../../transaction/decoder/DecodedParamsTable";
@@ -27,17 +22,21 @@ function validateArgument(arg: any, argType: ParamType) {
     if (!Array.isArray(arg)) {
       throw new Error(`Invalid array "${arg}": got type ${typeof arg}`);
     }
-    arg.map((childArg) => validateArgument(childArg, argType.arrayChildren));
+    arg.map((childArg) => validateArgument(childArg, argType.arrayChildren!));
   } else if (argType.baseType === "tuple") {
     if (!Array.isArray(arg)) {
       throw new Error(`Invalid tuple "${arg}": got type ${typeof arg}`);
     }
-    if (arg.length !== argType.components.length) {
+    if (arg.length !== argType.components!.length) {
       throw new Error(
-        `Expected tuple length ${argType.components.length}, got ${arg.length}: [${arg}]`
+        `Expected tuple length ${argType.components!.length}, got ${
+          arg.length
+        }: [${arg}]`
       );
     }
-    arg.map((childArg, i) => validateArgument(childArg, argType.components[i]));
+    arg.map((childArg, i) =>
+      validateArgument(childArg, argType.components![i])
+    );
   }
 }
 

--- a/src/execution/address/renderer/TokenLogo.tsx
+++ b/src/execution/address/renderer/TokenLogo.tsx
@@ -7,7 +7,7 @@ import { RuntimeContext } from "../../../useRuntime";
 import { ChecksummedAddress } from "../../../types";
 
 type TokenLogoProps = {
-  chainId: number;
+  chainId: bigint;
   address: ChecksummedAddress;
   name: string;
 };

--- a/src/execution/address/renderer/TokenName.tsx
+++ b/src/execution/address/renderer/TokenName.tsx
@@ -5,7 +5,7 @@ import { ResolvedAddressRenderer } from "../../../api/address-resolver/address-r
 import { TokenMeta } from "../../../types";
 
 type TokenNameProps = {
-  chainId: number;
+  chainId: bigint;
   address: string;
   name: string;
   symbol: string;
@@ -58,7 +58,7 @@ const TokenName: FC<TokenNameProps> = ({
 };
 
 type ContentProps = {
-  chainId: number;
+  chainId: bigint;
   address: string;
   name: string;
   symbol: string;

--- a/src/execution/address/renderer/UniswapV1ExchangeName.tsx
+++ b/src/execution/address/renderer/UniswapV1ExchangeName.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../../api/address-resolver/UniswapV1Resolver";
 
 type UniswapV1ExchangeNameProps = {
-  chainId: number;
+  chainId: bigint;
   address: string;
   token: UniswapV1TokenMeta;
   linkable: boolean;
@@ -61,7 +61,7 @@ const UniswapV1ExchangeName: FC<UniswapV1ExchangeNameProps> = ({
 };
 
 type ContentProps = {
-  chainId: number;
+  chainId: bigint;
   address: ChecksummedAddress;
   name: string;
   symbol: string;

--- a/src/execution/address/renderer/UniswapV2PairName.tsx
+++ b/src/execution/address/renderer/UniswapV2PairName.tsx
@@ -9,7 +9,7 @@ import {
 import { ChecksummedAddress } from "../../../types";
 
 type UniswapV2PairNameProps = {
-  chainId: number;
+  chainId: bigint;
   address: string;
   token0: UniswapV2TokenMeta;
   token1: UniswapV2TokenMeta;
@@ -78,7 +78,7 @@ const UniswapV2PairName: FC<UniswapV2PairNameProps> = ({
 };
 
 type ContentProps = {
-  chainId: number;
+  chainId: bigint;
   address: ChecksummedAddress;
   name: string;
   symbol: string;

--- a/src/execution/address/renderer/UniswapV3PoolName.tsx
+++ b/src/execution/address/renderer/UniswapV3PoolName.tsx
@@ -9,7 +9,7 @@ import {
 import { ChecksummedAddress } from "../../../types";
 
 type UniswapV3PoolNameProps = {
-  chainId: number;
+  chainId: bigint;
   address: string;
   token0: UniswapV3TokenMeta;
   token1: UniswapV3TokenMeta;
@@ -86,7 +86,7 @@ const UniswapV3PairName: FC<UniswapV3PoolNameProps> = ({
 };
 
 type ContentProps = {
-  chainId: number;
+  chainId: bigint;
   address: ChecksummedAddress;
   name: string;
   symbol: string;

--- a/src/execution/block/BlockTransactionHeader.tsx
+++ b/src/execution/block/BlockTransactionHeader.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { BlockTag } from "@ethersproject/abstract-provider";
+import { BlockTag } from "ethers";
 import StandardSubtitle from "../../components/StandardSubtitle";
 import BlockLink from "../../components/BlockLink";
 import NavBlock from "../../components/NavBlock";

--- a/src/execution/components/BlockReward.tsx
+++ b/src/execution/components/BlockReward.tsx
@@ -1,5 +1,4 @@
 import { FC } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import NativeTokenAmount from "../../components/NativeTokenAmount";
 import FiatValue, { rewardPreset } from "../../components/FiatValue";
 import { ExtendedBlock } from "../../useErigonHooks";
@@ -10,14 +9,14 @@ type BlockRewardProps = {
 };
 
 const BlockReward: FC<BlockRewardProps> = ({ block }) => {
-  const netFeeReward = block?.feeReward ?? BigNumber.from(0);
-  const totalReward = block.blockReward.add(netFeeReward);
+  const netFeeReward = block?.feeReward ?? 0n;
+  const totalReward = block.blockReward + netFeeReward;
   const fiatValue = useFiatValue(totalReward, block.number);
 
   return (
     <>
-      <NativeTokenAmount value={block.blockReward.add(netFeeReward)} />
-      {!netFeeReward.isZero() && (
+      <NativeTokenAmount value={totalReward} />
+      {netFeeReward !== 0n && (
         <>
           {" "}
           (<NativeTokenAmount value={block.blockReward} hideUnit /> +{" "}

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -46,7 +46,7 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
   plain,
 }) => {
   const { config, provider } = useContext(RuntimeContext);
-  const match = useSourcifyMetadata(address, provider?.network.chainId);
+  const match = useSourcifyMetadata(address, provider?._network.chainId);
 
   const mint = addressCtx === AddressContext.FROM && address === ZERO_ADDRESS;
   const burn = addressCtx === AddressContext.TO && address === ZERO_ADDRESS;
@@ -163,7 +163,7 @@ const ResolvedAddress: FC<ResolvedAddressProps> = ({
   }
 
   return renderer(
-    provider.network.chainId,
+    provider._network.chainId,
     address,
     resolvedName,
     linkable,

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -357,8 +357,9 @@ const Details: FC<DetailsProps> = ({ txData }) => {
             </div>
             <PercentageBar
               perc={
-                Number(txData.confirmedData.gasUsed * 10000n /
-                    txData.gasLimit) / 100
+                Number(
+                  (txData.confirmedData.gasUsed * 10000n) / txData.gasLimit
+                ) / 100
               }
             />
           </div>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, useContext, useState } from "react";
-import { formatUnits } from "@ethersproject/units";
+import { formatUnits } from "ethers";
 import { Tab } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
@@ -82,7 +82,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
 
   const tokenTransfers = useTokenTransfers(txData);
 
-  const match = useSourcifyMetadata(txData?.to, provider?.network.chainId);
+  const match = useSourcifyMetadata(txData?.to, provider?._network.chainId);
   const metadata = match?.metadata;
 
   const txDesc = useSourcifyTransactionDescription(metadata, txData);
@@ -188,7 +188,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
                     ) : (
                       <DecodedParamsTable
                         args={errorDescription.args}
-                        paramTypes={errorDescription.errorFragment.inputs}
+                        paramTypes={errorDescription.fragment.inputs}
                         hasParamNames
                         userMethod={userError}
                         devMethod={devError}
@@ -326,7 +326,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
           </InfoRow>
         </>
       )}
-      {txData.gasPrice && (
+      {txData.gasPrice !== null && (
         <InfoRow title="Gas Price">
           <div className="flex items-baseline space-x-1">
             <span>
@@ -357,11 +357,8 @@ const Details: FC<DetailsProps> = ({ txData }) => {
             </div>
             <PercentageBar
               perc={
-                Math.round(
-                  (txData.confirmedData.gasUsed.toNumber() /
-                    txData.gasLimit.toNumber()) *
-                    10000
-                ) / 100
+                Number(txData.confirmedData.gasUsed * 10000n /
+                    txData.gasLimit) / 100
               }
             />
           </div>

--- a/src/execution/transaction/Logs.tsx
+++ b/src/execution/transaction/Logs.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { Log } from "@ethersproject/providers";
+import { Log } from "ethers";
 import ContentFrame from "../../components/ContentFrame";
 import LogEntry from "./LogEntry";
 

--- a/src/execution/transaction/NavButton.tsx
+++ b/src/execution/transaction/NavButton.tsx
@@ -8,7 +8,7 @@ import { addressByNonceURL } from "../../url";
 // TODO: extract common component with block/NavButton
 type NavButtonProps = {
   sender: ChecksummedAddress;
-  nonce: number;
+  nonce: bigint;
   disabled?: boolean;
 };
 
@@ -43,7 +43,7 @@ const NavButton: FC<PropsWithChildren<NavButtonProps>> = ({
 
 type PrefetcherProps = {
   checksummedAddress: ChecksummedAddress;
-  nonce: number;
+  nonce: bigint;
 };
 
 const Prefetcher: FC<PrefetcherProps> = ({ checksummedAddress, nonce }) => {

--- a/src/execution/transaction/NavNonce.tsx
+++ b/src/execution/transaction/NavNonce.tsx
@@ -11,7 +11,7 @@ import { useTransactionCount } from "../../useErigonHooks";
 
 type NavNonceProps = {
   sender: ChecksummedAddress;
-  nonce: number;
+  nonce: bigint;
 };
 
 const NavNonce: React.FC<NavNonceProps> = ({ sender, nonce }) => {
@@ -20,20 +20,20 @@ const NavNonce: React.FC<NavNonceProps> = ({ sender, nonce }) => {
 
   return (
     <div className="flex space-x-1 self-center pl-2">
-      <NavButton sender={sender} nonce={nonce - 1} disabled={nonce === 0}>
+      <NavButton sender={sender} nonce={nonce - 1n} disabled={nonce === 0n}>
         <FontAwesomeIcon icon={faChevronLeft} />
       </NavButton>
       <NavButton
         sender={sender}
-        nonce={nonce + 1}
-        disabled={count === undefined || nonce >= count - 1}
+        nonce={nonce + 1n}
+        disabled={count === undefined || nonce >= count - 1n}
       >
         <FontAwesomeIcon icon={faChevronRight} />
       </NavButton>
       <NavButton
         sender={sender}
-        nonce={count !== undefined ? count - 1 : -1}
-        disabled={count === undefined || nonce >= count - 1}
+        nonce={count !== undefined ? count - 1n : -1n}
+        disabled={count === undefined || nonce >= count - 1n}
       >
         <FontAwesomeIcon icon={faChevronRight} />
         <FontAwesomeIcon icon={faChevronRight} />

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBurn, faCoins } from "@fortawesome/free-solid-svg-icons";
 import FormattedBalance from "../../components/FormattedBalance";
@@ -20,14 +19,13 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
   const {
     nativeCurrency: { symbol },
   } = useChainInfo();
-  const paidFees = txData.gasPrice.mul(txData.confirmedData!.gasUsed);
+  const paidFees = txData.gasPrice * txData.confirmedData!.gasUsed;
   const burntFees = block
-    ? block.baseFeePerGas!.mul(txData.confirmedData!.gasUsed)
-    : BigNumber.from(0);
+    ? block.baseFeePerGas! * txData.confirmedData!.gasUsed
+    : 0n;
 
-  const minerReward = paidFees.sub(burntFees);
-  const burntPerc =
-    Math.round(burntFees.mul(10000).div(paidFees).toNumber()) / 100;
+  const minerReward = paidFees - burntFees;
+  const burntPerc = Number(burntFees * 10000n / paidFees) / 100;
   const minerPerc = Math.round((100 - burntPerc) * 100) / 100;
 
   return (

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -25,7 +25,7 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
     : 0n;
 
   const minerReward = paidFees - burntFees;
-  const burntPerc = Number(burntFees * 10000n / paidFees) / 100;
+  const burntPerc = Number((burntFees * 10000n) / paidFees) / 100;
   const minerPerc = Math.round((100 - burntPerc) * 100) / 100;
 
   return (

--- a/src/execution/transaction/Trace.tsx
+++ b/src/execution/transaction/Trace.tsx
@@ -16,7 +16,7 @@ const Trace: React.FC<TraceProps> = ({ txData }) => {
 
   return (
     <ContentFrame tabs>
-      <div className="mt-4 mb-5 flex flex-col items-start space-y-3 overflow-x-auto font-code text-sm">
+      <div className="mb-5 mt-4 flex flex-col items-start space-y-3 overflow-x-auto font-code text-sm">
         {traces ? (
           <>
             <div className="rounded border px-1 py-0.5 hover:border-gray-500">

--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -57,7 +57,7 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
               <>
                 <span>.</span>
                 <FunctionSignature callType={t.type} sig={sigText} />
-                {t.value && !t.value.isZero() && (
+                {t.value && t.value !== 0n && (
                   <span className="whitespace-nowrap text-red-700">
                     {"{"}value:{" "}
                     <FormattedBalance value={t.value} symbol={symbol} />

--- a/src/execution/transaction/TraceItem.tsx
+++ b/src/execution/transaction/TraceItem.tsx
@@ -19,7 +19,7 @@ const TraceItem: React.FC<TraceItemProps> = ({ t, last }) => {
   return (
     <>
       <div className="relative flex">
-        <div className="absolute h-6 w-5 -translate-y-3 border-l border-b"></div>
+        <div className="absolute h-6 w-5 -translate-y-3 border-b border-l"></div>
         {!last && (
           <div className="absolute left-0 h-full w-5 translate-y-3 border-l"></div>
         )}

--- a/src/execution/transaction/decoder/DecodedLogSignature.tsx
+++ b/src/execution/transaction/decoder/DecodedLogSignature.tsx
@@ -1,5 +1,5 @@
 import { FC, memo } from "react";
-import { EventFragment } from "@ethersproject/abi";
+import { EventFragment } from "ethers";
 
 type DecodedLogSignatureProps = {
   event: EventFragment;

--- a/src/execution/transaction/decoder/DecodedLogSignatures.stories.tsx
+++ b/src/execution/transaction/decoder/DecodedLogSignatures.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { EventFragment } from "@ethersproject/abi";
+import { EventFragment } from "ethers";
 import DecodedLogSignature from "./DecodedLogSignature";
 
 const meta = {
@@ -25,7 +25,7 @@ export const Numbers: Story = {
 
 export const Test: Story = {
   args: {
-    event: EventFragment.fromString(
+    event: EventFragment.from(
       "OrderFulfilled(bytes32 orderHash, address indexed offerer, address indexed zone, address recipient, tuple(uint8 itemType, address token, uint256 identifier, uint256 amount)[] offer, tuple(uint8 itemType, address token, uint256 identifier, uint256 amount, address recipient)[] consideration)"
     ),
   },

--- a/src/execution/transaction/decoder/DecodedParamRow.stories.tsx
+++ b/src/execution/transaction/decoder/DecodedParamRow.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ParamType } from "@ethersproject/abi";
+import { ParamType } from "ethers";
 import DecodedParamRow from "./DecodedParamRow";
 import { RuntimeContext } from "../../../useRuntime";
 import { ConnectionStatus } from "../../../types";

--- a/src/execution/transaction/decoder/DecodedParamRow.tsx
+++ b/src/execution/transaction/decoder/DecodedParamRow.tsx
@@ -46,7 +46,11 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
                 </span>
               ) : (
                 <>
-                  {paramType.name ?? <span className="italic">param_{i}</span>}{" "}
+                  {paramType.name !== "" ? (
+                    paramType.name
+                  ) : (
+                    <span className="italic">param_{i}</span>
+                  )}{" "}
                   {i !== undefined && (
                     <span className="text-xs text-gray-400">({i})</span>
                   )}
@@ -97,7 +101,7 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
           <DecodedParamRow
             key={idx}
             prefix={
-              paramType.name ? (
+              paramType.name !== "" ? (
                 paramType.name + "."
               ) : (
                 <span className="italic">param_{i}.</span>
@@ -112,7 +116,13 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
         r.map((e: any, idx: number) => (
           <DecodedParamRow
             key={idx}
-            prefix={paramType.name ?? <span className="italic">param_{i}</span>}
+            prefix={
+              paramType.name !== "" ? (
+                paramType.name
+              ) : (
+                <span className="italic">param_{i}</span>
+              )
+            }
             r={e}
             // arrayChildren is not null when the baseType is array
             paramType={paramType.arrayChildren!}

--- a/src/execution/transaction/decoder/DecodedParamRow.tsx
+++ b/src/execution/transaction/decoder/DecodedParamRow.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, ReactNode, useState } from "react";
-import { ParamType } from "@ethersproject/abi";
+import { ParamType } from "ethers";
 import { Switch } from "@headlessui/react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
@@ -105,7 +105,7 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
             }
             i={idx}
             r={e}
-            paramType={paramType.components[idx]}
+            paramType={paramType.components![idx]}
           />
         ))}
       {paramType.baseType === "array" &&
@@ -114,7 +114,8 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
             key={idx}
             prefix={paramType.name ?? <span className="italic">param_{i}</span>}
             r={e}
-            paramType={paramType.arrayChildren}
+            // arrayChildren is not null when the baseType is array
+            paramType={paramType.arrayChildren!}
             arrayElem={idx}
           />
         ))}

--- a/src/execution/transaction/decoder/DecodedParamsTable.stories.tsx
+++ b/src/execution/transaction/decoder/DecodedParamsTable.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { Result } from "ethers";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
 import { SourcifySource } from "../../../sourcify/useSourcify";
 import { ConnectionStatus } from "../../../types";
@@ -42,7 +43,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    args: [
+    args: Result.fromItems([
       Uint8WithHelp.args.r,
       Uint256WithHelp.args.r,
       BooleanWithHelp.args.r,
@@ -50,7 +51,7 @@ export const Default: Story = {
       ArrayWithHelp.args.r,
       TupleWithHelp.args.r,
       ArrayOfTupleWithHelp.args.r,
-    ],
+    ]),
     paramTypes: [
       Uint8WithHelp.args.paramType,
       Uint256WithHelp.args.paramType,

--- a/src/execution/transaction/decoder/DecodedParamsTable.tsx
+++ b/src/execution/transaction/decoder/DecodedParamsTable.tsx
@@ -1,11 +1,11 @@
 import { FC, memo } from "react";
-import { ParamType, Result } from "@ethersproject/abi";
+import { ParamType, Result } from "ethers";
 import DecodedParamRow from "./DecodedParamRow";
 import { DevMethod, UserMethod } from "../../../sourcify/useSourcify";
 
 type DecodedParamsTableProps = {
   args: Result;
-  paramTypes: ParamType[];
+  paramTypes: readonly ParamType[];
   hasParamNames?: boolean;
   userMethod?: UserMethod | undefined;
   devMethod?: DevMethod | undefined;

--- a/src/execution/transaction/decoder/DecodedParamsTable.tsx
+++ b/src/execution/transaction/decoder/DecodedParamsTable.tsx
@@ -29,7 +29,7 @@ const DecodedParamsTable: FC<DecodedParamsTableProps> = ({
       {!hasParamNames && (
         <tr className="grid grid-cols-12 gap-x-2 bg-amber-100 py-2 text-left text-red-700">
           <th className="col-span-12 px-1">
-            {paramTypes.length > 0 && paramTypes[0].name !== null
+            {paramTypes.length > 0 && paramTypes[0].name !== ""
               ? "Parameter names are estimated."
               : "Parameter names are not available."}
           </th>

--- a/src/execution/transaction/decoder/InputDecoder.tsx
+++ b/src/execution/transaction/decoder/InputDecoder.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
-import { TransactionDescription } from "@ethersproject/abi";
-import { toUtf8String } from "@ethersproject/strings";
+import { TransactionDescription } from "ethers";
+import { toUtf8String } from "ethers";
 import { Tab } from "@headlessui/react";
 import ModeTab from "../../../components/ModeTab";
 import DecodedParamsTable from "./DecodedParamsTable";
@@ -51,7 +51,7 @@ const InputDecoder: React.FC<InputDecoderProps> = ({
           ) : (
             <DecodedParamsTable
               args={resolvedTxDesc.args}
-              paramTypes={resolvedTxDesc.functionFragment.inputs}
+              paramTypes={resolvedTxDesc.fragment.inputs}
               hasParamNames={hasParamNames}
               userMethod={userMethod}
               devMethod={devMethod}

--- a/src/execution/transaction/decoder/Uint256Decoder.stories.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { BigNumber } from "@ethersproject/bignumber";
 import Uint256Decoder from "./Uint256Decoder";
 
 const meta = {
@@ -11,13 +10,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Zero: Story = {
   args: {
-    r: BigNumber.from(0),
+    r: 0n,
   },
 };
 
 export const Max: Story = {
   args: {
-    r: BigNumber.from(
+    r: BigInt(
       "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     ),
   },

--- a/src/execution/transaction/decoder/Uint256Decoder.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.tsx
@@ -1,5 +1,5 @@
 import { FC, memo, useState } from "react";
-import { hexlify, zeroPadValue, formatEther } from "ethers";
+import { toBeHex, zeroPadValue, formatEther } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { commify } from "../../../utils/utils";
@@ -56,7 +56,7 @@ const Uint256Decoder: FC<Uint256DecoderProps> = ({ r }) => {
         {displayMode === DisplayMode.RAW ? (
           <>{commify(r.toString())}</>
         ) : displayMode === DisplayMode.HEX ? (
-          <>{zeroPadValue(hexlify(r), 32)}</>
+          <>{zeroPadValue(toBeHex(r), 32)}</>
         ) : (
           <>{commify(formatEther(r))}</>
         )}

--- a/src/execution/transaction/decoder/Uint256Decoder.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.tsx
@@ -1,7 +1,5 @@
 import { FC, memo, useState } from "react";
-import { BigNumber } from "@ethersproject/bignumber";
-import { hexlify, hexZeroPad } from "@ethersproject/bytes";
-import { formatEther } from "@ethersproject/units";
+import { hexlify, zeroPadValue, formatEther } from "ethers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { commify } from "../../../utils/utils";
@@ -17,11 +15,11 @@ enum DisplayMode {
   _LAST,
 }
 
-const VERY_BIG_NUMBER = BigNumber.from(10).pow(BigNumber.from(36));
+const VERY_BIG_NUMBER = 10n ** 36n;
 
 const initDisplayMode = (r: any): DisplayMode => {
-  const n = BigNumber.from(r);
-  if (n.gte(VERY_BIG_NUMBER)) {
+  const n = BigInt(r);
+  if (n >= VERY_BIG_NUMBER) {
     return DisplayMode.HEX;
   }
   return DisplayMode.RAW;
@@ -58,7 +56,7 @@ const Uint256Decoder: FC<Uint256DecoderProps> = ({ r }) => {
         {displayMode === DisplayMode.RAW ? (
           <>{commify(r.toString())}</>
         ) : displayMode === DisplayMode.HEX ? (
-          <>{hexZeroPad(hexlify(r), 32)}</>
+          <>{zeroPadValue(hexlify(r), 32)}</>
         ) : (
           <>{commify(formatEther(r))}</>
         )}

--- a/src/execution/transaction/log/RawLog.tsx
+++ b/src/execution/transaction/log/RawLog.tsx
@@ -4,7 +4,7 @@ import Topic from "./Topic";
 import StandardTextarea from "../../../components/StandardTextarea";
 
 type RawLogProps = {
-  topics: string[];
+  topics: readonly string[];
   data: string;
 };
 

--- a/src/kleros/useTokenList.ts
+++ b/src/kleros/useTokenList.ts
@@ -1,14 +1,14 @@
 import { useMemo } from "react";
-import { getAddress } from "@ethersproject/address";
+import { getAddress } from "ethers";
 import { ChecksummedAddress } from "../types";
 import t2crtokens from "./t2crtokens.eth.json";
 
 export const useTokenSet = (
-  chainId: number | undefined
+  chainId: bigint | undefined
 ): Set<ChecksummedAddress> => {
   const res = useMemo(() => {
     const list = t2crtokens.tokens
-      .filter((t) => t.chainId === chainId)
+      .filter((t) => t.chainId === Number(chainId))
       .map((t) => getAddress(t.address));
     return new Set(list);
   }, [chainId]);

--- a/src/ots2/contractMatchParsers.ts
+++ b/src/ots2/contractMatchParsers.ts
@@ -1,4 +1,3 @@
-import { BigNumber } from "@ethersproject/bignumber";
 import { ContractMatch, ContractResultParser } from "./usePrototypeHooks";
 import { ChecksummedAddress } from "../types";
 
@@ -29,14 +28,14 @@ export type ERC4626ContractMatch = ERC20ContractMatch & {
 export const contractMatchParser: ContractResultParser<ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
 });
 
 export const erc20MatchParser: ContractResultParser<ERC20ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
   name: m.name,
   symbol: m.symbol,
@@ -46,7 +45,7 @@ export const erc20MatchParser: ContractResultParser<ERC20ContractMatch> = (
 export const erc4626MatchParser: ContractResultParser<ERC4626ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
   name: m.name,
   symbol: m.symbol,
@@ -58,7 +57,7 @@ export const erc4626MatchParser: ContractResultParser<ERC4626ContractMatch> = (
 export const erc721MatchParser: ContractResultParser<ERC721ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
   name: m.name,
   symbol: m.symbol,
@@ -67,7 +66,7 @@ export const erc721MatchParser: ContractResultParser<ERC721ContractMatch> = (
 export const erc1155MatchParser: ContractResultParser<ERC1155ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
   name: m.name,
   symbol: m.symbol,
@@ -76,7 +75,7 @@ export const erc1155MatchParser: ContractResultParser<ERC1155ContractMatch> = (
 export const erc1167MatchParser: ContractResultParser<ERC1167ContractMatch> = (
   m
 ) => ({
-  blockNumber: BigNumber.from(m.blockNumber).toNumber(),
+  blockNumber: BigInt(m.blockNumber),
   address: m.address,
   implementation: m.implementation,
 });

--- a/src/ots2/usePrototypeHooks.ts
+++ b/src/ots2/usePrototypeHooks.ts
@@ -1,23 +1,23 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { JsonRpcApiProvider } from "ethers";
 import useSWR from "swr";
 import useSWRImmutable from "swr/immutable";
 import { providerFetcher } from "../useErigonHooks";
 import { pageToReverseIdx } from "./pagination";
 
 export type BlockSummary = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
 };
 
 export type ContractMatch = {
-  blockNumber: number;
+  blockNumber: bigint;
   address: string;
 };
 
 export type ContractResultParser<T> = (e: any) => T;
 
 export type ContractListResults<T> = {
-  blocksSummary: Map<number, BlockSummary>;
+  blocksSummary: Map<bigint, BlockSummary>;
   results: T[];
 };
 
@@ -36,7 +36,7 @@ export type ContractSearchType =
   | "ERC1167";
 
 export const useGenericContractSearch = <T extends ContractMatch>(
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   t: ContractSearchType,
   pageNumber: number,
   pageSize: number,
@@ -60,9 +60,11 @@ export const useGenericContractSearch = <T extends ContractMatch>(
   }
   const results = (data.results as any[]).map((m) => parser(m));
 
-  const blockMap = new Map<number, BlockSummary>();
+  const blockMap = new Map<bigint, BlockSummary>();
   for (const [k, v] of Object.entries(data.blocksSummary as any)) {
-    blockMap.set(parseInt(k), v as any);
+    // TODO: parseInt -> BigInt won't work when the int is followed
+    // by non-numeric characters
+    blockMap.set(BigInt(k), v as any);
   }
   return {
     blocksSummary: blockMap,
@@ -71,7 +73,7 @@ export const useGenericContractSearch = <T extends ContractMatch>(
 };
 
 export const useGenericContractsCount = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   t: ContractSearchType
 ): number | undefined => {
   const rpcMethod = `ots_get${t}Count`;

--- a/src/ots2/usePrototypeTransferHooks.ts
+++ b/src/ots2/usePrototypeTransferHooks.ts
@@ -1,13 +1,12 @@
 import { useMemo } from "react";
 import {
-  JsonRpcProvider,
-  Formatter,
+  JsonRpcApiProvider,
   TransactionResponse,
   TransactionReceipt,
-} from "@ethersproject/providers";
-import { Contract } from "@ethersproject/contracts";
-import { BigNumber } from "@ethersproject/bignumber";
-import { AddressZero } from "@ethersproject/constants";
+  TransactionReceiptParams,
+} from "ethers";
+import { Contract } from "ethers";
+import { ZeroAddress } from "ethers";
 import useSWR, { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { ChecksummedAddress } from "../types";
@@ -15,6 +14,7 @@ import { providerFetcher } from "../useErigonHooks";
 import { BlockSummary } from "./usePrototypeHooks";
 import { pageToReverseIdx } from "./pagination";
 import erc20 from "../erc20.json";
+import { formatter } from "../utils/formatter";
 
 /**
  * All supported transaction search types.
@@ -39,7 +39,7 @@ export type TransactionMatchWithData = TransactionMatch & {
 };
 
 export const useGenericTransactionCount = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   t: TransactionSearchType,
   address: ChecksummedAddress
 ): number | undefined => {
@@ -52,10 +52,8 @@ export const useGenericTransactionCount = (
   return data as number | undefined;
 };
 
-const formatter = new Formatter();
-
 const resultFetcher = (
-  provider: JsonRpcProvider | undefined
+  provider: JsonRpcApiProvider | undefined
 ): Fetcher<
   TransactionListResults<TransactionMatchWithData> | undefined,
   [string, ...any]
@@ -71,8 +69,9 @@ const resultFetcher = (
     const converted = (res.results as any[]).map(
       (m): TransactionMatchWithData => ({
         hash: m.hash,
-        transaction: formatter.transactionResponse(m.transaction),
-        receipt: formatter.receipt(m.receipt),
+        // provider is a JsonRpcApiProvider; fetcher/res would be undefined otherwise
+        transaction: new TransactionResponse(formatter.transactionResponse(m.transaction), provider as JsonRpcApiProvider),
+        receipt: new TransactionReceipt(formatter.transactionReceiptParams(m.receipt), provider as JsonRpcApiProvider),
       })
     );
     const blockMap = new Map<number, BlockSummary>();
@@ -88,7 +87,7 @@ const resultFetcher = (
 };
 
 export const useGenericTransactionList = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   t: TransactionSearchType,
   address: ChecksummedAddress,
   pageNumber: number,
@@ -110,7 +109,7 @@ export const useGenericTransactionList = (
 };
 
 export const useERC1167Impl = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   address: ChecksummedAddress | undefined
 ): ChecksummedAddress | undefined | null => {
   const fetcher = providerFetcher(provider);
@@ -125,7 +124,7 @@ export const useERC1167Impl = (
 };
 
 export const useERC20Holdings = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   address: ChecksummedAddress
 ): ChecksummedAddress[] | undefined => {
   const fetcher = providerFetcher(provider);
@@ -144,13 +143,13 @@ export const useERC20Holdings = (
   return converted;
 };
 
-const ERC20_PROTOTYPE = new Contract(AddressZero, erc20);
+const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
 
 const erc20BalanceFetcher =
   (
-    provider: JsonRpcProvider | undefined
+    provider: JsonRpcApiProvider | undefined
   ): Fetcher<
-    BigNumber | null,
+    bigint | null,
     ["erc20balance", ChecksummedAddress, ChecksummedAddress]
   > =>
   async ([_, address, tokenAddress]) => {
@@ -158,15 +157,16 @@ const erc20BalanceFetcher =
       return null;
     }
 
-    const contract = ERC20_PROTOTYPE.connect(provider).attach(tokenAddress);
+    // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
+    const contract = ERC20_PROTOTYPE.connect(provider).attach(tokenAddress) as Contract;
     return contract.balanceOf(address);
   };
 
 export const useTokenBalance = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   address: ChecksummedAddress | undefined,
   tokenAddress: ChecksummedAddress | undefined
-): BigNumber | null | undefined => {
+): bigint | null | undefined => {
   const fetcher = erc20BalanceFetcher(provider);
   const { data, error } = useSWR(
     ["erc20balance", address, tokenAddress],
@@ -192,7 +192,7 @@ export type AddressAttributes = {
 };
 
 export const useAddressAttributes = (
-  provider: JsonRpcProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   address: ChecksummedAddress
 ): AddressAttributes | undefined => {
   const fetcher = providerFetcher(provider);

--- a/src/ots2/usePrototypeTransferHooks.ts
+++ b/src/ots2/usePrototypeTransferHooks.ts
@@ -70,8 +70,14 @@ const resultFetcher = (
       (m): TransactionMatchWithData => ({
         hash: m.hash,
         // provider is a JsonRpcApiProvider; fetcher/res would be undefined otherwise
-        transaction: new TransactionResponse(formatter.transactionResponse(m.transaction), provider as JsonRpcApiProvider),
-        receipt: new TransactionReceipt(formatter.transactionReceiptParams(m.receipt), provider as JsonRpcApiProvider),
+        transaction: new TransactionResponse(
+          formatter.transactionResponse(m.transaction),
+          provider as JsonRpcApiProvider
+        ),
+        receipt: new TransactionReceipt(
+          formatter.transactionReceiptParams(m.receipt),
+          provider as JsonRpcApiProvider
+        ),
       })
     );
     const blockMap = new Map<number, BlockSummary>();
@@ -158,7 +164,9 @@ const erc20BalanceFetcher =
     }
 
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const contract = ERC20_PROTOTYPE.connect(provider).attach(tokenAddress) as Contract;
+    const contract = ERC20_PROTOTYPE.connect(provider).attach(
+      tokenAddress
+    ) as Contract;
     return contract.balanceOf(address);
   };
 

--- a/src/ots2/useUIHooks.ts
+++ b/src/ots2/useUIHooks.ts
@@ -55,7 +55,7 @@ const useContractSearch = <T extends ContractMatch>(
 
 export type ResultMapper<T> = (
   m: any,
-  blocksSummary: ReadonlyMap<number, BlockSummary>
+  blocksSummary: ReadonlyMap<bigint, BlockSummary>
 ) => T;
 
 /**

--- a/src/search/CameraScanner.tsx
+++ b/src/search/CameraScanner.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { isAddress } from "@ethersproject/address";
+import { isAddress } from "ethers";
 import { QrReader } from "@otterscan/react-qr-reader";
 import { OnResultFunction } from "@otterscan/react-qr-reader/dist-types/types";
 import { BarcodeFormat } from "@zxing/library";

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -10,7 +10,7 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
 }) => (
-  <div className="grid grid-cols-12 gap-x-1 border-t border-b border-gray-200 bg-gray-100 px-2 py-2 text-sm font-bold text-gray-500">
+  <div className="grid grid-cols-12 gap-x-1 border-b border-t border-gray-200 bg-gray-100 px-2 py-2 text-sm font-bold text-gray-500">
     <div className="col-span-2">Txn Hash</div>
     <div>Method</div>
     <div>Block</div>

--- a/src/search/SearchResultNavBar.tsx
+++ b/src/search/SearchResultNavBar.tsx
@@ -4,7 +4,7 @@ import PageControl from "./PageControl";
 type SearchResultNavBarProps = {
   /**
    * 1-based page number.
-   * 
+   *
    * If omitted, assumes 1 using default value.
    */
   pageNumber?: number;

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -47,7 +47,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
     }
   }
 
-  const flash = tx.gasPrice.isZero() && sendsToMiner;
+  const flash = tx.gasPrice === 0n && sendsToMiner;
 
   return (
     <BlockNumberContext.Provider value={tx.blockNumber}>

--- a/src/search/TransactionItemFiatFee.tsx
+++ b/src/search/TransactionItemFiatFee.tsx
@@ -17,7 +17,9 @@ const TransactionItemFiatFee: React.FC<TransactionItemFiatFeeProps> = ({
   const { provider } = useContext(RuntimeContext);
   const eth2USDValue = useETHUSDOracle(provider, blockTag);
   const fiatValue =
-    eth2USDValue !== undefined ? (fee * eth2USDValue / 100_000_000n) : undefined;
+    eth2USDValue !== undefined
+      ? (fee * eth2USDValue) / 100_000_000n
+      : undefined;
 
   return fiatValue ? (
     <span className="text-xs">

--- a/src/search/TransactionItemFiatFee.tsx
+++ b/src/search/TransactionItemFiatFee.tsx
@@ -1,13 +1,13 @@
 import React, { useContext } from "react";
-import { BlockTag } from "@ethersproject/providers";
-import { BigNumber, FixedNumber } from "@ethersproject/bignumber";
+import { BlockTag } from "ethers";
+import { FixedNumber } from "ethers";
 import { RuntimeContext } from "../useRuntime";
 import { useETHUSDOracle } from "../usePriceOracle";
 import { commify } from "../utils/utils";
 
 type TransactionItemFiatFeeProps = {
   blockTag: BlockTag;
-  fee: BigNumber;
+  fee: bigint;
 };
 
 const TransactionItemFiatFee: React.FC<TransactionItemFiatFeeProps> = ({
@@ -17,7 +17,7 @@ const TransactionItemFiatFee: React.FC<TransactionItemFiatFeeProps> = ({
   const { provider } = useContext(RuntimeContext);
   const eth2USDValue = useETHUSDOracle(provider, blockTag);
   const fiatValue =
-    eth2USDValue !== undefined ? fee.mul(eth2USDValue).div(10 ** 8) : undefined;
+    eth2USDValue !== undefined ? (fee * eth2USDValue / 100_000_000n) : undefined;
 
   return fiatValue ? (
     <span className="text-xs">

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -6,7 +6,11 @@ import {
   useState,
 } from "react";
 import { NavigateFunction, useNavigate } from "react-router";
-import { JsonRpcApiProvider, TransactionResponse,  TransactionReceiptParams } from "ethers";
+import {
+  JsonRpcApiProvider,
+  TransactionResponse,
+  TransactionReceiptParams,
+} from "ethers";
 import { isAddress } from "ethers";
 import { isHexString } from "ethers";
 import useKeyboardShortcut from "use-keyboard-shortcut";
@@ -15,14 +19,16 @@ import { ProcessedTransaction, TransactionChunk } from "../types";
 import { formatter } from "../utils/formatter";
 
 export const rawToProcessed = (provider: JsonRpcApiProvider, _rawRes: any) => {
-  const _res: TransactionResponse[] = _rawRes.txs.map((t: any) =>
-    new TransactionResponse(formatter.transactionResponse(t), provider)
+  const _res: TransactionResponse[] = _rawRes.txs.map(
+    (t: any) =>
+      new TransactionResponse(formatter.transactionResponse(t), provider)
   );
 
   return {
     txs: _res.map((t, i): ProcessedTransaction => {
       const _rawReceipt = _rawRes.receipts[i];
-      const _receipt: TransactionReceiptParams = formatter.transactionReceiptParams(_rawReceipt);
+      const _receipt: TransactionReceiptParams =
+        formatter.transactionReceiptParams(_rawReceipt);
       return {
         blockNumber: t.blockNumber!,
         timestamp: formatter.number(_rawReceipt.timestamp),

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
-import { Interface } from "@ethersproject/abi";
-import { ErrorDescription } from "@ethersproject/abi/lib/interface";
+import { Interface } from "ethers";
+import { ErrorDescription } from "ethers";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { ChecksummedAddress, TransactionData } from "../types";
@@ -112,7 +112,7 @@ const resolveSourcifySource = (source: SourcifySource) => {
  */
 export const sourcifyMetadata = (
   address: ChecksummedAddress,
-  chainId: number,
+  chainId: bigint,
   source: SourcifySource,
   type: MatchType
 ) =>
@@ -122,7 +122,7 @@ export const sourcifyMetadata = (
 
 export const sourcifySourceFile = (
   address: ChecksummedAddress,
-  chainId: number,
+  chainId: bigint,
   filepath: string,
   source: SourcifySource,
   type: MatchType
@@ -143,7 +143,7 @@ export type Match = {
 
 const sourcifyFetcher: Fetcher<
   Match | null | undefined,
-  ["sourcify", ChecksummedAddress, number, SourcifySource]
+  ["sourcify", ChecksummedAddress, bigint, SourcifySource]
 > = async ([_, address, chainId, sourcifySource]) => {
   // Try full match
   try {
@@ -192,7 +192,7 @@ const sourcifyFetcher: Fetcher<
 
 export const useSourcifyMetadata = (
   address: ChecksummedAddress | undefined,
-  chainId: number | undefined
+  chainId: bigint | undefined
 ): Match | null | undefined => {
   const { sourcifySource } = useAppConfigContext();
   const metadataURL = () =>
@@ -219,7 +219,7 @@ const contractFetcher: Fetcher<string | null, string> = async (url) => {
 
 export const useContract = (
   checksummedAddress: string,
-  networkId: number,
+  networkId: bigint,
   filename: string,
   sourcifySource: SourcifySource,
   type: MatchType

--- a/src/special/london/BlockRow.tsx
+++ b/src/special/london/BlockRow.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import { FixedNumber } from "@ethersproject/bignumber";
-import { formatEther } from "@ethersproject/units";
+import { FixedNumber, formatEther } from "ethers";
 import BlockLink from "../../components/BlockLink";
 import TimestampAge from "../../components/TimestampAge";
 import Blip from "./Blip";
@@ -8,7 +7,7 @@ import { ExtendedBlock } from "../../useErigonHooks";
 import { useChainInfo } from "../../useChainInfo";
 import { commify } from "../../utils/utils";
 
-const ELASTICITY_MULTIPLIER = 2;
+const ELASTICITY_MULTIPLIER = 2n;
 
 type BlockRowProps = {
   block: ExtendedBlock;
@@ -19,11 +18,11 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
   const {
     nativeCurrency: { symbol },
   } = useChainInfo();
-  const gasTarget = block.gasLimit.div(ELASTICITY_MULTIPLIER);
+  const gasTarget = block.gasLimit / ELASTICITY_MULTIPLIER;
   const burntFees =
-    block?.baseFeePerGas && block.baseFeePerGas.mul(block.gasUsed);
-  const netFeeReward = block && block.feeReward.sub(burntFees ?? 0);
-  const totalReward = block.blockReward.add(netFeeReward ?? 0);
+    block?.baseFeePerGas && block.baseFeePerGas * block.gasUsed;
+  const netFeeReward = block && block.feeReward - (burntFees ?? 0n);
+  const totalReward = block.blockReward + (netFeeReward ?? 0n);
 
   return (
     <div className="grid grid-cols-9 gap-x-2 px-3 py-2 hover:bg-skin-table-hover">
@@ -32,9 +31,9 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
       </div>
       <div
         className={`text-right ${
-          block.gasUsed.gt(gasTarget)
+          (block.gasUsed > gasTarget)
             ? "text-emerald-500"
-            : block.gasUsed.lt(gasTarget)
+            : (block.gasUsed < gasTarget)
             ? "text-red-500"
             : ""
         }`}
@@ -47,8 +46,8 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
       <div className="text-right">
         <div className="relative">
           <span>
-            {FixedNumber.from(block.baseFeePerGas)
-              .divUnsafe(FixedNumber.from(1e9))
+            {FixedNumber.fromValue(block.baseFeePerGas ?? 0n)
+              .divUnsafe(FixedNumber.fromValue(1_000_000_000n))
               .round(0)
               .toUnsafeFloat()}{" "}
             Gwei
@@ -60,7 +59,7 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
         {commify(formatEther(totalReward))} {symbol}
       </div>
       <div className="col-span-2 text-right text-orange-500 line-through">
-        {commify(formatEther(block.gasUsed.mul(block.baseFeePerGas!)))} {symbol}
+        {commify(formatEther(block.gasUsed * block.baseFeePerGas!))} {symbol}
       </div>
       <div className="text-right text-gray-400">
         <TimestampAge timestamp={block.timestamp} />

--- a/src/special/london/BlockRow.tsx
+++ b/src/special/london/BlockRow.tsx
@@ -19,8 +19,7 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
     nativeCurrency: { symbol },
   } = useChainInfo();
   const gasTarget = block.gasLimit / ELASTICITY_MULTIPLIER;
-  const burntFees =
-    block?.baseFeePerGas && block.baseFeePerGas * block.gasUsed;
+  const burntFees = block?.baseFeePerGas && block.baseFeePerGas * block.gasUsed;
   const netFeeReward = block && block.feeReward - (burntFees ?? 0n);
   const totalReward = block.blockReward + (netFeeReward ?? 0n);
 
@@ -31,9 +30,9 @@ const BlockRow: React.FC<BlockRowProps> = ({ block, baseFeeDelta }) => {
       </div>
       <div
         className={`text-right ${
-          (block.gasUsed > gasTarget)
+          block.gasUsed > gasTarget
             ? "text-emerald-500"
-            : (block.gasUsed < gasTarget)
+            : block.gasUsed < gasTarget
             ? "text-red-500"
             : ""
         }`}

--- a/src/special/london/Blocks.tsx
+++ b/src/special/london/Blocks.tsx
@@ -71,8 +71,11 @@ const Blocks: React.FC<BlocksProps> = ({ latestBlock, targetBlockNumber }) => {
 
       const extBlock = await readBlock(provider, blockNumber.toString());
       setBlocks((_blocks) => {
-        if (_blocks.length > 0 && blockNumber === _blocks[0].number) {
-          return _blocks;
+        for (let i = 0; i < _blocks.length; i++) {
+          if (_blocks[i].number === blockNumber) {
+            // Block already in list
+            return _blocks;
+          }
         }
         if (extBlock === null) {
           return _blocks;

--- a/src/special/london/Blocks.tsx
+++ b/src/special/london/Blocks.tsx
@@ -124,7 +124,7 @@ const Blocks: React.FC<BlocksProps> = ({ latestBlock, targetBlockNumber }) => {
 
   return (
     <div className="w-full grow">
-      <div className="divide-y-2 px-9 pt-3 pb-12">
+      <div className="divide-y-2 px-9 pb-12 pt-3">
         <div className="relative">
           <div className="flex items-baseline justify-center space-x-2 px-3 pb-2 text-lg text-orange-500 ">
             <span>

--- a/src/special/london/Blocks.tsx
+++ b/src/special/london/Blocks.tsx
@@ -5,8 +5,7 @@ import React, {
   useMemo,
   useCallback,
 } from "react";
-import { Block } from "@ethersproject/abstract-provider";
-import { FixedNumber } from "@ethersproject/bignumber";
+import { Block, FixedNumber } from "ethers";
 import { Line } from "react-chartjs-2";
 import {
   Chart as ChartJS,
@@ -195,12 +194,12 @@ const Blocks: React.FC<BlocksProps> = ({ latestBlock, targetBlockNumber }) => {
               block={b}
               baseFeeDelta={
                 i < all.length - 1
-                  ? FixedNumber.from(b.baseFeePerGas!)
-                      .divUnsafe(FixedNumber.from(1e9))
+                  ? FixedNumber.fromValue(b.baseFeePerGas!)
+                      .divUnsafe(FixedNumber.fromValue(1e9))
                       .round(0)
                       .subUnsafe(
-                        FixedNumber.from(all[i + 1].baseFeePerGas!)
-                          .divUnsafe(FixedNumber.from(1e9))
+                        FixedNumber.fromValue(all[i + 1].baseFeePerGas!)
+                          .divUnsafe(FixedNumber.fromValue(1e9))
                           .round(0)
                       )
                       .toUnsafeFloat()

--- a/src/special/london/Countdown.tsx
+++ b/src/special/london/Countdown.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { JsonRpcProvider, Block } from "@ethersproject/providers";
+import { JsonRpcApiProvider, Block } from "ethers";
 import { commify } from "../../utils/utils";
 
 type CountdownProps = {
-  provider: JsonRpcProvider;
+  provider: JsonRpcApiProvider;
   currentBlock: Block;
   targetBlock: number;
 };
@@ -21,7 +21,7 @@ const Countdown: React.FC<CountdownProps> = ({
       const _prevBlock = await provider.getBlock(currentBlock.number - diff);
       const _targetTimestamp =
         currentBlock.timestamp +
-        (currentBlock.timestamp - _prevBlock.timestamp);
+        (currentBlock.timestamp - (_prevBlock?.timestamp ?? 0));
       setTargetTimestamp(_targetTimestamp);
     };
     calcTime();

--- a/src/special/london/London.tsx
+++ b/src/special/london/London.tsx
@@ -14,7 +14,7 @@ const London: React.FC = () => {
 
   // Display countdown
   const targetBlockNumber =
-    londonBlockNumber[provider.network.chainId.toString()];
+    londonBlockNumber[provider._network.chainId.toString()];
   if (block.number < targetBlockNumber) {
     return (
       <Countdown

--- a/src/special/london/chart.ts
+++ b/src/special/london/chart.ts
@@ -1,6 +1,6 @@
-import { commify } from "../../utils/utils";
 import { ChartData, ChartOptions } from "chart.js";
 import { ExtendedBlock } from "../../useErigonHooks";
+import { commify } from "../../utils/utils";
 
 export const burntFeesChartOptions: ChartOptions<"line"> = {
   animation: false,
@@ -53,7 +53,7 @@ export const burntFeesChartData = (
     {
       label: "Burnt fees (Gwei)",
       data: blocks
-        .map((b) => b.gasUsed.mul(b.baseFeePerGas!).div(1e9).toNumber())
+        .map((b) => Number(b.gasUsed * b.baseFeePerGas! / (10n ** 9n)))
         .reverse(),
       fill: true,
       backgroundColor: "#FDBA7470",
@@ -62,7 +62,7 @@ export const burntFeesChartData = (
     },
     {
       label: "Base fee (wei)",
-      data: blocks.map((b) => b.baseFeePerGas!.toNumber()).reverse(),
+      data: blocks.map((b) => Number(b.baseFeePerGas!)).reverse(),
       yAxisID: "yBaseFee",
       borderColor: "#38BDF8",
       tension: 0.2,
@@ -119,17 +119,17 @@ export const gasChartData = (blocks: ExtendedBlock[]): ChartData<"line"> => ({
   datasets: [
     {
       label: "Gas used",
-      data: blocks.map((b) => b.gasUsed.toNumber()).reverse(),
+      data: blocks.map((b) => Number(b.gasUsed)).reverse(),
       fill: true,
       segment: {
         backgroundColor: (ctx, x) =>
           ctx.p1.parsed.y >
-          Math.round(blocks[ctx.p1DataIndex].gasLimit.toNumber() / 2)
+          Math.round(Number(blocks[ctx.p1DataIndex].gasLimit) / 2)
             ? "#22C55E70"
             : "#EF444470",
         borderColor: (ctx) =>
           ctx.p1.parsed.y >
-          Math.round(blocks[ctx.p1DataIndex].gasLimit.toNumber() / 2)
+          Math.round(Number(blocks[ctx.p1DataIndex].gasLimit) / 2)
             ? "#22C55E"
             : "#EF4444",
       },
@@ -137,7 +137,7 @@ export const gasChartData = (blocks: ExtendedBlock[]): ChartData<"line"> => ({
     },
     {
       label: "Gas target",
-      data: blocks.map((b) => Math.round(b.gasLimit.toNumber() / 2)).reverse(),
+      data: blocks.map((b) => Math.round(Number(b.gasLimit) / 2)).reverse(),
       borderColor: "#FCA5A5",
       borderDash: [5, 5],
       borderWidth: 2,
@@ -146,7 +146,7 @@ export const gasChartData = (blocks: ExtendedBlock[]): ChartData<"line"> => ({
     },
     {
       label: "Gas limit",
-      data: blocks.map((b) => b.gasLimit.toNumber()).reverse(),
+      data: blocks.map((b) => Number(b.gasLimit)).reverse(),
       borderColor: "#B91C1CF0",
       tension: 0.2,
       pointStyle: "crossRot",
@@ -154,7 +154,7 @@ export const gasChartData = (blocks: ExtendedBlock[]): ChartData<"line"> => ({
     },
     {
       label: "Base fee (wei)",
-      data: blocks.map((b) => b.baseFeePerGas!.toNumber()).reverse(),
+      data: blocks.map((b) => Number(b.baseFeePerGas!)).reverse(),
       yAxisID: "yBaseFee",
       borderColor: "#38BDF8",
       tension: 0.2,

--- a/src/special/london/chart.ts
+++ b/src/special/london/chart.ts
@@ -53,7 +53,7 @@ export const burntFeesChartData = (
     {
       label: "Burnt fees (Gwei)",
       data: blocks
-        .map((b) => Number(b.gasUsed * b.baseFeePerGas! / (10n ** 9n)))
+        .map((b) => Number((b.gasUsed * b.baseFeePerGas!) / 10n ** 9n))
         .reverse(),
       fill: true,
       backgroundColor: "#FDBA7470",

--- a/src/token/ContractItem.tsx
+++ b/src/token/ContractItem.tsx
@@ -6,7 +6,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ContractItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
 };

--- a/src/token/ERC1155Item.tsx
+++ b/src/token/ERC1155Item.tsx
@@ -7,7 +7,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ERC1155ItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
   name: string;

--- a/src/token/ERC1167Item.tsx
+++ b/src/token/ERC1167Item.tsx
@@ -7,7 +7,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ERC1167ItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
   implementation: ChecksummedAddress;

--- a/src/token/ERC20Item.tsx
+++ b/src/token/ERC20Item.tsx
@@ -7,7 +7,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ERC20ItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
   name: string;

--- a/src/token/ERC4626Item.tsx
+++ b/src/token/ERC4626Item.tsx
@@ -7,7 +7,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ERC4626ItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
   name: string;

--- a/src/token/ERC721Item.tsx
+++ b/src/token/ERC721Item.tsx
@@ -7,7 +7,7 @@ import { ChecksummedAddress } from "../types";
 import { ResultMapper } from "../ots2/useUIHooks";
 
 type ERC721ItemProps = {
-  blockNumber: number;
+  blockNumber: bigint;
   timestamp: number;
   address: ChecksummedAddress;
   name: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
-import { BigNumber } from "@ethersproject/bignumber";
-import { Log } from "@ethersproject/providers";
+import { Log } from "ethers";
 
 export enum ConnectionStatus {
   CONNECTING,
@@ -18,9 +17,9 @@ export type ProcessedTransaction = {
   from?: string;
   to: string | null;
   createdContractAddress?: string;
-  value: BigNumber;
-  fee: BigNumber;
-  gasPrice: BigNumber;
+  value: bigint;
+  fee: bigint;
+  gasPrice: bigint;
   data: string;
   status: number;
 };
@@ -35,13 +34,13 @@ export type TransactionData = {
   transactionHash: string;
   from: string;
   to?: string;
-  value: BigNumber;
+  value: bigint;
   type: number;
-  maxFeePerGas?: BigNumber | undefined;
-  maxPriorityFeePerGas?: BigNumber | undefined;
-  gasPrice: BigNumber;
-  gasLimit: BigNumber;
-  nonce: number;
+  maxFeePerGas?: bigint | undefined;
+  maxPriorityFeePerGas?: bigint | undefined;
+  gasPrice: bigint;
+  gasLimit: bigint;
+  nonce: bigint;
   data: string;
   confirmedData?: ConfirmedTransactionData | undefined;
 };
@@ -52,8 +51,8 @@ export type ConfirmedTransactionData = {
   transactionIndex: number;
   confirmations: number;
   createdContractAddress?: string;
-  fee: BigNumber;
-  gasUsed: BigNumber;
+  fee: bigint;
+  gasUsed: bigint;
   logs: Log[];
 };
 
@@ -84,14 +83,14 @@ export type InternalOperation = {
   type: OperationType;
   from: string;
   to: string;
-  value: BigNumber;
+  value: bigint;
 };
 
 export type TokenTransfer = {
   token: string;
   from: string;
   to: string;
-  value: BigNumber;
+  value: bigint;
 };
 
 export type TokenMeta = {

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,4 +1,4 @@
-import { BlockTag } from "@ethersproject/abstract-provider";
+import { BlockTag } from "ethers";
 import { ChecksummedAddress } from "./types";
 
 export const fourBytesURL = (
@@ -11,13 +11,13 @@ export const topic0URL = (assetsURLPrefix: string, topic0: string): string =>
 
 export const tokenLogoURL = (
   assetsURLPrefix: string,
-  chainId: number,
+  chainId: bigint,
   address: string
 ): string => `${assetsURLPrefix}/assets/${chainId}/${address}/logo.png`;
 
 export const chainInfoURL = (
   assetsURLPrefix: string,
-  chainId: number
+  chainId: bigint
 ): string => `${assetsURLPrefix}/chains/eip155-${chainId}.json`;
 
 export const epochURL = (epochNumber: number) => `/epoch/${epochNumber}`;
@@ -36,8 +36,8 @@ export const blockTxsURL = (blockNum: BlockTag) => `/block/${blockNum}/txs`;
 
 export const transactionURL = (txHash: string) => `/tx/${txHash}`;
 
-export const addressByNonceURL = (address: ChecksummedAddress, nonce: number) =>
+export const addressByNonceURL = (address: ChecksummedAddress, nonce: bigint) =>
   `/address/${address}?nonce=${nonce}`;
 
-export const openInRemixURL = (checksummedAddress: string, networkId: number) =>
+export const openInRemixURL = (checksummedAddress: string, networkId: bigint) =>
   `https://remix.ethereum.org/#activate=sourcify&call=sourcify//fetchAndSave//${checksummedAddress}//${networkId}`;

--- a/src/use4Bytes.ts
+++ b/src/use4Bytes.ts
@@ -1,9 +1,5 @@
 import { useContext, useMemo } from "react";
-import {
-  Fragment,
-  Interface,
-  TransactionDescription,
-} from "ethers";
+import { Fragment, Interface, TransactionDescription } from "ethers";
 import { BigNumberish } from "ethers";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";

--- a/src/use4Bytes.ts
+++ b/src/use4Bytes.ts
@@ -3,8 +3,8 @@ import {
   Fragment,
   Interface,
   TransactionDescription,
-} from "@ethersproject/abi";
-import { BigNumberish } from "@ethersproject/bignumber";
+} from "ethers";
+import { BigNumberish } from "ethers";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { RuntimeContext } from "./useRuntime";
@@ -135,7 +135,7 @@ export const useTransactionDescription = (
     }
 
     const sig = fourBytesEntry?.signature;
-    const functionFragment = Fragment.fromString(`function ${sig}`);
+    const functionFragment = Fragment.from(`function ${sig}`);
     const intf = new Interface([functionFragment]);
     try {
       return intf.parseTransaction({ data, value });

--- a/src/useChainInfo.ts
+++ b/src/useChainInfo.ts
@@ -9,7 +9,7 @@ export const ChainInfoContext = createContext<ChainInfo | undefined>(undefined);
 
 const chainInfoFetcher: (
   runtime: OtterscanRuntime | undefined
-) => Fetcher<ChainInfo, [string, number]> =
+) => Fetcher<ChainInfo, [string, bigint]> =
   (runtime) =>
   async ([assetsURLPrefix, chainId]) => {
     // Hardcoded chainInfo; DON'T fetch it
@@ -32,7 +32,7 @@ export const useChainInfoFromMetadataFile = (
 ): ChainInfo | undefined => {
   const hardcodedChainInfo = runtime?.config?.chainInfo !== undefined;
   const assetsURLPrefix = runtime?.config?.assetsURLPrefix;
-  const chainId = runtime?.provider?.network?.chainId;
+  const chainId = runtime?.provider?._network?.chainId;
 
   const { data, error } = useSWRImmutable(
     !hardcodedChainInfo &&

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -74,12 +74,8 @@ export const readBlock = async (
     size: formatter.number(_rawBlock.block.size),
     sha3Uncles: _rawBlock.block.sha3Uncles,
     stateRoot: _rawBlock.block.stateRoot,
-    totalDifficulty: formatter.bigInt(
-      _rawBlock.block.totalDifficulty
-    ),
-    transactionCount: formatter.number(
-      _rawBlock.block.transactionCount
-    ),
+    totalDifficulty: formatter.bigInt(_rawBlock.block.totalDifficulty),
+    transactionCount: formatter.number(_rawBlock.block.transactionCount),
     ..._block,
   };
   return extBlock;
@@ -99,9 +95,7 @@ const blockTransactionsFetcher: Fetcher<
     pageNumber,
     pageSize,
   ]);
-  const _block = formatter.blockParamsWithTransactions(
-    result.fullblock
-  );
+  const _block = formatter.blockParamsWithTransactions(result.fullblock);
   const _receipts = result.receipts;
 
   const rawTxs = _block.transactions
@@ -109,8 +103,9 @@ const blockTransactionsFetcher: Fetcher<
       const _rawReceipt = _receipts[i];
       // Empty logs on purpose because of ethers formatter requires it
       _rawReceipt.logs = [];
-      const _receipt: TransactionReceiptParams = formatter.transactionReceiptParams(_rawReceipt);
-      
+      const _receipt: TransactionReceiptParams =
+        formatter.transactionReceiptParams(_rawReceipt);
+
       if (t.hash === null) {
         throw new Error("blockTransactionsFetcher: unknown tx hash");
       }
@@ -128,8 +123,8 @@ const blockTransactionsFetcher: Fetcher<
         fee:
           t.type !== 2
             ? formatter.bigInt(_receipt.gasUsed) * t.gasPrice!
-            : formatter
-                .bigInt(_receipt.gasUsed) * (t.maxPriorityFeePerGas! + _block.baseFeePerGas!),
+            : formatter.bigInt(_receipt.gasUsed) *
+              (t.maxPriorityFeePerGas! + _block.baseFeePerGas!),
         gasPrice:
           t.type !== 2
             ? t.gasPrice!
@@ -365,9 +360,7 @@ export const useTraceTransaction = (
         results[i].from = formatter.address(results[i].from);
         results[i].to = formatter.address(results[i].to);
         results[i].value =
-          results[i].value === null
-            ? null
-            : formatter.bigInt(results[i].value);
+          results[i].value === null ? null : formatter.bigInt(results[i].value);
       }
 
       // Build trace tree
@@ -673,9 +666,11 @@ const tokenMetadataFetcher =
     if (provider === undefined) {
       return null;
     }
-    
+
     // TODO: workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const erc20Contract: Contract = ERC20_PROTOTYPE.connect(provider).attach(address) as Contract;
+    const erc20Contract: Contract = ERC20_PROTOTYPE.connect(provider).attach(
+      address
+    ) as Contract;
     try {
       const name = (await erc20Contract.name()) as string;
       if (!name.trim()) {

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -14,6 +14,7 @@ import {
   isHexString,
   ZeroAddress,
   Transaction,
+  toNumber,
 } from "ethers";
 import useSWR, { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
@@ -508,7 +509,7 @@ const getTransactionBySenderAndNonceFetcher =
 
     const result = (await provider.send("ots_getTransactionBySenderAndNonce", [
       sender,
-      nonce,
+      toNumber(nonce),
     ])) as string;
 
     // Empty or success

--- a/src/useLatestBlock.ts
+++ b/src/useLatestBlock.ts
@@ -1,13 +1,13 @@
 import { useState, useEffect } from "react";
-import { Block } from "@ethersproject/abstract-provider";
-import { JsonRpcProvider } from "@ethersproject/providers";
+import { Block, JsonRpcApiProvider } from "ethers";
+import { formatter } from "./utils/formatter";
 
 /**
  * Returns the latest block header AND hook an internal listener
  * that'll update and trigger a component render as a side effect
  * every time it is notified of a new block by the web3 provider.
  */
-export const useLatestBlockHeader = (provider?: JsonRpcProvider) => {
+export const useLatestBlockHeader = (provider?: JsonRpcApiProvider) => {
   const [latestBlock, setLatestBlock] = useState<Block>();
 
   useEffect(() => {
@@ -19,7 +19,7 @@ export const useLatestBlockHeader = (provider?: JsonRpcProvider) => {
       const _raw = await provider.send("erigon_getHeaderByNumber", [
         blockNumber,
       ]);
-      const _block = provider.formatter.block(_raw);
+      const _block = new Block(formatter.blockParams(_raw), provider);
       setLatestBlock(_block);
     };
 
@@ -48,7 +48,7 @@ export const useLatestBlockHeader = (provider?: JsonRpcProvider) => {
  *
  * This hook is cheaper than useLatestBlockHeader.
  */
-export const useLatestBlockNumber = (provider?: JsonRpcProvider) => {
+export const useLatestBlockNumber = (provider?: JsonRpcApiProvider) => {
   const [latestBlock, setLatestBlock] = useState<number>();
 
   useEffect(() => {

--- a/src/usePriceOracle.ts
+++ b/src/usePriceOracle.ts
@@ -52,7 +52,9 @@ const feedRegistryFetcher =
 
     // Let SWR handle error
     // TODO: using "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const feedRegistry = FEED_REGISTRY_MAINNET_PROTOTYPE.connect(provider) as Contract;
+    const feedRegistry = FEED_REGISTRY_MAINNET_PROTOTYPE.connect(
+      provider
+    ) as Contract;
     const priceData = await feedRegistry.latestRoundData(tokenAddress, USD, {
       blockTag,
     });
@@ -98,8 +100,9 @@ const ethUSDFetcher =
     }
 
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
-    const c =
-      ETH_USD_FEED_PROTOTYPE.connect(provider).attach("eth-usd.data.eth") as Contract;
+    const c = ETH_USD_FEED_PROTOTYPE.connect(provider).attach(
+      "eth-usd.data.eth"
+    ) as Contract;
     const priceData = await c.latestRoundData({ blockTag });
     return priceData;
   };
@@ -130,7 +133,7 @@ export const useFiatValue = (
     return undefined;
   }
 
-  return FixedNumber.fromValue(ethAmount * eth2USDValue / (10n ** 8n), 18);
+  return FixedNumber.fromValue((ethAmount * eth2USDValue) / 10n ** 8n, 18);
 };
 
 export const formatFiatValue = (

--- a/src/useProvider.ts
+++ b/src/useProvider.ts
@@ -37,7 +37,7 @@ export const useProvider = (
       const network = Network.from(experimentalFixedChainId);
       network.attachPlugin(new EnsPlugin(null, experimentalFixedChainId));
       setProvider(
-        new JsonRpcProvider(erigonURL, network, {staticNetwork: network})
+        new JsonRpcProvider(erigonURL, network, { staticNetwork: network })
       );
       return;
     }

--- a/src/useResolvedAddresses.ts
+++ b/src/useResolvedAddresses.ts
@@ -1,6 +1,5 @@
 import { useState, useEffect, useContext } from "react";
-import { BaseProvider } from "@ethersproject/providers";
-import { getAddress, isAddress } from "@ethersproject/address";
+import { JsonRpcApiProvider, EnsPlugin, getAddress, isAddress } from "ethers";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { getResolver } from "./api/address-resolver";
@@ -44,7 +43,7 @@ export const useAddressOrENS = (
     if (!provider) {
       return;
     }
-    if (provider.network.ensAddress) {
+    if ((provider._network.getPlugin("org.ethers.plugins.network.Ens") as EnsPlugin).address) {
       const resolveName = async () => {
         const resolvedAddress = await provider.resolveName(addressOrName);
         if (resolvedAddress !== null) {
@@ -69,7 +68,7 @@ export const useAddressOrENS = (
 };
 
 export const useResolvedAddress = (
-  provider: BaseProvider | undefined,
+  provider: JsonRpcApiProvider | undefined,
   address: ChecksummedAddress
 ): SelectedResolvedName<any> | undefined => {
   const fetcher: Fetcher<
@@ -79,7 +78,7 @@ export const useResolvedAddress = (
     if (!provider) {
       return undefined;
     }
-    const resolver = getResolver(provider.network.chainId);
+    const resolver = getResolver(provider._network.chainId);
     return resolver.resolveAddress(provider, key);
   };
 

--- a/src/useResolvedAddresses.ts
+++ b/src/useResolvedAddresses.ts
@@ -43,7 +43,13 @@ export const useAddressOrENS = (
     if (!provider) {
       return;
     }
-    if ((provider._network.getPlugin("org.ethers.plugins.network.Ens") as EnsPlugin).address) {
+    if (
+      (
+        provider._network.getPlugin(
+          "org.ethers.plugins.network.Ens"
+        ) as EnsPlugin
+      ).address
+    ) {
       const resolveName = async () => {
         const resolvedAddress = await provider.resolveName(addressOrName);
         if (resolvedAddress !== null) {

--- a/src/useRuntime.ts
+++ b/src/useRuntime.ts
@@ -1,8 +1,9 @@
 import { createContext, useMemo } from "react";
 import {
   JsonRpcProvider,
-  StaticJsonRpcProvider,
-} from "@ethersproject/providers";
+  JsonRpcApiProvider,
+  Network
+} from "ethers";
 import { OtterscanConfig, useConfig } from "./useConfig";
 import { useProvider } from "./useProvider";
 import { ConnectionStatus } from "./types";
@@ -26,7 +27,7 @@ export type OtterscanRuntime = {
    * ETH provider; may be undefined if not ready because of config fetching,
    * probing occurring, etc.
    */
-  provider?: JsonRpcProvider;
+  provider?: JsonRpcApiProvider;
 };
 
 export const useRuntime = (): OtterscanRuntime => {
@@ -57,12 +58,14 @@ export const useRuntime = (): OtterscanRuntime => {
 
     // Hardcoded config
     if (effectiveConfig.experimentalFixedChainId !== undefined) {
+      const network = Network.from(effectiveConfig.experimentalFixedChainId);
       return {
         config: effectiveConfig,
         connStatus: ConnectionStatus.CONNECTED,
-        provider: new StaticJsonRpcProvider(
+        provider: new JsonRpcProvider(
           effectiveConfig.erigonURL,
-          effectiveConfig.experimentalFixedChainId
+          network,
+          { staticNetwork: network }
         ),
       };
     }

--- a/src/useRuntime.ts
+++ b/src/useRuntime.ts
@@ -1,9 +1,5 @@
 import { createContext, useMemo } from "react";
-import {
-  JsonRpcProvider,
-  JsonRpcApiProvider,
-  Network
-} from "ethers";
+import { JsonRpcProvider, JsonRpcApiProvider, Network } from "ethers";
 import { OtterscanConfig, useConfig } from "./useConfig";
 import { useProvider } from "./useProvider";
 import { ConnectionStatus } from "./types";
@@ -62,11 +58,9 @@ export const useRuntime = (): OtterscanRuntime => {
       return {
         config: effectiveConfig,
         connStatus: ConnectionStatus.CONNECTED,
-        provider: new JsonRpcProvider(
-          effectiveConfig.erigonURL,
-          network,
-          { staticNetwork: network }
-        ),
+        provider: new JsonRpcProvider(effectiveConfig.erigonURL, network, {
+          staticNetwork: network,
+        }),
       };
     }
     return { config: effectiveConfig, connStatus, provider };

--- a/src/utils/NOTICE.txt
+++ b/src/utils/NOTICE.txt
@@ -1,0 +1,23 @@
+This repository uses code for the `commify` function and `Formatter` class that is derived from the ethers library, version 5, available under the following license:
+
+MIT License
+
+Copyright (c) 2019 Richard Moore
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,0 +1,387 @@
+import {
+  TransactionResponseParams,
+  TransactionReceiptParams,
+  LogParams,
+  BlockParams,
+  makeError,
+  Transaction,
+  isHexString,
+  AccessList,
+  accessListify,
+  ZeroAddress,
+  getAddress,
+  dataSlice,
+  getCreateAddress,
+  toQuantity,
+  dataLength,
+  zeroPadValue,
+  Signature,
+} from "ethers";
+
+export type FormatFunc<T> = (value: any) => T;
+
+type FormatObject<T> = {
+  [K in keyof T]: T[K] extends FormatFunc<infer U> ? U : never;
+};
+
+type BlockParamsWithTransactions = BlockParams & { transactions: ReadonlyArray<TransactionResponseParams> };
+
+class Formatter {
+  static formats = {
+    block: {
+      hash: Formatter.allowNull(Formatter.hash),
+      parentHash: Formatter.hash,
+      number: Formatter.number,
+
+      timestamp: Formatter.number,
+      nonce: Formatter.hex,
+      difficulty: Formatter.bigInt,
+
+      gasLimit: Formatter.bigInt,
+      gasUsed: Formatter.bigInt,
+
+      miner: Formatter.address,
+      extraData: Formatter.data,
+
+      transactions: Formatter.arrayOf(Formatter.hash),
+
+      baseFeePerGas: Formatter.allowNull(Formatter.bigInt),
+    },
+    receipt: {
+      to: Formatter.allowNull(Formatter.address, null),
+      from: Formatter.address,
+      contractAddress: Formatter.allowNull(Formatter.address, null),
+      transactionIndex: Formatter.number,
+
+      // should be allowNull(hash), but broken-EIP-658 support is handled in receipt
+      root: Formatter.allowNull(Formatter.hex),
+      gasPrice: Formatter.allowNull(Formatter.bigInt, null),
+      gasUsed: Formatter.bigInt,
+      logsBloom: Formatter.data,
+      blockHash: Formatter.hash,
+      transactionHash: Formatter.hash,
+      logs: Formatter.arrayOf(Formatter.logParams),
+      blockNumber: Formatter.number,
+      cumulativeGasUsed: Formatter.bigInt,
+      effectiveGasPrice: Formatter.allowNull(Formatter.bigInt),
+      status: Formatter.allowNull(Formatter.number, null),
+      type: Formatter.number,
+    },
+    receiptLog: {
+      transactionIndex: Formatter.number,
+      blockNumber: Formatter.number,
+      transactionHash: Formatter.hash,
+      address: Formatter.address,
+      topics: Formatter.arrayOf(Formatter.hash),
+      data: Formatter.data,
+      logIndex: Formatter.number,
+      blockHash: Formatter.hash,
+      removed: Formatter.boolean,
+    },
+    transaction: {
+      hash: Formatter.hash,
+
+      type: Formatter.number,
+      accessList: Formatter.allowNull(Formatter.accessList, null),
+
+      blockHash: Formatter.allowNull(Formatter.hash, null),
+      blockNumber: Formatter.allowNull(Formatter.number, null),
+      transactionIndex: Formatter.allowNull(Formatter.number, null),
+
+      confirmations: Formatter.allowNull(Formatter.number, null),
+
+      from: Formatter.address,
+
+      // gasPrice must be set
+      // maxPriorityFeePerGas + maxFeePerGas, not necessarily
+      gasPrice: Formatter.bigInt,
+      maxPriorityFeePerGas: Formatter.allowNull(Formatter.bigInt),
+      maxFeePerGas: Formatter.allowNull(Formatter.bigInt),
+
+      gasLimit: Formatter.bigInt,
+      to: Formatter.allowNull(Formatter.address, null),
+      value: Formatter.bigInt,
+      nonce: Formatter.number,
+      data: Formatter.data,
+
+      r: Formatter.allowNull(Formatter.uint256),
+      s: Formatter.allowNull(Formatter.uint256),
+      v: Formatter.allowNull(Formatter.number),
+
+      creates: Formatter.allowNull(Formatter.address, null),
+
+      raw: Formatter.allowNull(Formatter.data),
+    },
+  };
+
+  static address(value: any): string {
+    return getAddress(value);
+  }
+
+  // Requires a BigNumberish that is within the IEEE754 safe integer range; returns a number
+  // Strict! Used on input.
+  static number(number: any): number {
+    if (number === "0x") {
+      return 0;
+    }
+    return Number(BigInt(number));
+  }
+
+  static bigInt(value: any): bigint {
+    return BigInt(value);
+  }
+
+  static boolean(value: any): boolean {
+    if (typeof value === "boolean") {
+      return value;
+    }
+    if (typeof value === "string") {
+      value = value.toLowerCase();
+      if (value === "true") {
+        return true;
+      }
+      if (value === "false") {
+        return false;
+      }
+    }
+    throw new Error("invalid boolean - " + value);
+  }
+
+  // if value is null-ish, nullValue is returned
+  static allowNull<T>(
+    format: FormatFunc<T>,
+    nullValue?: any
+  ): FormatFunc<T | typeof nullValue> {
+    return function (value: any) {
+      if (value === null || value === undefined) {
+        return nullValue;
+      }
+      return format(value);
+    };
+  }
+
+  // Requires an Array satisfying check
+  static arrayOf<T>(format: FormatFunc<T>): FormatFunc<T[]> {
+    return function (array: any): T[] {
+      if (!Array.isArray(array)) {
+        throw new Error("not an array");
+      }
+
+      const result: T[] = [];
+
+      array.forEach(function (value) {
+        result.push(format(value));
+      });
+
+      return result;
+    };
+  }
+
+  static hex(value: any, strict?: boolean): string {
+    if (typeof value === "string") {
+      if (!strict && value.substring(0, 2) !== "0x") {
+        value = "0x" + value;
+      }
+      if (isHexString(value)) {
+        return value.toLowerCase();
+      }
+    }
+    throw makeError("invalid hash", "INVALID_ARGUMENT", {
+      argument: "value",
+      value,
+    });
+  }
+
+  static uint256(value: any): string {
+    if (!isHexString(value)) {
+      throw makeError("invalid uint256", "INVALID_ARGUMENT", {
+        argument: "value",
+        value,
+      });
+    }
+    return zeroPadValue(value, 32);
+  }
+
+  // Requires a hash, optionally requires 0x prefix; returns prefixed lowercase hash.
+  static hash(value: any, strict?: boolean): string {
+    const result = Formatter.hex(value, strict);
+    if (dataLength(result) !== 32) {
+      throw makeError("invalid hash", "INVALID_ARGUMENT", {
+        argument: "value",
+        value,
+      });
+    }
+    return result;
+  }
+
+  static data(value: any, strict?: boolean): string {
+    const result = Formatter.hex(value, strict);
+    if (result.length % 2 !== 0) {
+      throw makeError("invalid data; odd-length", "INVALID_ARGUMENT", {
+        argument: "value",
+        value,
+      });
+    }
+    return result;
+  }
+
+  static check<T extends Record<string, FormatFunc<any>>>(
+    format: T,
+    object: any
+  ): FormatObject<T> {
+    const result = {} as FormatObject<T>;
+    for (const key in format) {
+      try {
+        const value = format[key](object[key]);
+        if (value !== undefined) {
+          result[key] = value;
+        }
+      } catch (error: any) {
+        error.checkKey = key;
+        error.checkValue = object[key];
+        throw error;
+      }
+    }
+    return result;
+  }
+
+  static blockParams(blockObj: any): BlockParams {
+    return Formatter.check(Formatter.formats.block, blockObj);
+  }
+
+  static blockParamsWithTransactions(blockObj: any): BlockParamsWithTransactions {
+    let blockWithTxsFormat = {
+      ...Formatter.formats.block,
+      transactions: Formatter.arrayOf(Formatter.transactionResponse),
+    };
+    return Formatter.check(blockWithTxsFormat, blockObj);
+  }
+
+  static logParams(receiptLogObj: any): LogParams {
+    const nodeLog = Formatter.check(
+      Formatter.formats.receiptLog,
+      receiptLogObj
+    );
+    return {
+      index: nodeLog.logIndex,
+      ...nodeLog,
+    };
+  }
+
+  static transactionReceiptParams(receiptObj: any): TransactionReceiptParams {
+    const nodeReceipt = Formatter.check(Formatter.formats.receipt, receiptObj);
+    return {
+      hash: nodeReceipt.transactionHash,
+      index: nodeReceipt.transactionIndex,
+      ...nodeReceipt,
+    };
+  }
+
+  static accessList(obj: any): AccessList {
+    return accessListify(obj || []);
+  }
+
+  static transactionResponse(transaction: any): TransactionResponseParams {
+    // Rename gas to gasLimit
+    if (transaction.gas != null && transaction.gasLimit == null) {
+      transaction.gasLimit = transaction.gas;
+    }
+
+    // Some clients (TestRPC) do strange things like return 0x0 for the
+    // 0 address; correct this to be a real address
+    // TODO: Remove this?
+    if (transaction.to && BigInt(transaction.to) === 0n) {
+      transaction.to = "0x0000000000000000000000000000000000000000";
+    }
+
+    // Rename input to data
+    if (transaction.input != null && transaction.data == null) {
+      transaction.data = transaction.input;
+    }
+
+    // Removed in ethers v6
+    // If to and creates are empty, populate the creates from the transaction
+    /*if (transaction.to == null && transaction.creates == null) {
+            transaction.creates = this.contractAddress(transaction);
+        }*/
+
+    if (
+      (transaction.type === 1 || transaction.type === 2) &&
+      transaction.accessList == null
+    ) {
+      transaction.accessList = [];
+    }
+
+    type ParsedTransactionType = FormatObject<
+      typeof Formatter.formats.transaction
+    >;
+    type ParsedResponseType = ParsedTransactionType & {
+      index: number;
+      chainId: bigint;
+      signature: Signature;
+    };
+    const parsedTx: ParsedTransactionType = Formatter.check(
+      this.formats.transaction,
+      transaction
+    );
+
+    const index = parsedTx.transactionIndex;
+    let chainId: bigint;
+    if (transaction.chainId != null) {
+      chainId = transaction.chainId;
+
+      if (isHexString(chainId)) {
+        chainId = BigInt(chainId);
+      }
+    } else {
+      chainId = transaction.networkId;
+
+      // geth-etc returns chainId
+      /*
+            if (chainId == null && result.v == null) {
+                chainId = transaction.chainId;
+            }
+            */
+
+      if (isHexString(chainId)) {
+        chainId = BigInt(chainId);
+      }
+
+      // TODO: v shouldn't exist on this type, so double check that removing this doesn't break anything
+      /*
+            if (typeof(chainId) !== "bigint" && result.v != null) {
+                chainId = (result.v - 35) / 2;
+                if (chainId < 0) { chainId = 0; }
+                chainId = parseInt(chainId);
+            }
+            */
+
+      if (typeof chainId !== "bigint") {
+        chainId = 0n;
+      }
+    }
+
+    // 0x0000... should actually be null
+    // TODO: Remove?
+    /*if (result.blockHash && result.blockHash.replace(/0/g, "") === "x") {
+            result.blockHash = null;
+        }*/
+
+    const signature = Signature.from({
+      r: parsedTx.r,
+      s: parsedTx.s,
+      v: parsedTx.v,
+    });
+    const result: TransactionResponseParams = {
+      ...parsedTx,
+      index,
+      chainId,
+      signature,
+    };
+    return result;
+  }
+}
+
+const addressFormat: FormatFunc<string> = Formatter.address;
+
+export const formatter = Formatter;

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -16,6 +16,7 @@ import {
   dataLength,
   zeroPadValue,
   Signature,
+  toBeHex,
 } from "ethers";
 
 export type FormatFunc<T> = (value: any) => T;
@@ -208,7 +209,7 @@ class Formatter {
         value,
       });
     }
-    return zeroPadValue(value, 32);
+    return zeroPadValue(toBeHex(value), 32);
   }
 
   // Requires a hash, optionally requires 0x prefix; returns prefixed lowercase hash.

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -41,29 +41,6 @@ export const ageString = (durationInSecs: number) => {
   return desc;
 };
 
-/*
-  MIT License
-
-  Copyright (c) 2019 Richard Moore
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
 export function commify(value: string | number | bigint): string {
   const comps = String(value).split(".");
 


### PR DESCRIPTION
Closes #1184.

Needs to be done:
- [x] Add MIT attribution for the portions of the Formatter class from ethers v5

Testing still required:
- [x] ENS
- [x] Internal transactions
- [x] USD values
- [x] Trace
- [x] Beacon chain
- [x] Search
- [x] Navigation (block/address transactions)

Most of this ought to be testable via test cases in the future.