### PR TITLE
Allow block links to break at any character

### DIFF
--- a/src/components/BlockLink.tsx
+++ b/src/components/BlockLink.tsx
@@ -19,7 +19,7 @@ const BlockLink: FC<BlockLinkProps> = ({ blockTag }) => {
 
   return (
     <NavLink
-      className={`flex-inline items-baseline space-x-1 text-link-blue hover:text-link-blue-hover ${
+      className={`flex-inline items-baseline space-x-1 break-all text-link-blue hover:text-link-blue-hover ${
         isNum ? "font-blocknum" : "font-hash"
       }`}
       to={blockURL(blockTag)}


### PR DESCRIPTION
Closes #1425 

Addresses suggestion (2) such that (1) is not needed. Essentially, line breaks are allowed anywhere, as in the other hashes. This means there won't be a line break between the block icon and hash text.