### PR TITLE
Add toggle for non-view functions in Read Contract

### DIFF
--- a/src/components/LabeledSwitch.stories.tsx
+++ b/src/components/LabeledSwitch.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from "@storybook/react";
+import LabeledSwitch from "./LabeledSwitch";
+
+const meta = {
+  component: LabeledSwitch,
+} satisfies Meta<typeof LabeledSwitch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Enabled: Story = {
+  args: {
+    defaultEnabled: true,
+    onToggle: (newValue: boolean) => {},
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    defaultEnabled: false,
+    onToggle: (newValue: boolean) => {},
+  },
+};

--- a/src/components/LabeledSwitch.tsx
+++ b/src/components/LabeledSwitch.tsx
@@ -1,0 +1,37 @@
+import { Switch } from "@headlessui/react";
+import React, { PropsWithChildren, useState } from "react";
+
+interface LabeledSwitchProps extends PropsWithChildren {
+  defaultEnabled?: boolean;
+  onToggle: (newValue: boolean) => void;
+}
+
+const LabeledSwitch: React.FC<LabeledSwitchProps> = ({
+  defaultEnabled = false,
+  onToggle,
+  children,
+}) => {
+  const [enabled, setEnabled] = useState<boolean>(defaultEnabled);
+  return (
+    <div className="pb-4 flex">
+      <Switch
+        checked={enabled}
+        onChange={(newValue: boolean) => {
+          setEnabled(newValue);
+          onToggle(newValue);
+        }}
+        className={`${
+          enabled ? "bg-link-blue/100" : "bg-gray-200"
+        } relative inline-flex h-6 w-11 items-center rounded-full mr-2 transition-colors`}
+      >
+        <span
+          className={`${
+            enabled ? "translate-x-6" : "translate-x-1"
+          } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+        />
+      </Switch>{" "}
+      {children}
+    </div>
+  );
+};
+export default LabeledSwitch;

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -1,6 +1,7 @@
 import { FunctionFragment } from "ethers";
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import ContentFrame from "../../../components/ContentFrame";
+import LabeledSwitch from "../../../components/LabeledSwitch";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
 import { Match } from "../../../sourcify/useSourcify";
 import { RuntimeContext } from "../../../useRuntime";
@@ -23,8 +24,13 @@ const ReadContract: React.FC<ContractsProps> = ({
   match,
 }) => {
   const { provider } = useContext(RuntimeContext);
+  const [showNonViewReturns, setShowNonViewReturns] = useState<boolean>(false);
+
   const viewFunctions = match?.metadata.output.abi.filter((fn) =>
     isReadFunction(fn),
+  );
+  const nonViewReturns = match?.metadata.output.abi.filter(
+    (fn) => fn.outputs && fn.outputs.length > 0 && !isReadFunction(fn),
   );
 
   return (
@@ -40,11 +46,13 @@ const ReadContract: React.FC<ContractsProps> = ({
               Sourcify repository.
             </span>
           )}
+
           {viewFunctions && (
             <div>
               {viewFunctions.length === 0 &&
                 "This contract has no external view functions."}
-              {viewFunctions.length > 0 && (
+              {(viewFunctions.length > 0 ||
+                (nonViewReturns && nonViewReturns.length > 0)) && (
                 <ol className="marker:text-md list-inside list-decimal marker:text-gray-400">
                   {viewFunctions.map((fn, i) => (
                     <ReadFunction
@@ -53,6 +61,28 @@ const ReadContract: React.FC<ContractsProps> = ({
                       key={i}
                     />
                   ))}
+                  {nonViewReturns && nonViewReturns.length > 0 && (
+                    <>
+                      <LabeledSwitch
+                        defaultEnabled={showNonViewReturns}
+                        onToggle={setShowNonViewReturns}
+                      >
+                        Show non-view functions with return values
+                      </LabeledSwitch>
+                      {showNonViewReturns && (
+                        <>
+                          <hr className="pb-4" />
+                          {nonViewReturns.map((fn, i) => (
+                            <ReadFunction
+                              func={FunctionFragment.from(fn)}
+                              address={checksummedAddress}
+                              key={i}
+                            />
+                          ))}
+                        </>
+                      )}
+                    </>
+                  )}
                 </ol>
               )}
             </div>


### PR DESCRIPTION
Closes #1579. Adds a toggle for non-view functions that have return values below the view functions:

Off (default):
![image](https://github.com/otterscan/otterscan/assets/125761775/146001cb-63ea-4aed-8e0e-07961fef2793)

On:
![image](https://github.com/otterscan/otterscan/assets/125761775/12394f85-138e-468a-98ec-0ba7f2a0a697)
