### PR TITLE
Add remaining Optimism-specific changes

### DIFF
--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -17,10 +17,14 @@ const WarningHeader: React.FC = () => {
     chainMsg = "Rinkeby Testnet";
   } else if (chainId === 5n) {
     chainMsg = "Görli Testnet";
+  } else if (chainId === 10n) {
+    chainMsg = "OP Mainnet";
   } else if (chainId === 42n) {
     chainMsg = "Kovan Testnet";
   } else if (chainId === 11155111n) {
     chainMsg = "Sepolia Testnet";
+  } else if (chainId === 11155420n) {
+    chainMsg = "OP Sepolia";
   } else if (chainId === 17000n) {
     chainMsg = "Holesky Testnet";
   } else if (name) {

--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -32,6 +32,13 @@ const TransactionType: React.FC<TransactionTypeProps> = ({ type }) => {
         </ExternalLink>
       );
       break;
+    case 126:
+      description = (
+        <ExternalLink href="https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#the-deposited-transaction-type">
+          Optimism: Deposit
+        </ExternalLink>
+      );
+      break;
     default:
       description = "unknown";
   }

--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -34,7 +34,7 @@ const TransactionType: React.FC<TransactionTypeProps> = ({ type }) => {
       break;
     case 126:
       description = (
-        <ExternalLink href="https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md#the-deposited-transaction-type">
+        <ExternalLink href="https://specs.optimism.io/protocol/deposits.html#the-deposited-transaction-type">
           Optimism: Deposit
         </ExternalLink>
       );

--- a/src/execution/BlockDetails.tsx
+++ b/src/execution/BlockDetails.tsx
@@ -42,7 +42,13 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
   const extraStr = useMemo(() => {
     return block && toUtf8String(block.extraData, Utf8ErrorFuncs.replace);
   }, [block]);
-  const burntFees = block?.baseFeePerGas && block.baseFeePerGas * block.gasUsed;
+  // gasUsedDepositTx: Optimism-specific; "gas used" by the deposit transaction which does
+  // not pay the basefee
+  const gasUsedWithoutDepositTx = block
+    ? block.gasUsed - (block.gasUsedDepositTx ?? 0n)
+    : 0n;
+  const burntFees =
+    block?.baseFeePerGas && block.baseFeePerGas * gasUsedWithoutDepositTx;
   const gasUsedPerc =
     block && Number((block.gasUsed * 10000n) / block.gasLimit) / 100;
 

--- a/src/execution/components/BlockReward.tsx
+++ b/src/execution/components/BlockReward.tsx
@@ -9,7 +9,16 @@ type BlockRewardProps = {
 };
 
 const BlockReward: FC<BlockRewardProps> = ({ block }) => {
-  const netFeeReward = block?.feeReward ?? 0n;
+  const totalFees = block?.feeReward ?? 0n;
+
+  // Optimism-specific: subtract deposit transaction's gas, which does not pay the basefee
+  const gasUsedWithoutDepositTx =
+    block.gasUsed - (block.gasUsedDepositTx ?? 0n);
+  const burntFees =
+    (block?.baseFeePerGas && block.baseFeePerGas * gasUsedWithoutDepositTx) ??
+    0n;
+  const netFeeReward = totalFees - burntFees;
+
   const totalReward = block.blockReward + netFeeReward;
   const fiatValue = useFiatValue(totalReward, block.number);
 

--- a/src/execution/op-tx-calculation.ts
+++ b/src/execution/op-tx-calculation.ts
@@ -1,0 +1,33 @@
+export function multiplyByScalar(num: bigint, decimalStr: string): bigint {
+  const [integerPart, fractionalPart] = decimalStr.split(".");
+  const numInteger = BigInt(integerPart);
+  if (fractionalPart) {
+    const numFraction = BigInt(fractionalPart);
+    const divisor = 10n ** BigInt(fractionalPart.length);
+    return (num * numInteger * divisor + num * numFraction) / divisor;
+  }
+  return num * numInteger;
+}
+
+export const isOptimistic = (chainId: bigint): boolean => {
+  return chainId === 10n || chainId === 11155420n;
+};
+
+export function getOpFeeData(
+  txType: number,
+  gasPrice: bigint,
+  gasUsed: bigint,
+  l1GasUsed: bigint,
+  l1GasPrice: bigint,
+  l1FeeScalar: string,
+): { fee: bigint; gasPrice: bigint } {
+  if (txType === 0x7e) {
+    return { gasPrice: 0n, fee: 0n };
+  }
+  return {
+    gasPrice,
+    fee:
+      gasUsed * gasPrice +
+      multiplyByScalar(l1GasUsed * l1GasPrice, l1FeeScalar),
+  };
+}

--- a/src/execution/op-tx-calculation.ts
+++ b/src/execution/op-tx-calculation.ts
@@ -9,9 +9,12 @@ export function multiplyByScalar(num: bigint, decimalStr: string): bigint {
   return num * numInteger;
 }
 
-export const isOptimistic = (chainId: bigint): boolean => {
+export function isOptimisticChain(chainId: bigint | undefined): boolean {
+  if (chainId === undefined) {
+    return false;
+  }
   return chainId === 10n || chainId === 11155420n;
-};
+}
 
 export function getOpFeeData(
   txType: number,

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -52,6 +52,7 @@ import { RuntimeContext } from "../../useRuntime";
 import { commify } from "../../utils/utils";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import { calculateFee } from "../feeCalc";
+import { multiplyByScalar } from "../op-tx-calculation";
 import NavNonce from "./NavNonce";
 import RewardSplit from "./RewardSplit";
 import TokenTransferItem from "./TokenTransferItem";
@@ -391,23 +392,69 @@ const Details: FC<DetailsProps> = ({ txData }) => {
         </InfoRow>
       )}
       {txData.confirmedData && (
-        <InfoRow title="Gas Used / Limit">
-          <div className="flex items-baseline space-x-3">
-            <div>
-              <RelativePosition
-                pos={commify(formatUnits(txData.confirmedData.gasUsed, 0))}
-                total={commify(formatUnits(txData.gasLimit, 0))}
+        <>
+          <InfoRow title="Gas Used / Limit">
+            <div className="flex items-baseline space-x-3">
+              <div>
+                <RelativePosition
+                  pos={commify(formatUnits(txData.confirmedData.gasUsed, 0))}
+                  total={commify(formatUnits(txData.gasLimit, 0))}
+                />
+              </div>
+              <PercentageBar
+                perc={
+                  Number(
+                    (txData.confirmedData.gasUsed * 10000n) / txData.gasLimit,
+                  ) / 100
+                }
               />
             </div>
-            <PercentageBar
-              perc={
-                Number(
-                  (txData.confirmedData.gasUsed * 10000n) / txData.gasLimit,
-                ) / 100
-              }
-            />
-          </div>
-        </InfoRow>
+          </InfoRow>
+          {txData.confirmedData && txData.confirmedData.l1GasUsed && (
+            <InfoRow title="L1 Gas Used by Txn">
+              <span>{commify(txData.confirmedData.l1GasUsed)}</span>
+            </InfoRow>
+          )}
+          {txData.confirmedData &&
+            txData.confirmedData.l1FeeScalar !== undefined && (
+              <InfoRow title="L1 Fee Scalar">
+                <span>{txData.confirmedData.l1FeeScalar}</span>
+              </InfoRow>
+            )}
+          {txData.confirmedData && txData.confirmedData.l1GasPrice && (
+            <InfoRow title="L1 Gas Price">
+              <div className="flex items-baseline space-x-1">
+                <span>
+                  <FormattedBalance value={txData.confirmedData.l1GasPrice} />{" "}
+                  {symbol} (
+                  <FormattedBalance
+                    value={txData.confirmedData.l1GasPrice}
+                    decimals={9}
+                  />{" "}
+                  Gwei)
+                </span>
+              </div>
+            </InfoRow>
+          )}
+          {txData.confirmedData &&
+            txData.confirmedData.l1GasUsed &&
+            txData.confirmedData.l1GasPrice &&
+            txData.confirmedData.l1FeeScalar !== undefined && (
+              <InfoRow title="L1 Fees Paid">
+                <span>
+                  <NativeTokenAmountAndFiat
+                    value={multiplyByScalar(
+                      txData.confirmedData.l1GasUsed *
+                        txData.confirmedData.l1GasPrice,
+                      txData.confirmedData.l1FeeScalar,
+                    )}
+                    blockTag={txData.confirmedData?.blockNumber}
+                    {...feePreset}
+                  />
+                </span>
+              </InfoRow>
+            )}
+        </>
       )}
       {block && hasEIP1559 && (
         <InfoRow title="Block Base Fee">

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -52,7 +52,7 @@ import { RuntimeContext } from "../../useRuntime";
 import { commify } from "../../utils/utils";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import { calculateFee } from "../feeCalc";
-import { multiplyByScalar } from "../op-tx-calculation";
+import { isOptimisticChain } from "../op-tx-calculation";
 import NavNonce from "./NavNonce";
 import RewardSplit from "./RewardSplit";
 import TokenTransferItem from "./TokenTransferItem";
@@ -117,6 +117,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
     : undefined;
   const [expanded, setExpanded] = useState<boolean>(false);
   const [showFunctionHelp, setShowFunctionHelp] = useState<boolean>(false);
+  const isOptimistic = isOptimisticChain(provider?._network.chainId);
 
   const { totalFees } = calculateFee(txData, block);
 
@@ -436,24 +437,6 @@ const Details: FC<DetailsProps> = ({ txData }) => {
               </div>
             </InfoRow>
           )}
-          {txData.confirmedData &&
-            txData.confirmedData.l1GasUsed &&
-            txData.confirmedData.l1GasPrice &&
-            txData.confirmedData.l1FeeScalar !== undefined && (
-              <InfoRow title="L1 Fees Paid">
-                <span>
-                  <NativeTokenAmountAndFiat
-                    value={multiplyByScalar(
-                      txData.confirmedData.l1GasUsed *
-                        txData.confirmedData.l1GasPrice,
-                      txData.confirmedData.l1FeeScalar,
-                    )}
-                    blockTag={txData.confirmedData?.blockNumber}
-                    {...feePreset}
-                  />
-                </span>
-              </InfoRow>
-            )}
         </>
       )}
       {block && hasEIP1559 && (
@@ -531,7 +514,9 @@ const Details: FC<DetailsProps> = ({ txData }) => {
                   {...feePreset}
                 />
               </div>
-              {hasEIP1559 && <RewardSplit txData={txData} />}
+              {hasEIP1559 && (!isOptimistic || txData.type !== 126) && (
+                <RewardSplit txData={txData} />
+              )}
             </div>
           </InfoRow>
           <InfoRow title={`${name} Price`}>

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -1,3 +1,4 @@
+import { faEthereum } from "@fortawesome/free-brands-svg-icons";
 import { faBurn, faCoins, faSplotch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useContext } from "react";
@@ -78,6 +79,26 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
                 </span>
                 <span>
                   <FormattedBalance value={feeDist.blob} symbol={symbol} />
+                </span>
+              </span>
+            </div>
+          </>
+        )}
+        {feePerc.opL1Fee > 0n && (
+          <>
+            <PercentageGauge
+              perc={feePerc.opL1Fee}
+              bgColor="bg-blue-100"
+              bgColorPerc="bg-blue-300"
+              textColor="text-blue-700"
+            />
+            <div className="flex items-baseline space-x-1">
+              <span className="flex space-x-1">
+                <span className="text-blue-300" title="L1 Security fees">
+                  <FontAwesomeIcon icon={faEthereum} size="1x" />
+                </span>
+                <span>
+                  <FormattedBalance value={feeDist.opL1Fee} symbol={symbol} />
                 </span>
               </span>
             </div>

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -14,7 +14,10 @@ import {
 } from "react";
 import { NavigateFunction, useNavigate } from "react-router";
 import useKeyboardShortcut from "use-keyboard-shortcut";
-import { getOpFeeData, isOptimistic } from "../execution/op-tx-calculation";
+import {
+  getOpFeeData,
+  isOptimisticChain,
+} from "../execution/op-tx-calculation";
 import { PAGE_SIZE } from "../params";
 import { ProcessedTransaction, TransactionChunk } from "../types";
 import { formatter } from "../utils/formatter";
@@ -33,7 +36,7 @@ export const rawToProcessed = (provider: JsonRpcApiProvider, _rawRes: any) => {
 
       let fee: bigint;
       let gasPrice: bigint;
-      if (isOptimistic(provider._network.chainId)) {
+      if (isOptimisticChain(provider._network.chainId)) {
         const l1GasUsed: bigint = formatter.bigInt(_rawReceipt.l1GasUsed ?? 0n);
         const l1GasPrice: bigint = formatter.bigInt(
           _rawReceipt.l1GasPrice ?? 0n,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,11 @@ export type ProcessedTransaction = {
   gasPrice: bigint;
   data: string;
   status: number;
+
+  // Optimism-specific
+  l1GasUsed?: bigint;
+  l1GasPrice?: bigint;
+  l1FeeScalar?: string;
 };
 
 export type TransactionChunk = {
@@ -64,6 +69,11 @@ export type ConfirmedTransactionData = {
   logs: Log[];
   blobGasPrice?: bigint;
   blobGasUsed?: bigint;
+
+  // Optimism-specific
+  l1GasUsed?: bigint;
+  l1GasPrice?: bigint;
+  l1FeeScalar?: string;
 };
 
 // The VOID...

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,6 @@ export type ProcessedTransaction = {
   gasPrice: bigint;
   data: string;
   status: number;
-
-  // Optimism-specific
-  l1GasUsed?: bigint;
-  l1GasPrice?: bigint;
-  l1FeeScalar?: string;
 };
 
 export type TransactionChunk = {

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 import useSWR, { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import erc20 from "./abi/erc20.json";
+import { getOpFeeData, isOptimistic } from "./execution/op-tx-calculation";
 import {
   ChecksummedAddress,
   InternalOperation,
@@ -109,6 +110,7 @@ const blockTransactionsFetcher: Fetcher<
         throw new Error("blockTransactionsFetcher: unknown tx hash");
       }
 
+      let fee: bigint;
       let effectiveGasPrice: bigint;
       if (t.type === 2 || t.type === 3) {
         const tip =
@@ -118,6 +120,31 @@ const blockTransactionsFetcher: Fetcher<
         effectiveGasPrice = _block.baseFeePerGas! + tip;
       } else {
         effectiveGasPrice = t.gasPrice!;
+      }
+
+      // Handle Optimism-specific values
+      let l1GasUsed: bigint | undefined;
+      let l1GasPrice: bigint | undefined;
+      let l1FeeScalar: string | undefined;
+      if (isOptimistic(provider._network.chainId)) {
+        if (t.type === 0x7e) {
+          fee = 0n;
+          effectiveGasPrice = 0n;
+        } else {
+          l1GasUsed = formatter.bigInt(_rawReceipt.l1GasUsed);
+          l1GasPrice = formatter.bigInt(_rawReceipt.l1GasPrice);
+          l1FeeScalar = _rawReceipt.l1FeeScalar;
+          ({ fee, gasPrice: effectiveGasPrice } = getOpFeeData(
+            t.type,
+            effectiveGasPrice,
+            _receipt.gasUsed!,
+            l1GasUsed,
+            l1GasPrice,
+            l1FeeScalar ?? "0",
+          ));
+        }
+      } else {
+        fee = formatter.bigInt(_receipt.gasUsed) * effectiveGasPrice;
       }
 
       return {
@@ -131,10 +158,13 @@ const blockTransactionsFetcher: Fetcher<
         createdContractAddress: _receipt.contractAddress ?? undefined,
         value: t.value,
         type: t.type,
-        fee: formatter.bigInt(_receipt.gasUsed) * effectiveGasPrice,
+        fee,
         gasPrice: effectiveGasPrice,
         data: t.data,
         status: formatter.number(_receipt.status),
+        l1GasUsed,
+        l1GasPrice,
+        l1FeeScalar,
       };
     })
     .reverse();
@@ -199,17 +229,6 @@ export const useBlockDataFromTransaction = (
   return block;
 };
 
-function multiplyByScalar(num: bigint, decimalStr: string): bigint {
-  const [integerPart, fractionalPart] = decimalStr.split(".");
-  const numInteger = BigInt(integerPart);
-  if (fractionalPart) {
-    const numFraction = BigInt(fractionalPart);
-    const divisor = 10n ** BigInt(fractionalPart.length);
-    return (num * numInteger * divisor + num * numFraction) / divisor;
-  }
-  return num * numInteger;
-}
-
 export const useTxData = (
   provider: JsonRpcApiProvider | undefined,
   txhash: string,
@@ -234,10 +253,12 @@ export const useTxData = (
 
         let fee: bigint;
         let gasPrice: bigint;
-        const isOptimistic =
-          provider._network.chainId === 10n ||
-          provider._network.chainId === 11155420n;
-        if (isOptimistic) {
+
+        // Handle Optimism-specific values
+        let l1GasUsed: bigint | undefined;
+        let l1GasPrice: bigint | undefined;
+        let l1FeeScalar: string | undefined;
+        if (isOptimistic(provider._network.chainId)) {
           if (_response.type === 0x7e) {
             fee = 0n;
             gasPrice = 0n;
@@ -246,15 +267,17 @@ export const useTxData = (
               "eth_getTransactionReceipt",
               [txhash],
             );
-            console.log(_receipt);
-            console.log(_rawReceipt);
-            const l1GasUsed: bigint = formatter.bigInt(_rawReceipt.l1GasUsed);
-            const l1GasPrice: bigint = formatter.bigInt(_rawReceipt.l1GasPrice);
-            const l1FeeScalar: string = _rawReceipt.l1FeeScalar;
-            gasPrice = _response.gasPrice!;
-            fee =
-              _receipt!.gasUsed! * gasPrice +
-              multiplyByScalar(l1GasUsed * l1GasPrice, l1FeeScalar);
+            l1GasUsed = formatter.bigInt(_rawReceipt.l1GasUsed);
+            l1GasPrice = formatter.bigInt(_rawReceipt.l1GasPrice);
+            l1FeeScalar = _rawReceipt.l1FeeScalar;
+            ({ fee, gasPrice } = getOpFeeData(
+              _response.type,
+              _response.gasPrice!,
+              _receipt ? _receipt.gasUsed! : 0n,
+              l1GasUsed,
+              l1GasPrice,
+              l1FeeScalar ?? "0",
+            ));
           }
         } else {
           fee = _response.gasPrice! * _receipt!.gasUsed!;
@@ -290,6 +313,9 @@ export const useTxData = (
                   logs: Array.from(_receipt.logs),
                   blobGasPrice: _receipt.blobGasPrice ?? undefined,
                   blobGasUsed: _receipt.blobGasUsed ?? undefined,
+                  l1GasUsed,
+                  l1GasPrice,
+                  l1FeeScalar,
                 },
         });
       } catch (err) {


### PR DESCRIPTION
Primary differences:
* Uses op-erigon specific fields in block and transaction responses
* Adds L1 Security Fees bar to transactions which pay L1 fees
* Adds additional L1 gas/fee details to transactions
* Adjusts block reward calculation to ignore the system transaction in Optimism blocks

New transaction details example (ignore the custom "eETH" symbol which should just be "ETH"):
![image](https://github.com/otterscan/otterscan/assets/125761775/7ce1e06d-6ae4-4e26-a96e-ed01f838fc49)


Closes #1253