### PR TITLE
Add copy button to token addresses on Token Balances page

### DIFF
--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -1,5 +1,4 @@
 import { FC, useContext } from "react";
-import Copy from "../../components/Copy";
 import USDAmount from "../../components/USDAmount";
 import { useTokenBalance } from "../../ots2/usePrototypeTransferHooks";
 import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
@@ -7,7 +6,7 @@ import { ChecksummedAddress } from "../../types";
 import { useTokenMetadata } from "../../useErigonHooks";
 import { useTokenUSDOracle } from "../../usePriceOracle";
 import { RuntimeContext } from "../../useRuntime";
-import DecoratedAddressLink from "../components/DecoratedAddressLink";
+import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 
 type TokenBalanceProps = {
   holderAddress: ChecksummedAddress;
@@ -26,10 +25,7 @@ const TokenBalance: FC<TokenBalanceProps> = ({
   return (
     <tr>
       <td>
-        <div className="flex items-baseline space-x-2">
-          <DecoratedAddressLink address={tokenAddress} />
-          <Copy value={tokenAddress} />
-        </div>
+        <TransactionAddressWithCopy address={tokenAddress} />
       </td>
       <td>
         {balance !== null && balance !== undefined && (

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -26,7 +26,7 @@ const TokenBalance: FC<TokenBalanceProps> = ({
   return (
     <tr>
       <td>
-        <div className="-ml-1 flex items-baseline space-x-2">
+        <div className="flex items-baseline space-x-2">
           <DecoratedAddressLink address={tokenAddress} />
           <Copy value={tokenAddress} />
         </div>

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -1,4 +1,5 @@
 import { FC, useContext } from "react";
+import Copy from "../../components/Copy";
 import USDAmount from "../../components/USDAmount";
 import { useTokenBalance } from "../../ots2/usePrototypeTransferHooks";
 import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
@@ -25,7 +26,10 @@ const TokenBalance: FC<TokenBalanceProps> = ({
   return (
     <tr>
       <td>
-        <DecoratedAddressLink address={tokenAddress} />
+        <div className="-ml-1 flex items-baseline space-x-2">
+          <DecoratedAddressLink address={tokenAddress} />
+          <Copy value={tokenAddress} />
+        </div>
       </td>
       <td>
         {balance !== null && balance !== undefined && (


### PR DESCRIPTION
Closes #1474

Example:
![image](https://github.com/otterscan/otterscan/assets/125761775/77697485-ed03-4f1f-a111-a05e67e1193b)

I wonder if this would be useful in other places token addresses appear, somehow without overcrowding the UI.

The main reason I wanted this feature was to copy token addresses into Read Contract input fields.