### PR TITLE
Reduce horizontal margin on small screens

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -19,7 +19,7 @@ const Header: FC = () => {
   return (
     <>
       {isScanning && <CameraScanner turnOffScan={() => setScanning(false)} />}
-      <div className="flex flex-col sm:flex-row items-baseline space-y-1 sm:space-y-0 justify-between px-9 py-2">
+      <div className="flex flex-col sm:flex-row items-baseline space-y-1 sm:space-y-0 justify-between px-4 md:px-9 py-2">
         <div className="flex flex-row justify-between sm:self-center items-center w-full sm:w-auto shrink-0 mr-2">
           <Link className="self-center" to="/">
             <div className="flex items-center space-x-2 font-title text-2xl font-bold text-link-blue">

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -44,7 +44,11 @@ const Header: FC = () => {
           </div>
         </div>
         <div className="flex items-baseline space-x-3">
-          {provider?._network.chainId === 1n && <PriceBox />}
+          {provider?._network.chainId === 1n && (
+            <div className="hidden md:inline">
+              <PriceBox />
+            </div>
+          )}
           <form
             className="flex"
             onSubmit={handleSubmit}

--- a/src/components/StandardFrame.tsx
+++ b/src/components/StandardFrame.tsx
@@ -1,7 +1,7 @@
 import React, { PropsWithChildren } from "react";
 
 const StandardFrame: React.FC<PropsWithChildren> = ({ children }) => (
-  <div className="grow bg-gray-100 px-9 pb-12 pt-3">{children}</div>
+  <div className="grow bg-gray-100 px-4 md:px-9 pb-12 pt-3">{children}</div>
 );
 
 export default StandardFrame;


### PR DESCRIPTION
On medium width and smaller, cuts the horizontal margin by half.
On medium width and smaller, hides the price box.

There is still a layout break near the medium width cutoff due to the price box, but I'd rather not hide the price box at higher widths; at large width the price box and search are fully expanded.

We potentially could also change the price box so that it squishes at a slower rate than the search field.

Closes #1420.