### PR TITLE
Break overflowing words in Read Contract error messages

### DIFF
--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -254,11 +254,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
             defaultNameBase="ret"
           />
         )}
-        {error && (
-          <p className="whitespace-break-spaces font-mono text-red-500">
-            {error}
-          </p>
-        )}
+        {error && <p className="break-words font-mono text-red-500">{error}</p>}
       </div>
     </li>
   );


### PR DESCRIPTION
Fixes #1664

Ex:
![image](https://github.com/otterscan/otterscan/assets/125761775/900d6bb7-c3e5-45da-8d49-24e119ebd910)
