### PR TITLE
Show function signatures

### DIFF
--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -221,7 +221,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func }) => {
             func.inputs.map((param, index) => (
               <li className="mt-2" key={index}>
                 <div className="text-sm font-medium text-gray-600">
-                  <ParamDeclaration input={param} index={index} />
+                  <ParamDeclaration input={param} index={index} short={true} />
                 </div>
                 <FunctionParamInput
                   param={param}

--- a/src/execution/components/ParamDeclaration.tsx
+++ b/src/execution/components/ParamDeclaration.tsx
@@ -1,27 +1,57 @@
 import { ParamType } from "ethers";
-import { FC } from "react";
+import { FC, type ReactNode } from "react";
 
 type ParamDeclarationProps = {
   input: ParamType;
   index: number;
+  short?: boolean;
 };
 
-function getShortenedParamType(paramType: ParamType): string {
+function insertCommaEveryOther(components: ReactNode[]): ReactNode[] {
+  const result = [];
+  for (let i = 0; i < components.length; i++) {
+    if (i > 0) {
+      result.push(", ");
+    }
+    result.push(components[i]);
+  }
+  return result;
+}
+
+function getParamType(
+  paramType: ParamType,
+  short: boolean = false,
+): ReactNode[] {
   if (paramType.isArray()) {
     const end =
       paramType.arrayLength === -1 ? "[]" : "[" + paramType.arrayLength + "]";
-    return getShortenedParamType(paramType.arrayChildren!) + end;
+    return [...getParamType(paramType.arrayChildren!), end];
   } else if (paramType.isTuple()) {
-    return "tuple(...)";
+    if (short) {
+      return ["tuple(...)"];
+    }
+    return [
+      "(",
+      ...insertCommaEveryOther(
+        paramType.components!.map((component: ParamType, index: number) => (
+          <ParamDeclaration input={component} index={index} short={short} />
+        )),
+      ),
+      ")",
+    ];
   } else {
-    return paramType.type;
+    return [paramType.type];
   }
 }
 
-const ParamDeclaration: FC<ParamDeclarationProps> = ({ input, index }) => {
+const ParamDeclaration: FC<ParamDeclarationProps> = ({
+  input,
+  index,
+  short,
+}) => {
   return (
     <span className="font-code text-sm font-medium text-blue-700">
-      <span className="text-red-700">{getShortenedParamType(input)}</span>{" "}
+      <span className="text-red-700">{getParamType(input, short)}</span>{" "}
       {input.name !== "" ? (
         input.name
       ) : (

--- a/src/execution/transaction/decoder/FunctionSignature.tsx
+++ b/src/execution/transaction/decoder/FunctionSignature.tsx
@@ -3,7 +3,7 @@ import { faQuestionCircle as faQuestionCircleSolid } from "@fortawesome/free-sol
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Switch } from "@headlessui/react";
 import { FunctionFragment, ParamType } from "ethers";
-import { FC, useState } from "react";
+import { FC, Fragment, useState } from "react";
 import { DevMethod, UserMethod } from "../../../sourcify/useSourcify";
 import ParamDeclaration from "../../components/ParamDeclaration";
 
@@ -30,10 +30,10 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({
           <span className="font-bold">{fragment.name}</span>
           {"("}
           {fragment.inputs.map((param: ParamType, index: number) => (
-            <>
+            <Fragment key={index}>
               <ParamDeclaration input={param} index={index} />
               {index !== fragment.inputs.length - 1 && <>, </>}
-            </>
+            </Fragment>
           ))}
           {")"}
         </span>

--- a/src/execution/transaction/decoder/FunctionSignature.tsx
+++ b/src/execution/transaction/decoder/FunctionSignature.tsx
@@ -11,18 +11,20 @@ type FunctionSignatureProps = {
   userMethod?: UserMethod | undefined;
   devMethod?: DevMethod | undefined;
   fragment: FunctionFragment;
+  className?: string;
 };
 
 const FunctionSignature: FC<FunctionSignatureProps> = ({
   userMethod,
   devMethod,
   fragment,
+  className,
 }) => {
   const [showHelp, setShowHelp] = useState<boolean>(false);
   const hasHelp =
     (userMethod && userMethod.notice) || (devMethod && devMethod.details);
   return (
-    <div>
+    <div className={className}>
       <div>
         <span className="font-mono text-sm text-gray-800">
           <span className="font-bold">{fragment.name}</span>
@@ -48,26 +50,22 @@ const FunctionSignature: FC<FunctionSignatureProps> = ({
           </Switch>
         )}
       </div>
-      {hasHelp && (
-        <>
-          {showHelp && (
-            <div>
-              {userMethod && userMethod.notice && (
-                <div className="gap-x-2 pt-1 px-1 font-normal">
-                  {userMethod.notice}
-                </div>
-              )}
-              {devMethod && devMethod.details && (
-                <div className="gap-x-2 pt-1 px-1 font-normal">
-                  <span className="font-bold italic text-xs mr-2 select-none">
-                    dev{" "}
-                  </span>
-                  {devMethod.details}
-                </div>
-              )}
+      {hasHelp && showHelp && (
+        <blockquote className="font-semibold border-l-4 pl-1 mt-2 mb-3 py-1">
+          {userMethod && userMethod.notice && (
+            <div className="gap-x-2 mt-1 px-1 font-normal">
+              {userMethod.notice}
             </div>
           )}
-        </>
+          {devMethod && devMethod.details && (
+            <div className="gap-x-2 mt-1 px-1 font-normal">
+              <span className="font-bold italic text-xs mr-2 select-none">
+                dev{" "}
+              </span>
+              {devMethod.details}
+            </div>
+          )}
+        </blockquote>
       )}
     </div>
   );

--- a/src/execution/transaction/decoder/FunctionSignature.tsx
+++ b/src/execution/transaction/decoder/FunctionSignature.tsx
@@ -1,0 +1,76 @@
+import { faQuestionCircle } from "@fortawesome/free-regular-svg-icons";
+import { faQuestionCircle as faQuestionCircleSolid } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Switch } from "@headlessui/react";
+import { FunctionFragment, ParamType } from "ethers";
+import { FC, useState } from "react";
+import { DevMethod, UserMethod } from "../../../sourcify/useSourcify";
+import ParamDeclaration from "../../components/ParamDeclaration";
+
+type FunctionSignatureProps = {
+  userMethod?: UserMethod | undefined;
+  devMethod?: DevMethod | undefined;
+  fragment: FunctionFragment;
+};
+
+const FunctionSignature: FC<FunctionSignatureProps> = ({
+  userMethod,
+  devMethod,
+  fragment,
+}) => {
+  const [showHelp, setShowHelp] = useState<boolean>(false);
+  const hasHelp =
+    (userMethod && userMethod.notice) || (devMethod && devMethod.details);
+  return (
+    <div>
+      <div>
+        <span className="font-mono text-sm text-gray-800">
+          <span className="font-bold">{fragment.name}</span>
+          {"("}
+          {fragment.inputs.map((param: ParamType, index: number) => (
+            <>
+              <ParamDeclaration input={param} index={index} />
+              {index !== fragment.inputs.length - 1 && <>, </>}
+            </>
+          ))}
+          {")"}
+        </span>
+        {hasHelp && (
+          <Switch
+            checked={showHelp}
+            onChange={setShowHelp}
+            className="self-center text-gray-500 pr-2 ml-1"
+          >
+            <FontAwesomeIcon
+              icon={showHelp ? faQuestionCircleSolid : faQuestionCircle}
+              size="1x"
+            />
+          </Switch>
+        )}
+      </div>
+      {hasHelp && (
+        <>
+          {showHelp && (
+            <div>
+              {userMethod && userMethod.notice && (
+                <div className="gap-x-2 pt-1 px-1 font-normal">
+                  {userMethod.notice}
+                </div>
+              )}
+              {devMethod && devMethod.details && (
+                <div className="gap-x-2 pt-1 px-1 font-normal">
+                  <span className="font-bold italic text-xs mr-2 select-none">
+                    dev{" "}
+                  </span>
+                  {devMethod.details}
+                </div>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default FunctionSignature;

--- a/src/execution/transaction/decoder/InputDecoder.tsx
+++ b/src/execution/transaction/decoder/InputDecoder.tsx
@@ -54,6 +54,7 @@ const InputDecoder: React.FC<InputDecoderProps> = ({
                 fragment={resolvedTxDesc.fragment}
                 userMethod={userMethod}
                 devMethod={devMethod}
+                className="pt-1"
               />
               <DecodedParamsTable
                 args={resolvedTxDesc.args}

--- a/src/execution/transaction/decoder/InputDecoder.tsx
+++ b/src/execution/transaction/decoder/InputDecoder.tsx
@@ -5,6 +5,7 @@ import ModeTab from "../../../components/ModeTab";
 import StandardTextarea from "../../../components/StandardTextarea";
 import { DevMethod, UserMethod } from "../../../sourcify/useSourcify";
 import DecodedParamsTable from "./DecodedParamsTable";
+import FunctionSignature from "./FunctionSignature";
 
 type InputDecoderProps = {
   fourBytes: string;
@@ -48,13 +49,20 @@ const InputDecoder: React.FC<InputDecoderProps> = ({
           ) : resolvedTxDesc === null ? (
             <>Can't decode data</>
           ) : (
-            <DecodedParamsTable
-              args={resolvedTxDesc.args}
-              paramTypes={resolvedTxDesc.fragment.inputs}
-              hasParamNames={hasParamNames}
-              userMethod={userMethod}
-              devMethod={devMethod}
-            />
+            <div className="space-y-2">
+              <FunctionSignature
+                fragment={resolvedTxDesc.fragment}
+                userMethod={userMethod}
+                devMethod={devMethod}
+              />
+              <DecodedParamsTable
+                args={resolvedTxDesc.args}
+                paramTypes={resolvedTxDesc.fragment.inputs}
+                hasParamNames={hasParamNames}
+                userMethod={userMethod}
+                devMethod={devMethod}
+              />
+            </div>
           )}
         </Tab.Panel>
         <Tab.Panel>


### PR DESCRIPTION
This PR adds a FunctionSignature component that shows a colored function signature and modifies the ParamDeclaration component to support full signatures in addition to short ones with abbreviated tuples.

Here is how it looks. I've added the help button here so that it appears in traces but of course we can remove that part if desired.
![image](https://github.com/otterscan/otterscan/assets/125761775/cd50a1a8-928b-4e16-8fe3-e2879dbc822e)

Something that might improve the look is to switch from `font-code` to `font-mono` for the parameters. I kept it at `font-code` since that is what `ParamDeclaration` uses, but I think `font-mono` would look better:
![image](https://github.com/otterscan/otterscan/assets/125761775/9109c8a2-e071-466f-ba05-f49543415e86)

This probably varies per machine but at least for my default font it looks better :)

This is what it looks like (with font-mono) using 4bytes instead of a verified contract:
![image](https://github.com/otterscan/otterscan/assets/125761775/b0c05557-bf2d-495b-84f7-60f6680eda35)

My intention was to give the decoded function signature a style similar to the decoded log signature which is present in the Logs tab:
![image](https://github.com/otterscan/otterscan/assets/125761775/e2d7d0d4-43e5-4da1-b8fb-6f639318b135)

Closes #1674
Closes #700
Closes #721 
