### PR TITLE
Update run-nginx.sh - exec in front

### DIFF
--- a/run-nginx.sh
+++ b/run-nginx.sh
@@ -15,4 +15,4 @@ PARAMS=$(jq -n \
 
 # Overwrite base image config.json with our own and let nginx do the rest
 echo $PARAMS > /usr/share/nginx/html/config.json
-nginx -g "daemon off;"
+exec nginx -g "daemon off;"


### PR DESCRIPTION
hope this will help with handling graceful termination from docker!  currently takes ~8s to shutdown on my `docker-compose down`, while other images shutdown instantly

<img width="789" alt="image" src="https://github.com/otterscan/otterscan/assets/142251406/e3fe025e-645c-4a68-a26e-8bdb83850d0c">
