### PR TITLE
Add contract tabs for matched proxy contracts

### DIFF
--- a/src/ots2/usePrototypeTransferHooks.ts
+++ b/src/ots2/usePrototypeTransferHooks.ts
@@ -201,8 +201,11 @@ export type AddressAttributes = {
 
 export const useAddressAttributes = (
   provider: JsonRpcApiProvider | undefined,
-  address: ChecksummedAddress
+  address: ChecksummedAddress | undefined
 ): AddressAttributes | undefined => {
+  if (address === undefined) {
+    return undefined;
+  }
   const fetcher = providerFetcher(provider);
   const { data, error } = useSWR(
     ["ots2_getAddressAttributes", address],


### PR DESCRIPTION
Closes #1251, and also displays the source code of the proxy's implementation address in a new tab.

Things to consider:
* Having separate tabs for a proxy Contract and proxy Read Contract tab is great for when other proxy types are supported, since proxy contracts might be verified and add functions on top of the implementation contract's functions.
* On the other hand, it takes up space in the header
* Maybe we should be clear about which type of proxy is matched and give a link to the implementation contract somewhere, e.g. in the proxy's Contracts tab.