### PR TITLE
Show actual transfers in ERC20 Transfers tab

### DIFF
--- a/src/execution/address/AddressERC20Results.tsx
+++ b/src/execution/address/AddressERC20Results.tsx
@@ -6,6 +6,7 @@ import {
 } from "../../ots2/usePrototypeTransferHooks";
 import { usePageNumber } from "../../ots2/useUIHooks";
 import { PAGE_SIZE } from "../../params";
+import { findTokenTransfersInLogs } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
 import { usePageTitle } from "../../useTitle";
 import { AddressAwareComponentProps } from "../types";
@@ -53,6 +54,7 @@ const AddressERC20Results: FC<AddressAwareComponentProps> = ({ address }) => {
           to: m.receipt.to,
           value: m.transaction.value,
           type: m.transaction.type,
+          tokenTransfers: findTokenTransfersInLogs(m.receipt.logs),
         }),
       ),
     [results],

--- a/src/execution/address/AddressERC20Results.tsx
+++ b/src/execution/address/AddressERC20Results.tsx
@@ -1,4 +1,5 @@
 import { FC, useContext, useMemo } from "react";
+import StandardTHead from "../../components/StandardTHead";
 import {
   useGenericTransactionCount,
   useGenericTransactionList,
@@ -10,6 +11,19 @@ import { usePageTitle } from "../../useTitle";
 import { AddressAwareComponentProps } from "../types";
 import ERC20Item, { ERC20ItemProps } from "./ERC20Item";
 import GenericTransactionSearchResult from "./GenericTransactionSearchResult";
+
+const tableHeader = (
+  <StandardTHead>
+    <th className="w-56">Txn Hash</th>
+    <th className="w-28">Method</th>
+    <th className="w-28">Block</th>
+    <th className="w-28">Age</th>
+    <th>From</th>
+    <th>To</th>
+    <th className="w-48">Token</th>
+    <th>Value</th>
+  </StandardTHead>
+);
 
 const AddressERC20Results: FC<AddressAwareComponentProps> = ({ address }) => {
   const { provider } = useContext(RuntimeContext);
@@ -52,6 +66,8 @@ const AddressERC20Results: FC<AddressAwareComponentProps> = ({ address }) => {
       total={total}
       items={items}
       Item={(i) => <ERC20Item {...i} />}
+      header={tableHeader}
+      columns={8}
     />
   );
 };

--- a/src/execution/address/AddressERC721Results.tsx
+++ b/src/execution/address/AddressERC721Results.tsx
@@ -39,6 +39,8 @@ const AddressERC721Results: FC<AddressAwareComponentProps> = ({ address }) => {
           to: m.receipt.to,
           value: m.transaction.value,
           type: m.transaction.type,
+          // TODO: Token transfers for ERC-721 tokens
+          tokenTransfers: [],
         }),
       ),
     [results],

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useContext } from "react";
+import { FC, memo } from "react";
 import BlockLink from "../../components/BlockLink";
 import MethodName from "../../components/MethodName";
 import NativeTokenAmount from "../../components/NativeTokenAmount";
@@ -7,7 +7,6 @@ import TransactionDirection from "../../components/TransactionDirection";
 import TransactionLink from "../../components/TransactionLink";
 import { TokenTransfer } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
-import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
 import { AddressAwareComponentProps } from "../types";
 import TokenAmount from "./TokenAmount";
@@ -38,7 +37,6 @@ const ERC20Item: FC<ERC20ItemProps> = ({
   type,
   tokenTransfers,
 }) => {
-  const { provider } = useContext(RuntimeContext);
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -1,13 +1,17 @@
-import { FC, memo } from "react";
+import { FC, memo, useContext } from "react";
 import BlockLink from "../../components/BlockLink";
 import MethodName from "../../components/MethodName";
 import NativeTokenAmount from "../../components/NativeTokenAmount";
 import TimestampAge from "../../components/TimestampAge";
 import TransactionDirection from "../../components/TransactionDirection";
 import TransactionLink from "../../components/TransactionLink";
+import { TokenTransfer } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
+import { useTokenTransfers, useTxData } from "../../useErigonHooks";
+import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
 import { AddressAwareComponentProps } from "../types";
+import TokenAmount from "./TokenAmount";
 
 export type ERC20ItemProps = AddressAwareComponentProps & {
   blockNumber: number;
@@ -33,6 +37,9 @@ const ERC20Item: FC<ERC20ItemProps> = ({
   value,
   type,
 }) => {
+  const { provider } = useContext(RuntimeContext);
+  const txData = useTxData(provider, hash);
+  const tokenTransfers = useTokenTransfers(txData);
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>
@@ -75,10 +82,46 @@ const ERC20Item: FC<ERC20ItemProps> = ({
             />
           )}
         </td>
+        <td></td>
         <td>
           <NativeTokenAmount value={value} />
         </td>
       </tr>
+      {tokenTransfers &&
+        tokenTransfers.map((transfer: TokenTransfer, index: number) =>
+          transfer.from === address || transfer.to === address ? (
+            <tr key={index}>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td></td>
+              <td>
+                <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
+                  <span className="truncate">
+                    <TransactionAddress
+                      address={transfer.from}
+                      selectedAddress={address}
+                    />
+                  </span>
+                  <span>
+                    <TransactionDirection />
+                  </span>
+                </span>
+              </td>
+              <td>
+                <TransactionAddress
+                  address={transfer.to}
+                  selectedAddress={address}
+                  showCodeIndicator
+                />
+              </td>
+              <TokenAmount
+                tokenAddress={transfer.token}
+                amount={transfer.value}
+              />
+            </tr>
+          ) : null,
+        )}
     </BlockNumberContext.Provider>
   );
 };

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -7,7 +7,6 @@ import TransactionDirection from "../../components/TransactionDirection";
 import TransactionLink from "../../components/TransactionLink";
 import { TokenTransfer } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
-import { useTokenTransfers, useTxData } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
 import { AddressAwareComponentProps } from "../types";
@@ -23,6 +22,7 @@ export type ERC20ItemProps = AddressAwareComponentProps & {
   to: string | null;
   value: bigint;
   type: number;
+  tokenTransfers: TokenTransfer[];
 };
 
 const ERC20Item: FC<ERC20ItemProps> = ({
@@ -36,10 +36,9 @@ const ERC20Item: FC<ERC20ItemProps> = ({
   to,
   value,
   type,
+  tokenTransfers,
 }) => {
   const { provider } = useContext(RuntimeContext);
-  const txData = useTxData(provider, hash);
-  const tokenTransfers = useTokenTransfers(txData);
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>

--- a/src/execution/address/TokenAmount.tsx
+++ b/src/execution/address/TokenAmount.tsx
@@ -1,0 +1,60 @@
+import { FC, useContext } from "react";
+import { getPriceOraclePreset } from "../../components/FiatValue";
+import USDAmount from "../../components/USDAmount";
+import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
+import { ChecksummedAddress } from "../../types";
+import { useTokenMetadata } from "../../useErigonHooks";
+import { useTokenUSDOracle } from "../../usePriceOracle";
+import { RuntimeContext } from "../../useRuntime";
+import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
+
+type TokenAmountProps = {
+  tokenAddress: ChecksummedAddress;
+  amount?: bigint | null;
+};
+
+const TokenAmount: FC<TokenAmountProps> = ({ tokenAddress, amount }) => {
+  const { provider } = useContext(RuntimeContext);
+  const metadata = useTokenMetadata(provider, tokenAddress);
+  const {
+    price: quote,
+    decimals,
+    source: priceSource,
+  } = useTokenUSDOracle(
+    provider,
+    "latest",
+    tokenAddress,
+    metadata?.decimals !== undefined ? BigInt(metadata?.decimals) : undefined,
+  );
+
+  return (
+    <>
+      <td>
+        <TransactionAddressWithCopy address={tokenAddress} />
+      </td>
+      <td>
+        {amount !== null && amount !== undefined && (
+          <FormattedBalanceHighlighter
+            value={amount}
+            decimals={metadata?.decimals ?? 0}
+          />
+        )}
+        {amount !== null &&
+          amount !== undefined &&
+          metadata &&
+          quote !== undefined &&
+          decimals !== undefined && (
+            <USDAmount
+              amount={amount}
+              amountDecimals={metadata.decimals}
+              quote={quote}
+              quoteDecimals={Number(decimals) ?? 0}
+              colorScheme={getPriceOraclePreset(priceSource)}
+            />
+          )}
+      </td>
+    </>
+  );
+};
+
+export default TokenAmount;

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -1,13 +1,8 @@
 import { FC, useContext } from "react";
-import { getPriceOraclePreset } from "../../components/FiatValue";
-import USDAmount from "../../components/USDAmount";
 import { useTokenBalance } from "../../ots2/usePrototypeTransferHooks";
-import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
 import { ChecksummedAddress } from "../../types";
-import { useTokenMetadata } from "../../useErigonHooks";
-import { useTokenUSDOracle } from "../../usePriceOracle";
 import { RuntimeContext } from "../../useRuntime";
-import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
+import TokenAmount from "./TokenAmount";
 
 type TokenBalanceProps = {
   holderAddress: ChecksummedAddress;
@@ -20,44 +15,10 @@ const TokenBalance: FC<TokenBalanceProps> = ({
 }) => {
   const { provider } = useContext(RuntimeContext);
   const balance = useTokenBalance(provider, holderAddress, tokenAddress);
-  const metadata = useTokenMetadata(provider, tokenAddress);
-  const {
-    price: quote,
-    decimals,
-    source: priceSource,
-  } = useTokenUSDOracle(
-    provider,
-    "latest",
-    tokenAddress,
-    metadata?.decimals !== undefined ? BigInt(metadata?.decimals) : undefined,
-  );
 
   return (
     <tr>
-      <td>
-        <TransactionAddressWithCopy address={tokenAddress} />
-      </td>
-      <td>
-        {balance !== null && balance !== undefined && (
-          <FormattedBalanceHighlighter
-            value={balance}
-            decimals={metadata?.decimals ?? 0}
-          />
-        )}
-        {balance !== null &&
-          balance !== undefined &&
-          metadata &&
-          quote !== undefined &&
-          decimals !== undefined && (
-            <USDAmount
-              amount={balance}
-              amountDecimals={metadata.decimals}
-              quote={quote}
-              quoteDecimals={Number(decimals ?? 0)}
-              colorScheme={getPriceOraclePreset(priceSource)}
-            />
-          )}
-      </td>
+      <TokenAmount tokenAddress={tokenAddress} amount={balance} />
     </tr>
   );
 };

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -328,9 +328,12 @@ export const useTxData = (
 };
 
 export const useTokenTransfers = (
-  txData: TransactionData,
+  txData?: TransactionData | null,
 ): TokenTransfer[] | undefined => {
   const transfers = useMemo(() => {
+    if (txData === undefined || txData === null) {
+      return undefined;
+    }
     if (!txData.confirmedData) {
       return undefined;
     }


### PR DESCRIPTION
Closes #1405

We just fetch the token transfers with the `useTokenTransfers` hook that the transaction details page also uses.

Preview:
![image](https://github.com/otterscan/otterscan/assets/125761775/b136830d-8f0b-4452-ae13-ebffd0c89ba8)
