### PR TITLE
Use text-sm source code font size

### DIFF
--- a/src/execution/address/Contract.tsx
+++ b/src/execution/address/Contract.tsx
@@ -7,7 +7,7 @@ type ContractProps = {
 
 const Contract: React.FC<ContractProps> = ({ content }) => (
   <SyntaxHighlighter
-    className="h-full w-full border font-code text-base"
+    className="h-full w-full border font-code text-sm"
     language="solidity"
     style={docco}
     showLineNumbers

--- a/src/execution/address/ContractFromRepo.tsx
+++ b/src/execution/address/ContractFromRepo.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { SyntaxHighlighter, docco } from "../../highlight-init";
-import { MatchType, useContract } from "../../sourcify/useSourcify";
-import { useAppConfigContext } from "../../useAppConfig";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
+import { MatchType, useContract } from "../../sourcify/useSourcify";
+import { useAppConfigContext } from "../../useAppConfig";
+import Contract from "./Contract";
 
 type ContractFromRepoProps = {
   checksummedAddress: string;
@@ -40,16 +40,7 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
           </span>
         </div>
       )}
-      {content !== undefined && (
-        <SyntaxHighlighter
-          className="h-full w-full border font-code text-base"
-          language="solidity"
-          style={docco}
-          showLineNumbers
-        >
-          {content ?? ""}
-        </SyntaxHighlighter>
-      )}
+      {content !== undefined && <Contract content={content} />}
     </>
   );
 };


### PR DESCRIPTION
Reduces the size of source code from `text-base` to `text-sm`. The source code now is closer in font size to a default terminal application. It's still a little larger, but `text-sm` seems to look better than `text-xs`.

Closes #1106