### PR TITLE
Prevent address tab page titles from being overwritten

### DIFF
--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -20,7 +20,6 @@ import { ChecksummedAddress } from "../types";
 import { useHasCode } from "../useErigonHooks";
 import { useAddressOrENS } from "../useResolvedAddresses";
 import { RuntimeContext } from "../useRuntime";
-import { usePageTitle } from "../useTitle";
 import AddressERC20Results from "./address/AddressERC20Results";
 import AddressERC721Results from "./address/AddressERC721Results";
 import AddressSubtitle from "./address/AddressSubtitle";
@@ -64,14 +63,6 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
     provider?._network.chainId,
   );
   const proxyAttrs = useProxyAttributes(provider, checksummedAddress);
-
-  usePageTitle(
-    `Address ${
-      isENS || checksummedAddress === undefined
-        ? addressOrName
-        : checksummedAddress
-    }`,
-  );
 
   return (
     <StandardFrame>

--- a/src/execution/address/AddressTokens.tsx
+++ b/src/execution/address/AddressTokens.tsx
@@ -10,12 +10,14 @@ import { useERC20Holdings } from "../../ots2/usePrototypeTransferHooks";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import { RuntimeContext } from "../../useRuntime";
+import { usePageTitle } from "../../useTitle";
 import { AddressAwareComponentProps } from "../types";
 import TokenBalance from "./TokenBalance";
 
 const AddressTokens: FC<AddressAwareComponentProps> = ({ address }) => {
   const { provider } = useContext(RuntimeContext);
   const erc20List = useERC20Holdings(provider, address);
+  usePageTitle(`Token Balances | ${address}`);
 
   const [enabled, setEnabled] = useState<boolean>(true);
   const tokenSet = useTokenSet(provider?._network.chainId);

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -17,6 +17,7 @@ import { ProcessedTransaction } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
 import { useAddressBalance, useContractCreator } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
+import { usePageTitle } from "../../useTitle";
 import DecoratedAddressLink from "../components/DecoratedAddressLink";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import { AddressAwareComponentProps } from "../types";
@@ -32,6 +33,8 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   if (addressOrName === undefined) {
     throw new Error("addressOrName couldn't be undefined here");
   }
+
+  usePageTitle(`Address ${addressOrName}`);
 
   const [searchParams] = useSearchParams();
   const hash = searchParams.get("h");

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -8,6 +8,7 @@ import InfoRow from "../../components/InfoRow";
 import { Match, MatchType } from "../../sourcify/useSourcify";
 import { openInRemixURL } from "../../url";
 import { RuntimeContext } from "../../useRuntime";
+import { usePageTitle } from "../../useTitle";
 import { commify } from "../../utils/utils";
 import Contract from "./Contract";
 import ContractFromRepo from "./ContractFromRepo";
@@ -20,6 +21,7 @@ type ContractsProps = {
 
 const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
   const { provider } = useContext(RuntimeContext);
+  usePageTitle(`Contract | ${checksummedAddress}`);
 
   const [selected, setSelected] = useState<string>();
   useEffect(() => {

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -5,6 +5,7 @@ import LabeledSwitch from "../../../components/LabeledSwitch";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
 import { Match } from "../../../sourcify/useSourcify";
 import { RuntimeContext } from "../../../useRuntime";
+import { usePageTitle } from "../../../useTitle";
 import ReadFunction from "./ReadFunction";
 
 type ContractsProps = {
@@ -25,6 +26,7 @@ const ReadContract: React.FC<ContractsProps> = ({
 }) => {
   const { provider } = useContext(RuntimeContext);
   const [showNonViewReturns, setShowNonViewReturns] = useState<boolean>(false);
+  usePageTitle(`Read Contract | ${checksummedAddress}`);
 
   const viewFunctions = match?.metadata.output.abi.filter((fn) =>
     isReadFunction(fn),


### PR DESCRIPTION
The AddressMainPage component was overwriting individual tab titles with the address page title. This PR also adds page titles to the remaining address page tabs.

Closes #1649.