### PR TITLE
Use 3 pending columns in Blocks Rewarded table

### DIFF
--- a/src/execution/address/BlocksRewarded.tsx
+++ b/src/execution/address/BlocksRewarded.tsx
@@ -59,7 +59,7 @@ const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
       Item={(i) => <BlockRewardedItem {...i} />}
       header={searchHeader}
       typeName="block"
-      columns={2}
+      columns={3}
     />
   );
 };


### PR DESCRIPTION
Adds another column so when the page content is loading, all columns in the table have pending bars below them.