### PR TITLE
Resolve verified contract names in decorated addresses

### DIFF
--- a/src/execution/address/renderer/VerifiedContractName.stories.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/react";
+import VerifiedContractName from "./VerifiedContractName";
+
+const meta = {
+  component: VerifiedContractName,
+} satisfies Meta<typeof VerifiedContractName>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    chainId: 1n,
+    address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    linkable: false,
+    resolvedName: "WETH9",
+    dontOverrideColors: false,
+  },
+};
+
+export const Linkable: Story = {
+  args: {
+    ...Default.args,
+    linkable: true,
+  },
+};
+
+export const LongName: Story = {
+  args: {
+    ...Default.args,
+    resolvedName: "UniswapV2FeeOnTransferAdapterTransparentUpgradeableProxy",
+  },
+};

--- a/src/execution/address/renderer/VerifiedContractName.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.tsx
@@ -1,0 +1,60 @@
+import { FC } from "react";
+import { NavLink } from "react-router-dom";
+import { ResolvedAddressRenderer } from "../../../api/address-resolver/address-resolver";
+
+type VerifiedContractNameProps = {
+  chainId: bigint;
+  address: string;
+  linkable: boolean;
+  resolvedName: string;
+  dontOverrideColors?: boolean;
+};
+
+const VerifiedContractName: FC<VerifiedContractNameProps> = ({
+  chainId,
+  address,
+  linkable,
+  resolvedName,
+  dontOverrideColors,
+}) => {
+  const contents = <>{resolvedName}</>;
+  if (linkable) {
+    return (
+      <NavLink
+        className={`flex items-baseline space-x-1 font-sans ${
+          dontOverrideColors
+            ? ""
+            : "text-verified-purple hover:text-verified-purple-hover"
+        } truncate`}
+        to={`/address/${address}`}
+        title={`Verified Contract (${resolvedName}): ${address}`}
+      >
+        {contents}
+      </NavLink>
+    );
+  }
+
+  return (
+    <span className="truncate text-gray-400" title={name}>
+      {contents}
+    </span>
+  );
+};
+
+export const VerifiedContractRenderer: ResolvedAddressRenderer<string> = (
+  chainId,
+  address,
+  resolvedName,
+  linkable,
+  dontOverrideColors,
+) => (
+  <VerifiedContractName
+    chainId={chainId}
+    address={address}
+    linkable={linkable}
+    resolvedName={resolvedName}
+    dontOverrideColors={dontOverrideColors}
+  />
+);
+
+export default VerifiedContractName;

--- a/src/execution/address/renderer/VerifiedContractName.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.tsx
@@ -18,6 +18,7 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
   dontOverrideColors,
 }) => {
   const contents = <>{resolvedName}</>;
+  const title = `Verified Contract (${resolvedName}): ${address}`;
   if (linkable) {
     return (
       <NavLink
@@ -27,7 +28,7 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
             : "text-verified-contract hover:text-verified-contract-hover"
         } truncate`}
         to={`/address/${address}`}
-        title={`Verified Contract (${resolvedName}): ${address}`}
+        title={title}
       >
         {contents}
       </NavLink>
@@ -35,7 +36,7 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
   }
 
   return (
-    <span className="truncate text-gray-400" title={name}>
+    <span className="truncate text-gray-400" title={title}>
       {contents}
     </span>
   );

--- a/src/execution/address/renderer/VerifiedContractName.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.tsx
@@ -24,7 +24,7 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
         className={`flex items-baseline space-x-1 font-sans ${
           dontOverrideColors
             ? ""
-            : "text-verified-purple hover:text-verified-purple-hover"
+            : "text-verified-contract hover:text-verified-contract-hover"
         } truncate`}
         to={`/address/${address}`}
         title={`Verified Contract (${resolvedName}): ${address}`}

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -150,7 +150,6 @@ const ResolvedAddress: FC<ResolvedAddressProps> = ({
   ) {
     const compilationTarget = match.metadata.settings?.compilationTarget;
     if (Object.values(compilationTarget).length > 0) {
-      console.log(Object.values(compilationTarget)[0]);
       return VerifiedContractRenderer(
         provider._network.chainId,
         address,

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -16,6 +16,7 @@ import { AddressContext, ChecksummedAddress, ZERO_ADDRESS } from "../../types";
 import { useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
 import AddressAttributes from "../address/AddressAttributes";
+import { VerifiedContractRenderer } from "../address/renderer/VerifiedContractName";
 import { AddressAwareComponentProps } from "../types";
 import PlainAddress from "./PlainAddress";
 
@@ -139,6 +140,26 @@ const ResolvedAddress: FC<ResolvedAddressProps> = ({
   const { provider } = useContext(RuntimeContext);
   const resolvedAddress = useResolvedAddress(provider, address);
   const linkable = address !== selectedAddress;
+  const match = useSourcifyMetadata(address, provider?._network.chainId);
+
+  if (
+    provider &&
+    !resolvedAddress &&
+    match &&
+    match.metadata.settings?.compilationTarget
+  ) {
+    const compilationTarget = match.metadata.settings?.compilationTarget;
+    if (Object.values(compilationTarget).length > 0) {
+      console.log(Object.values(compilationTarget)[0]);
+      return VerifiedContractRenderer(
+        provider._network.chainId,
+        address,
+        Object.values(compilationTarget)[0],
+        linkable,
+        !!dontOverrideColors,
+      );
+    }
+  }
 
   if (!provider || !resolvedAddress) {
     return (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,8 @@ export default {
       colors: {
         "link-blue": "#3498db",
         "link-blue-hover": "#0468ab",
+        "verified-purple": "#5b00b9",
+        "verified-purple-hover": "#26007b",
       },
       fontFamily: {
         sans: ["Roboto"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,8 +15,8 @@ export default {
       colors: {
         "link-blue": "#3498db",
         "link-blue-hover": "#0468ab",
-        "verified-purple": "#5b00b9",
-        "verified-purple-hover": "#26007b",
+        "verified-contract": "#2b50aa",
+        "verified-contract-hover": "#26007b",
       },
       fontFamily: {
         sans: ["Roboto"],


### PR DESCRIPTION
Currently looks like this:
![image](https://github.com/otterscan/otterscan/assets/125761775/81527bd3-e66b-4ab9-8868-1f5a731485b1)

Closes #1424

Keep in mind that if Otterscan gets popular, this feature might be abused.