### PR TITLE
Improve readability of read contract page

### DIFF
--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -51,7 +51,7 @@ const ReadContract: React.FC<ContractsProps> = ({
               {viewFunctions.length === 0 &&
                 "This contract has no external view functions."}
               {viewFunctions.length > 0 && (
-                <ul className="list-inside list-decimal">
+                <ol className="marker:text-md list-inside list-decimal marker:text-gray-400">
                   {viewFunctions.map((fn, i) => (
                     <ReadFunction
                       func={FunctionFragment.from(fn)}
@@ -59,7 +59,7 @@ const ReadContract: React.FC<ContractsProps> = ({
                       key={i}
                     />
                   ))}
-                </ul>
+                </ol>
               )}
             </div>
           )}

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -165,7 +165,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
       <form onSubmit={onFormSubmit} className="mt-2 pl-4">
         {func.inputs && (
           <ul className="list-inside">
-            {func.inputs.map((input: any, index: number) => (
+            {func.inputs.map((input, index) => (
               <li className="pl-2" key={index}>
                 <span className="text-sm font-medium text-gray-600">
                   {input.format("full")}

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -164,7 +164,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
       <span className="text-md font-medium">{func.name}</span>
       <form onSubmit={onFormSubmit} className="mt-2 pl-4">
         {func.inputs && (
-          <ul className="list-inside">
+          <ol className="list-inside">
             {func.inputs.map((input, index) => (
               <li className="pl-2" key={index}>
                 <ParamDeclaration input={input} />
@@ -180,7 +180,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
                 />
               </li>
             ))}
-          </ul>
+          </ol>
         )}
         <button
           className="ml-2 mt-1 rounded border bg-skin-button-fill px-3 py-1 text-left text-sm text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -167,7 +167,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
           <ol className="list-inside">
             {func.inputs.map((input, index) => (
               <li className="pl-2" key={index}>
-                <ParamDeclaration input={input} />
+                <ParamDeclaration input={input} index={index} />
                 <input
                   type="text"
                   className="mt-1 w-full rounded border px-2 py-1 text-sm text-gray-600"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -1,5 +1,4 @@
 import { FC, memo, useContext, useState, FormEvent } from "react";
-import { SyntaxHighlighter, docco } from "../../../highlight-init";
 import {
   JsonRpcApiProvider,
   FunctionFragment,
@@ -8,6 +7,7 @@ import {
   type ParamType,
   resolveAddress,
 } from "ethers";
+import ParamDeclaration from "../../components/ParamDeclaration";
 import { RuntimeContext } from "../../../useRuntime";
 import { parse } from "./contractInputDataParser";
 import DecodedParamsTable from "../../transaction/decoder/DecodedParamsTable";
@@ -167,9 +167,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
           <ul className="list-inside">
             {func.inputs.map((input, index) => (
               <li className="pl-2" key={index}>
-                <span className="text-sm font-medium text-gray-600">
-                  {input.format("full")}
-                </span>
+                <ParamDeclaration input={input} />
                 <input
                   type="text"
                   className="mt-1 w-full rounded border px-2 py-1 text-sm text-gray-600"

--- a/src/execution/components/ParamDeclaration.stories.tsx
+++ b/src/execution/components/ParamDeclaration.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta, StoryObj } from "@storybook/react";
+import ParamDeclaration from "./ParamDeclaration";
+import { ParamType } from "ethers";
+
+const meta = {
+  component: ParamDeclaration,
+} satisfies Meta<typeof ParamDeclaration>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Address: Story = {
+  args: {
+    input: ParamType.from("address a"),
+  },
+};
+
+export const Bytes32: Story = {
+  args: {
+    input: ParamType.from("bytes32 data"),
+  },
+};

--- a/src/execution/components/ParamDeclaration.stories.tsx
+++ b/src/execution/components/ParamDeclaration.stories.tsx
@@ -12,11 +12,20 @@ type Story = StoryObj<typeof meta>;
 export const Address: Story = {
   args: {
     input: ParamType.from("address a"),
+    index: 0,
   },
 };
 
 export const Bytes32: Story = {
   args: {
+    ...Address.args,
     input: ParamType.from("bytes32 data"),
+  },
+};
+
+export const UnnamedParam: Story = {
+  args: {
+    ...Address.args,
+    input: ParamType.from("address"),
   },
 };

--- a/src/execution/components/ParamDeclaration.tsx
+++ b/src/execution/components/ParamDeclaration.tsx
@@ -1,0 +1,24 @@
+import { FC } from "react";
+import { ParamType } from "ethers";
+
+type ParamDeclarationProps = {
+  input: ParamType;
+};
+
+const ParamDeclaration: FC<ParamDeclarationProps> = ({ input }) => {
+  if (input.isArray() || input.isTuple()) {
+    return (
+      <span className="text-sm font-medium text-gray-600">
+        {input.format("full")}
+      </span>
+    );
+  }
+
+  return (
+    <span className="font-code text-sm font-medium text-blue-700">
+      <span className="text-red-700">{input.type}</span> {input.name}
+    </span>
+  );
+};
+
+export default ParamDeclaration;

--- a/src/execution/components/ParamDeclaration.tsx
+++ b/src/execution/components/ParamDeclaration.tsx
@@ -3,9 +3,10 @@ import { ParamType } from "ethers";
 
 type ParamDeclarationProps = {
   input: ParamType;
+  index: number;
 };
 
-const ParamDeclaration: FC<ParamDeclarationProps> = ({ input }) => {
+const ParamDeclaration: FC<ParamDeclarationProps> = ({ input, index }) => {
   if (input.isArray() || input.isTuple()) {
     return (
       <span className="text-sm font-medium text-gray-600">
@@ -16,7 +17,12 @@ const ParamDeclaration: FC<ParamDeclarationProps> = ({ input }) => {
 
   return (
     <span className="font-code text-sm font-medium text-blue-700">
-      <span className="text-red-700">{input.type}</span> {input.name}
+      <span className="text-red-700">{input.type}</span>{" "}
+      {input.name !== "" ? (
+        input.name
+      ) : (
+        <span className="italic text-blue-400">param_{index}</span>
+      )}
     </span>
   );
 };


### PR DESCRIPTION
I got annoyed while testing some stuff using the read contract page, I decided to play with some modifications myself :)

What I did:

- Tried to diversify colors and sizes, on big contracts the page looks like a big dump of black text, so we need something to guide the user.
- Changed the formatting of params: param type is red, param name is blue, I tried to mimic the colors of source highlighter.
- Applied the code font since it is a function parameter.
- For this to work, I changed the code to not use the format function anymore, instead broke down the components and formatted them myself.
- I intentionally didn't applied that formatting to tuples and arrays because we are going to implement a proper UI for them, and when that happens I don't think we'll display that giant function declaration.
- I applied a different color to the numbers in the ordered list of functions. Light gray because we want to say: this info is associated with the function, but don't pay much attention to it, the function name is what the user should look at.
- That way we make users' eyes scan the page for black text, which are the function names, then the colored parameters guide through what needs to be filled.

Sample image from mainnet:

<img width="658" alt="image" src="https://github.com/otterscan/otterscan/assets/28685/929e528e-a62c-4442-8f14-667b8b40a1f7">

@sealer3 plz review and if it's ok, plz merge so you can rebase/continue the other PR from these changes.