### PR TITLE
Prevent SectionHighlighter from truncating by default

### DIFF
--- a/src/components/AddressHighlighter.tsx
+++ b/src/components/AddressHighlighter.tsx
@@ -12,13 +12,15 @@ const AddressHighlighter: React.FC<AddressHighlighterProps> = ({
   address,
   children,
 }) => (
-  <SelectionHighlighter
-    myType="address"
-    myContent={address}
-    selector={addressSelector}
-  >
-    {children}
-  </SelectionHighlighter>
+  <div className="truncate">
+    <SelectionHighlighter
+      myType="address"
+      myContent={address}
+      selector={addressSelector}
+    >
+      {children}
+    </SelectionHighlighter>
+  </div>
 );
 
 export default AddressHighlighter;

--- a/src/execution/transaction/decoder/BytesDecoder.tsx
+++ b/src/execution/transaction/decoder/BytesDecoder.tsx
@@ -6,8 +6,9 @@ type BytesDecoderProps = {
 
 const BytesDecoder: FC<BytesDecoderProps> = ({ r }) => (
   <span className="font-code">
-    {r.toString()}{" "}
-    <span className="font-sans text-xs text-gray-400">
+    {r.toString()}
+    <span className="select-none"> </span>
+    <span className="font-sans text-xs text-gray-400 select-none">
       {r.toString().length / 2 - 1}{" "}
       {r.toString().length / 2 - 1 === 1 ? "byte" : "bytes"}
     </span>

--- a/src/selection/SelectionHighlighter.tsx
+++ b/src/selection/SelectionHighlighter.tsx
@@ -63,7 +63,7 @@ type HighlighterBoxProps = {
 const HighlighterBox: FC<PropsWithChildren<HighlighterBoxProps>> = memo(
   ({ selected, select, deselect, children }) => (
     <div
-      className={`truncate rounded border border-dashed px-1 hover:border-transparent hover:bg-transparent ${
+      className={`overflow-hidden rounded border border-dashed px-1 hover:border-transparent hover:bg-transparent ${
         selected ? "border-orange-400 bg-amber-100" : "border-transparent"
       }`}
       onMouseEnter={select}


### PR DESCRIPTION
Closes #1500 
Closes #722 

Now:
![image](https://github.com/otterscan/otterscan/assets/125761775/8a3aba98-4cbf-419e-b304-7a7688ee188e)

Also, with this PR the "44 bytes" text shown in this picture no longer can be selected, which makes it easier to copy the bytes values without the extra length label.