### PR TITLE
Fix typo: show as '0 contracts'

### DIFF
--- a/src/search/messages.ts
+++ b/src/search/messages.ts
@@ -14,7 +14,9 @@ export const totalBlocksFormatter = (total: number) =>
   `A total of ${commify(total)} ${total === 1 ? "block" : "blocks"} found`;
 
 export const totalContractsFormatter = (total: number) =>
-  `A total of ${commify(total)} ${total > 1 ? "contracts" : "contract"} found`;
+  `A total of ${commify(total)} ${
+    total === 1 ? "contract" : "contracts"
+  } found`;
 
 export const getTotalFormatter = (
   typeName: string,


### PR DESCRIPTION
Minor typo, was showing as "0 contract found"