### PR TITLE
Enable static network discovery

### DIFF
--- a/src/useProvider.ts
+++ b/src/useProvider.ts
@@ -51,10 +51,14 @@ export const useProvider = (
     const tryToConnect = async () => {
       let provider: JsonRpcApiProvider;
       if (erigonURL?.startsWith("ws://") || erigonURL?.startsWith("wss://")) {
-        provider = new WebSocketProvider(erigonURL);
+        provider = new WebSocketProvider(erigonURL, undefined, {
+          staticNetwork: true,
+        });
       } else {
         // Batching takes place by default
-        provider = new JsonRpcProvider(erigonURL);
+        provider = new JsonRpcProvider(erigonURL, undefined, {
+          staticNetwork: true,
+        });
       }
 
       // Check if it is at least a regular ETH node


### PR DESCRIPTION
Ethers 6.9.0 allows you to discover the chain id just once and keep it as static: https://github.com/ethers-io/ethers.js/discussions/4199

that should save us some network calls because it is unlikely the node URL configured by the user will change. Worst case scenario the user can just refresh the page.

It is still better to set the chain id statically as we do in our hosted testnet instances because it allows us to simply skip the discovery, but this PR should improve for the default general case.