### PR TITLE
Display uint256 values with unselectable commas

### DIFF
--- a/src/components/DisplayInteger.stories.tsx
+++ b/src/components/DisplayInteger.stories.tsx
@@ -1,0 +1,34 @@
+import { Meta, StoryObj } from "@storybook/react";
+import DisplayInteger from "./DisplayInteger";
+
+const meta = {
+  component: DisplayInteger,
+} satisfies Meta<typeof DisplayInteger>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const One: Story = {
+  args: {
+    numberStr: "1",
+  },
+};
+
+export const MultipleCommas: Story = {
+  args: {
+    numberStr: "1234567",
+  },
+};
+
+export const NegativeNumber: Story = {
+  args: {
+    numberStr: "-123456789",
+  },
+};
+
+export const EighteenDecimalsWithShadow: Story = {
+  args: {
+    numberStr: "11000000000000000000",
+    decimalHint: true,
+  },
+};

--- a/src/components/DisplayInteger.stories.tsx
+++ b/src/components/DisplayInteger.stories.tsx
@@ -26,9 +26,8 @@ export const NegativeNumber: Story = {
   },
 };
 
-export const EighteenDecimalsWithShadow: Story = {
+export const EighteenDecimals: Story = {
   args: {
     numberStr: "11000000000000000000",
-    decimalHint: true,
   },
 };

--- a/src/components/DisplayInteger.tsx
+++ b/src/components/DisplayInteger.tsx
@@ -1,0 +1,42 @@
+import { FC } from "react";
+
+type DisplayIntegerProps = {
+  numberStr: string;
+  // If true, displays a shadow around the comma before 18 digits
+  decimalHint: boolean;
+};
+
+const DisplayInteger: FC<DisplayIntegerProps> = ({
+  numberStr,
+  decimalHint = false,
+}) => {
+  const parts = [];
+  const isNegative = numberStr[0] == "-";
+  let n = isNegative ? numberStr.slice(1) : numberStr;
+  let groupNum = 0;
+  for (var pos = n.length; pos > 0; pos -= 3) {
+    const firstGroup = pos - 3 <= 0;
+    const part = n.slice(firstGroup ? 0 : pos - 3, pos);
+    parts.unshift(
+      <span
+        key={pos}
+        className={`${
+          groupNum === 5 && decimalHint
+            ? "before:drop-shadow-[0_2px_2px_rgba(0,0,0,0.8)] "
+            : ""
+        }${firstGroup ? "" : "before:content-[',']"}`}
+      >
+        {part}
+      </span>,
+    );
+    groupNum += 1;
+  }
+  return (
+    <>
+      {isNegative ? "-" : ""}
+      {parts}
+    </>
+  );
+};
+
+export default DisplayInteger;

--- a/src/components/DisplayInteger.tsx
+++ b/src/components/DisplayInteger.tsx
@@ -2,14 +2,9 @@ import { FC } from "react";
 
 type DisplayIntegerProps = {
   numberStr: string;
-  // If true, displays a shadow around the comma before 18 digits
-  decimalHint?: boolean;
 };
 
-const DisplayInteger: FC<DisplayIntegerProps> = ({
-  numberStr,
-  decimalHint = false,
-}) => {
+const DisplayInteger: FC<DisplayIntegerProps> = ({ numberStr }) => {
   const parts = [];
   const isNegative = numberStr[0] == "-";
   let n = isNegative ? numberStr.slice(1) : numberStr;
@@ -18,14 +13,7 @@ const DisplayInteger: FC<DisplayIntegerProps> = ({
     const firstGroup = pos - 3 <= 0;
     const part = n.slice(firstGroup ? 0 : pos - 3, pos);
     parts.unshift(
-      <span
-        key={pos}
-        className={`${
-          groupNum === 5 && decimalHint
-            ? "before:drop-shadow-[0_2px_2px_rgba(0,0,0,0.8)] "
-            : ""
-        }${firstGroup ? "" : "before:content-[',']"}`}
-      >
+      <span key={pos} className={firstGroup ? "" : "before:content-[',']"}>
         {part}
       </span>,
     );

--- a/src/components/DisplayInteger.tsx
+++ b/src/components/DisplayInteger.tsx
@@ -3,7 +3,7 @@ import { FC } from "react";
 type DisplayIntegerProps = {
   numberStr: string;
   // If true, displays a shadow around the comma before 18 digits
-  decimalHint: boolean;
+  decimalHint?: boolean;
 };
 
 const DisplayInteger: FC<DisplayIntegerProps> = ({

--- a/src/execution/transaction/decoder/Uint256Decoder.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.tsx
@@ -2,6 +2,7 @@ import { faSync } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { formatEther, toBeHex, zeroPadValue } from "ethers";
 import { FC, memo, useState } from "react";
+import DisplayInteger from "../../../components/DisplayInteger";
 import { commify } from "../../../utils/utils";
 
 type Uint256DecoderProps = {
@@ -54,7 +55,7 @@ const Uint256Decoder: FC<Uint256DecoderProps> = ({ r }) => {
       </button>
       <span>
         {displayMode === DisplayMode.RAW ? (
-          <>{r.toString()}</>
+          <DisplayInteger numberStr={r.toString()} decimalHint={true} />
         ) : displayMode === DisplayMode.HEX ? (
           <>{zeroPadValue(toBeHex(r), 32)}</>
         ) : (

--- a/src/execution/transaction/decoder/Uint256Decoder.tsx
+++ b/src/execution/transaction/decoder/Uint256Decoder.tsx
@@ -55,7 +55,7 @@ const Uint256Decoder: FC<Uint256DecoderProps> = ({ r }) => {
       </button>
       <span>
         {displayMode === DisplayMode.RAW ? (
-          <DisplayInteger numberStr={r.toString()} decimalHint={true} />
+          <DisplayInteger numberStr={r.toString()} />
         ) : displayMode === DisplayMode.HEX ? (
           <>{zeroPadValue(toBeHex(r), 32)}</>
         ) : (


### PR DESCRIPTION
This adds a component called DisplayInteger that renders an integer with comma separators which are not selected when the rest of the number is clicked. The number still is considered a complete word by the browser, so double-clicking a DisplayInteger that renders as "123,456,789" will select the string "123456789". Users therefore won't have to remove commas manually or do any extra work to select numbers.

This component could potentially be used in other areas of Otterscan where it's nice to show commas but where users might want to select text without the commas, such as in showing the current block number or validator.

I also added an attribute that enables a hint to the comma that marks the 18th decimal place in the form of a drop shadow:
![image](https://github.com/otterscan/otterscan/assets/125761775/d9be98c5-5469-4bde-9862-3aaccd7af1da)

I'm not sure if the shadow is really necessary. The idea was to add a non-obtrusive hint so you don't have to click the button to convert it to the "18 dec" view. This helps when there are many uint256 numbers being shown, and you don't want to click to convert all of them.

Thoughts?