### PR TITLE
Replace 'network' key with 'name' in ChainInfo

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -57,12 +57,14 @@ Some components in the user interface can be customized in the config under the 
 ```json
 {
   "branding": {
-    "siteName": "Otterscan"
+    "siteName": "Otterscan",
+    "hideAnnouncements": false
   }
 }
 ```
 
 * `siteName`: Sets the name displayed on the home page, header, and page titles.
+* `hideAnnouncements`: If set to true, hides new feature announcements from the home page.
 
 ### Logo
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,7 +22,7 @@ VITE_CONFIG_JSON='
   "assetsURLPrefix": "http://localhost:5175",
   "experimentalFixedChainId": 11155111,
   "chainInfo": {
-    "network": "",
+    "name": "Sepolia Testnet",
     "faucets": [],
     "nativeCurrency": {
       "name": "Sepolia Ether",
@@ -67,3 +67,27 @@ Some components in the user interface can be customized in the config under the 
 ### Logo
 
 To replace the default Otterscan logo with your own, simply replace `src/otter.png` with a different PNG image. Rebuild Otterscan for the change to take effect.
+
+### Chain information
+
+By default, Otterscan recognizes several chains, including the Ethereum mainnet and several Ethereum test networks. For other chains, specify either (1) a `chainInfo` key in the Otterscan config, or (2) create a JSON file accessible at `{assetsURLPrefix}/chains/eip155-{chainId}.json`. In both cases, use the [ethereum-lists](https://github.com/ethereum-lists/chains) structure to describe the properties of the chain:
+
+* `name`: The full name of the network, such as "Ethereum Mainnet".
+* `faucets`: A list of faucet URLs which are accessible at the `/faucets` endpoint and navigable from address pages. The special string `${ADDRESS}` can be included in the URL and will be replaced with the address the user navigated from.
+* `nativeCurrency`: Describes the native currency of the chain; this is analagous to ETH on the Ethereum mainnet.
+  * `name`: Full name of the native currency, e.g. "Ether".
+  * `symbol`: Few-character symbol used in trading, e.g. "ETH".
+  * `decimals`: Number of decimals; usually 18.
+
+Example:
+```json
+{
+  "name": "Sepolia Testnet",
+  "faucets": [],
+  "nativeCurrency": {
+    "name": "Sepolia Ether",
+    "symbol": "sepETH",
+    "decimals": 18
+  }
+}
+```

--- a/src/Faucets.tsx
+++ b/src/Faucets.tsx
@@ -12,19 +12,16 @@ import StandardSubtitle from "./components/StandardSubtitle";
 import { useChainInfo } from "./useChainInfo";
 
 const Faucets: React.FC = () => {
-  const { network, faucets } = useChainInfo();
+  const { faucets } = useChainInfo();
   const loc = useLocation();
   const urls = useMemo(() => {
     const s = new URLSearchParams(loc.search);
     const address = s.get("address");
 
-    const _urls: string[] =
-      network === "testnet"
-        ? faucets.map((u) =>
-            // eslint-disable-next-line no-template-curly-in-string
-            address !== null ? u.replaceAll("${ADDRESS}", address) : u
-          )
-        : [];
+    const _urls: string[] = faucets.map((u) =>
+      // eslint-disable-next-line no-template-curly-in-string
+      address !== null ? u.replaceAll("${ADDRESS}", address) : u
+    );
 
     // Shuffle faucets to avoid UI bias
     for (let i = _urls.length - 1; i > 0; i--) {
@@ -33,7 +30,7 @@ const Faucets: React.FC = () => {
     }
 
     return _urls;
-  }, [network, faucets, loc]);
+  }, [faucets, loc]);
 
   return (
     <StandardFrame>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -68,14 +68,15 @@ const Home: FC = () => {
           Search
         </button>
       </form>
-      {config?.experimental && (
-        <NavLink
-          className="text-md font-bold text-green-600 hover:text-green-800"
-          to="contracts/all"
-        >
-          🧪 EXPERIMENTAL CONTRACT BROWSER 🧪
-        </NavLink>
-      )}
+      {!(config?.branding?.hideAnnouncements ?? false) &&
+        config?.experimental && (
+          <NavLink
+            className="text-md font-bold text-green-600 hover:text-green-800"
+            to="contracts/all"
+          >
+            🧪 EXPERIMENTAL CONTRACT BROWSER 🧪
+          </NavLink>
+        )}
       {latestBlock && (
         <NavLink
           className="mt-5 flex flex-col items-center space-y-1 text-sm text-gray-500 hover:text-link-blue"

--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -1,8 +1,10 @@
 import React, { useContext } from "react";
 import { RuntimeContext } from "./useRuntime";
+import { useChainInfo } from "./useChainInfo";
 
 const WarningHeader: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
+  const { name } = useChainInfo();
   const chainId = provider?._network.chainId;
   if (chainId === 1n) {
     return <></>;
@@ -21,7 +23,10 @@ const WarningHeader: React.FC = () => {
     chainMsg = "Sepolia Testnet";
   } else if (chainId === 17000n) {
     chainMsg = "Holesky Testnet";
+  } else if (name) {
+    chainMsg = name;
   }
+
   return (
     <div className="w-full bg-orange-400 px-2 py-1 text-center font-bold text-white">
       You are on {chainMsg}

--- a/src/execution/address/AddressSubtitle.tsx
+++ b/src/execution/address/AddressSubtitle.tsx
@@ -19,7 +19,7 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
   addressOrName,
 }) => {
   const { config } = useContext(RuntimeContext);
-  const { network, faucets } = useChainInfo();
+  const { faucets } = useChainInfo();
 
   return (
     <StandardSubtitle>
@@ -33,9 +33,7 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
         <span className="font-address text-base text-gray-500">{address}</span>
         <Copy value={address} rounded />
         {/* Only display faucets for testnets who actually have any */}
-        {network === "testnet" && faucets && faucets.length > 0 && (
-          <Faucet address={address} rounded />
-        )}
+        {faucets && faucets.length > 0 && <Faucet address={address} rounded />}
         {isENS && (
           <span className="rounded-lg bg-gray-200 px-2 py-1 text-xs text-gray-500">
             ENS: {addressOrName}

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -10,12 +10,9 @@ import { jsonFetcherWithErrorHandling } from "./fetcher";
  */
 export type ChainInfo = {
   /**
-   * It contains a string "testnet" for testnets.
-   *
-   * @todo Change this name; it comes from the field name on ethereum-lists,
-   * but it is confusing.
+   * Full name of the chain.
    */
-  network: string | undefined;
+  name: string;
 
   /**
    * If this is a testnet, list example faucets; used by a certain part of
@@ -45,7 +42,7 @@ export type ChainInfo = {
 };
 
 export const defaultChainInfo: ChainInfo = {
-  network: undefined,
+  name: "",
   faucets: [],
   nativeCurrency: {
     name: "Ether",

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -98,9 +98,13 @@ export type OtterscanConfig = {
    */
   branding?: {
     /**
-     * Site name shown in page titles, home, and header
+     * Site name shown in page titles, home, and header.
      */
-    siteName: string;
+    siteName?: string;
+    /**
+     * If set to true, hides new feature announcements on the home page.
+     */
+    hideAnnouncements?: boolean;
   };
 };
 


### PR DESCRIPTION
Removes the `network` key from ChainInfo, which doesn't seem to be used anymore by ethereum-lists. Adds `name` instead and applies it to the chain ID warning header if supplied.

Closes #1253 