### PR TITLE
Show withdrawals on slot page

### DIFF
--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -3,16 +3,13 @@ import { FC, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import BlockLink from "../../components/BlockLink";
 import ContentFrame from "../../components/ContentFrame";
-import { balancePreset } from "../../components/FiatValue";
 import HexValue from "../../components/HexValue";
 import InfoRow from "../../components/InfoRow";
-import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
 import RelevantNumericValue from "../../components/RelevantNumericValue";
 import StandardTBody from "../../components/StandardTBody";
 import StandardTHead from "../../components/StandardTHead";
 import StandardTable from "../../components/StandardTable";
 import Timestamp from "../../components/Timestamp";
-import DecoratedAddressLink from "../../execution/components/DecoratedAddressLink";
 import { slot2Epoch, useSlot, useSlotTimestamp } from "../../useConsensus";
 import { usePageTitle } from "../../useTitle";
 import CheckedValidatorLink from "../components/CheckedValidatorLink";
@@ -24,6 +21,7 @@ import AggregationParticipation from "./AggregationParticipation";
 import BlockRoot from "./BlockRoot";
 import OverviewSkeleton from "./OverviewSkeleton";
 import SlotNotFound from "./SlotNotFound";
+import WithdrawalDetailsRow from "./WithdrawalDetailsRow";
 
 const GWEI = 10n ** 9n;
 
@@ -163,26 +161,13 @@ const Overview: FC = () => {
                       <StandardTBody>
                         {slot.data.message.body.execution_payload.withdrawals.map(
                           (withdrawal: Withdrawal) => (
-                            <tr>
-                              <td>
-                                <CheckedValidatorLink
-                                  validatorIndex={Number(
-                                    withdrawal.validator_index,
-                                  )}
-                                />
-                              </td>
-                              <td>
-                                <DecoratedAddressLink
-                                  address={getAddress(withdrawal.address)}
-                                />
-                              </td>
-                              <td>
-                                <NativeTokenAmountAndFiat
-                                  value={BigInt(withdrawal.amount) * GWEI}
-                                  {...balancePreset}
-                                />
-                              </td>
-                            </tr>
+                            <WithdrawalDetailsRow
+                              validatorIndex={Number(
+                                withdrawal.validator_index,
+                              )}
+                              address={getAddress(withdrawal.address)}
+                              amount={BigInt(withdrawal.amount) * GWEI}
+                            />
                           ),
                         )}
                       </StandardTBody>

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -162,6 +162,7 @@ const Overview: FC = () => {
                         {slot.data.message.body.execution_payload.withdrawals.map(
                           (withdrawal: Withdrawal) => (
                             <WithdrawalDetailsRow
+                              key={withdrawal.index}
                               validatorIndex={Number(
                                 withdrawal.validator_index,
                               )}

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -1,22 +1,31 @@
-import { toUtf8String } from "ethers";
+import { getAddress, toUtf8String } from "ethers";
 import { FC, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import BlockLink from "../../components/BlockLink";
 import ContentFrame from "../../components/ContentFrame";
+import { balancePreset } from "../../components/FiatValue";
 import HexValue from "../../components/HexValue";
 import InfoRow from "../../components/InfoRow";
+import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
 import RelevantNumericValue from "../../components/RelevantNumericValue";
+import StandardTBody from "../../components/StandardTBody";
+import StandardTHead from "../../components/StandardTHead";
+import StandardTable from "../../components/StandardTable";
 import Timestamp from "../../components/Timestamp";
+import DecoratedAddressLink from "../../execution/components/DecoratedAddressLink";
 import { slot2Epoch, useSlot, useSlotTimestamp } from "../../useConsensus";
 import { usePageTitle } from "../../useTitle";
 import CheckedValidatorLink from "../components/CheckedValidatorLink";
 import EpochLink from "../components/EpochLink";
 import SlashingCount from "../components/SlashingCount";
+import { Withdrawal } from "../types";
 import AggregationBits from "./AggregationBits";
 import AggregationParticipation from "./AggregationParticipation";
 import BlockRoot from "./BlockRoot";
 import OverviewSkeleton from "./OverviewSkeleton";
 import SlotNotFound from "./SlotNotFound";
+
+const GWEI = 10n ** 9n;
 
 const Overview: FC = () => {
   const { slotNumber } = useParams();
@@ -134,6 +143,54 @@ const Overview: FC = () => {
               value={slot.data.message.body.deposits.length}
             />
           </InfoRow>
+          {slot.data.message.body.execution_payload &&
+            slot.data.message.body.execution_payload.withdrawals && (
+              <InfoRow title="Withdrawals">
+                <RelevantNumericValue
+                  value={
+                    slot.data.message.body.execution_payload.withdrawals.length
+                  }
+                />
+                {slot.data.message.body.execution_payload.withdrawals.length >
+                  0 && (
+                  <div className="mt-3">
+                    <StandardTable>
+                      <StandardTHead>
+                        <th className="w-10">Validator</th>
+                        <th className="w-28">Withdrawal Address</th>
+                        <th className="w-20">Amount</th>
+                      </StandardTHead>
+                      <StandardTBody>
+                        {slot.data.message.body.execution_payload.withdrawals.map(
+                          (withdrawal: Withdrawal) => (
+                            <tr>
+                              <td>
+                                <CheckedValidatorLink
+                                  validatorIndex={Number(
+                                    withdrawal.validator_index,
+                                  )}
+                                />
+                              </td>
+                              <td>
+                                <DecoratedAddressLink
+                                  address={getAddress(withdrawal.address)}
+                                />
+                              </td>
+                              <td>
+                                <NativeTokenAmountAndFiat
+                                  value={BigInt(withdrawal.amount) * GWEI}
+                                  {...balancePreset}
+                                />
+                              </td>
+                            </tr>
+                          ),
+                        )}
+                      </StandardTBody>
+                    </StandardTable>
+                  </div>
+                )}
+              </InfoRow>
+            )}
         </>
       )}
     </ContentFrame>

--- a/src/consensus/slot/WithdrawalDetailsRow.tsx
+++ b/src/consensus/slot/WithdrawalDetailsRow.tsx
@@ -1,7 +1,7 @@
 import { FC, memo } from "react";
 import { balancePreset } from "../../components/FiatValue";
 import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
-import DecoratedAddressLink from "../../execution/components/DecoratedAddressLink";
+import TransactionAddress from "../../execution/components/TransactionAddress";
 import CheckedValidatorLink from "../components/CheckedValidatorLink";
 
 const GWEI = 10n ** 9n;
@@ -22,8 +22,8 @@ const WithdrawalDetailsRow: FC<WithdrawalDetailsRowProps> = ({
       <td>
         <CheckedValidatorLink validatorIndex={validatorIndex} />
       </td>
-      <td>
-        <DecoratedAddressLink address={address} />
+      <td className="flex">
+        <TransactionAddress address={address} />
       </td>
       <td>
         <NativeTokenAmountAndFiat value={amount} {...balancePreset} />

--- a/src/consensus/slot/WithdrawalDetailsRow.tsx
+++ b/src/consensus/slot/WithdrawalDetailsRow.tsx
@@ -1,0 +1,35 @@
+import { FC, memo } from "react";
+import { balancePreset } from "../../components/FiatValue";
+import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
+import DecoratedAddressLink from "../../execution/components/DecoratedAddressLink";
+import CheckedValidatorLink from "../components/CheckedValidatorLink";
+
+const GWEI = 10n ** 9n;
+
+interface WithdrawalDetailsRowProps {
+  validatorIndex: number;
+  address: string;
+  amount: bigint;
+}
+
+const WithdrawalDetailsRow: FC<WithdrawalDetailsRowProps> = ({
+  validatorIndex,
+  address,
+  amount,
+}) => {
+  return (
+    <tr>
+      <td>
+        <CheckedValidatorLink validatorIndex={validatorIndex} />
+      </td>
+      <td>
+        <DecoratedAddressLink address={address} />
+      </td>
+      <td>
+        <NativeTokenAmountAndFiat value={amount} {...balancePreset} />
+      </td>
+    </tr>
+  );
+};
+
+export default memo(WithdrawalDetailsRow);

--- a/src/consensus/types.ts
+++ b/src/consensus/types.ts
@@ -11,3 +11,13 @@ export type EpochAwareComponentProps = {
 export type SlotAwareComponentProps = {
   slotNumber: number;
 };
+
+/**
+ * Withdrawal details
+ */
+export type Withdrawal = {
+  index: string;
+  validator_index: string;
+  address: string;
+  amount: string;
+};


### PR DESCRIPTION
Closes #1723

I added the withdrawal details to the page:
![image](https://github.com/otterscan/otterscan/assets/125761775/c2960867-c688-4bf7-a5ca-3e2c3a393ed2)

Part of me wants to reduce the vertical padding in each row to make the list more compact.