### PR TITLE
Split tuple inputs in read contract interface

### DIFF
--- a/src/execution/address/contract/FunctionParamsInput.stories.tsx
+++ b/src/execution/address/contract/FunctionParamsInput.stories.tsx
@@ -1,0 +1,56 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Interface } from "ethers";
+import FunctionParamsInput from "./FunctionParamsInput";
+
+const meta = {
+  component: FunctionParamsInput,
+} satisfies Meta<typeof FunctionParamsInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const makeArgs = (fragment: string) => {
+  const intf = new Interface([fragment]);
+  return {
+    params: intf.fragments[0].inputs,
+    inputCallback: (values: string[]) => {},
+  };
+};
+
+export const Constructor: Story = {
+  args: {
+    ...makeArgs("constructor(uint _data) public"),
+  },
+};
+
+export const AddressUint: Story = {
+  args: {
+    ...makeArgs(
+      "function transfer(address _to, uint256 _value) public returns (bool success)",
+    ),
+  },
+};
+
+export const UintArray: Story = {
+  args: {
+    ...makeArgs(
+      "function processValues(uint256[] values) public returns (bool success)",
+    ),
+  },
+};
+
+export const TupleType: Story = {
+  args: {
+    ...makeArgs(
+      "function getRewardInfo(tuple(address rewardToken, address pool, uint256 startTime, uint256 endTime, address refundee) key, uint256 tokenId) view returns (uint256 reward, uint160 secondsInsideX128)",
+    ),
+  },
+};
+
+export const TupleArray: Story = {
+  args: {
+    ...makeArgs(
+      "function sendFunds(tuple(address destination, uint256 value, uint256 expiry, bytes32 sig)[] sends) public",
+    ),
+  },
+};

--- a/src/execution/address/contract/FunctionParamsInput.tsx
+++ b/src/execution/address/contract/FunctionParamsInput.tsx
@@ -1,0 +1,62 @@
+import { type ParamType } from "ethers";
+import { FC, memo, useState } from "react";
+import ParamDeclaration from "../../components/ParamDeclaration";
+import { prepareArgument } from "./ReadFunction";
+
+interface FunctionParamsInputProps {
+  params: readonly ParamType[];
+  inputCallback: (values: string[]) => void;
+}
+
+const FunctionParamsInput: FC<FunctionParamsInputProps> = ({
+  params,
+  inputCallback,
+}) => {
+  let [inputs, setInputs] = useState<string[]>(
+    new Array(params.length).fill(""),
+  );
+
+  function updateInput(index: number, value: string) {
+    let newInputs = [...inputs];
+    newInputs[index] = value;
+    setInputs(newInputs);
+    inputCallback(newInputs);
+  }
+
+  return (
+    <ul className="list-inside">
+      {params.map((param: ParamType, index: number) => (
+        <li className="pl-2" key={index}>
+          <span className="text-sm font-medium text-gray-600">
+            <ParamDeclaration input={param} index={index} />
+          </span>
+          {param.baseType === "tuple" ? (
+            <ul className="ml-2 list-inside">
+              <FunctionParamsInput
+                params={param.components!}
+                inputCallback={(values: string[]) => {
+                  const preparedValues = values.map(
+                    (value: string, valueIndex: number) =>
+                      prepareArgument(value, param.components![valueIndex]),
+                  );
+                  updateInput(index, "[" + preparedValues.join(",") + "]");
+                }}
+              />
+            </ul>
+          ) : (
+            <input
+              type="text"
+              className="mt-1 w-full rounded border px-2 py-1 text-sm text-gray-600"
+              placeholder={param.format("full")}
+              onChange={(event) => {
+                updateInput(index, event.target.value);
+              }}
+            />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default memo(FunctionParamsInput);

--- a/src/execution/components/ParamDeclaration.stories.tsx
+++ b/src/execution/components/ParamDeclaration.stories.tsx
@@ -29,3 +29,12 @@ export const UnnamedParam: Story = {
     input: ParamType.from("address"),
   },
 };
+
+export const OrderTuple: Story = {
+  args: {
+    ...Address.args,
+    input: ParamType.from(
+      "tuple(uint256 info, address makerAsset, address takerAsset, address maker, address allowedSender, uint256 makingAmount, uint256 takingAmount) order",
+    ),
+  },
+};

--- a/src/execution/components/ParamDeclaration.tsx
+++ b/src/execution/components/ParamDeclaration.tsx
@@ -7,17 +7,20 @@ type ParamDeclarationProps = {
 };
 
 const ParamDeclaration: FC<ParamDeclarationProps> = ({ input, index }) => {
-  if (input.isArray() || input.isTuple()) {
+  let paramTypeName = input.type;
+  if (input.isArray()) {
     return (
       <span className="text-sm font-medium text-gray-600">
         {input.format("full")}
       </span>
     );
+  } else if (input.isTuple()) {
+    paramTypeName = "tuple(...)";
   }
 
   return (
     <span className="font-code text-sm font-medium text-blue-700">
-      <span className="text-red-700">{input.type}</span>{" "}
+      <span className="text-red-700">{paramTypeName}</span>{" "}
       {input.name !== "" ? (
         input.name
       ) : (


### PR DESCRIPTION
Creates a new component that handles a list of parameters. This design makes recursive tuple input possible. Partially addresses #1192 since only base types of "tuple" are supported - arrays will require an interface for adding and removing elements.