### PR TITLE
Remove the filler beacon API URL from default config

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,5 +1,4 @@
 {
   "erigonURL": "http://localhost:8545",
-  "beaconAPI": "http://localhost:5052",
   "assetsURLPrefix": "http://localhost:5175"
 }


### PR DESCRIPTION
Because the default `config.json` contains a filler beacon API URL, it makes it impossible to override it using VITE_* variables when you don't want the beacon API integration, because there is no way to override the variable with `undefined` (it's an invalid value in json, for example).

Also, since the beacon API is an optional feature for now, it makes sense that all default configs assume they are not present if nothing is informed.

I caught this issue because our public instances keep connecting to beacon API (and failing to reach the default URL) because I left this attribute in config.json.