### PR TITLE
Fix '/' character keyboard shortcut handling

### DIFF
--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -321,9 +321,15 @@ export const useGenericSearch = (): [
   };
 
   const searchRef = useRef<HTMLInputElement>(null);
-  useKeyboardShortcut(["/"], () => {
-    searchRef.current?.focus();
-  });
+  useKeyboardShortcut(
+    ["/"],
+    () => {
+      searchRef.current?.focus();
+    },
+    {
+      overrideSystem: true,
+    }
+  );
 
   return [searchRef, handleChange, handleSubmit];
 };


### PR DESCRIPTION
Closes #1359 and #444

Note that the '/' character is still entered into the input field if the input field already has focus, as expected.