### PR TITLE
Prevent contract creation tx hash from overflowing

### DIFF
--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -113,13 +113,15 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
           </InfoRow>
           {creator && (
             <InfoRow title="Contract creator">
-              <div className="flex divide-x-2 divide-dotted divide-gray-300">
+              <div className="flex flex-col md:flex-row divide-x-2 divide-dotted divide-gray-300">
                 <TransactionAddressWithCopy
                   address={creator.creator}
                   showCodeIndicator
                 />
-                <div className="ml-3 flex items-baseline pl-3">
-                  <TransactionLink txHash={creator.hash} />
+                <div className="md:ml-3 flex items-baseline pl-3 truncate">
+                  <div className="truncate">
+                    <TransactionLink txHash={creator.hash} />
+                  </div>
                 </div>
               </div>
             </InfoRow>


### PR DESCRIPTION
Closes #1671

Makes the transaction hash responsive and also truncates it instead of letting it overflow.

Truncating:
![image](https://github.com/otterscan/otterscan/assets/125761775/7b13da71-6a48-4dd5-8cec-f0ecdfd19ecf)

Medium width and smaller:
![image](https://github.com/otterscan/otterscan/assets/125761775/b707ee14-39b1-4338-93b2-00a545756792)