### PR TITLE
Scroll tables horizontally in small viewport widths

### DIFF
--- a/src/components/StandardScrollableTable.tsx
+++ b/src/components/StandardScrollableTable.tsx
@@ -1,9 +1,17 @@
 import { FC, PropsWithChildren } from "react";
 
+interface StandardScrollableTableProps {
+  isAuto?: boolean;
+}
+
 // TODO: replace all usage of StandardTable with this component
-const StandardScrollableTable: FC<PropsWithChildren> = ({ children }) => (
+const StandardScrollableTable: FC<
+  StandardScrollableTableProps & PropsWithChildren
+> = ({ children, isAuto = false }) => (
   <div className="overflow-x-scroll">
-    <table className="w-full table-fixed border-gray-200 px-2 py-2 text-left text-sm [&>*>tr]:items-baseline">
+    <table
+      className={`w-full ${isAuto ? "table-auto" : "table-fixed"} border-gray-200 px-2 py-2 text-left text-sm [&>*>tr]:items-baseline`}
+    >
       {children}
     </table>
   </div>

--- a/src/components/StandardTBody.tsx
+++ b/src/components/StandardTBody.tsx
@@ -1,7 +1,7 @@
 import { FC, PropsWithChildren } from "react";
 
 const StandardTBody: FC<PropsWithChildren> = ({ children }) => (
-  <tbody className="[&>tr>td]:truncate [&>tr>td]:px-2 [&>tr>td]:py-3 [&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover">
+  <tbody className="[&>tr>td]:truncate [&>tr>td]:px-1 [&>tr>td]:py-3 [&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover">
     {children}
   </tbody>
 );

--- a/src/components/StandardTBody.tsx
+++ b/src/components/StandardTBody.tsx
@@ -1,7 +1,7 @@
 import { FC, PropsWithChildren } from "react";
 
 const StandardTBody: FC<PropsWithChildren> = ({ children }) => (
-  <tbody className="[&>tr>td]:truncate [&>tr>td]:px-1 [&>tr>td]:py-3 [&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover">
+  <tbody className="[&>tr>td]:truncate [&>tr>td]:px-1 [&>tr>td:first-child]:pl-2 [&>tr>td:last-child]:pr-2 [&>tr>td]:py-3 [&>tr]:border-t [&>tr]:border-gray-200 hover:[&>tr]:bg-skin-table-hover">
     {children}
   </tbody>
 );

--- a/src/components/StandardTHead.tsx
+++ b/src/components/StandardTHead.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren } from "react";
 
 const StandardTHead: FC<PropsWithChildren> = ({ children }) => (
   <thead>
-    <tr className="bg-gray-100 text-gray-500 [&>th]:truncate [&>th]:px-1 [&>th]:py-2">
+    <tr className="bg-gray-100 text-gray-500 [&>th]:truncate [&>th:first-child]:pl-2 [&>th:last-child]:pr-2 [&>th]:px-1 [&>th]:py-2">
       {children}
     </tr>
   </thead>

--- a/src/components/StandardTHead.tsx
+++ b/src/components/StandardTHead.tsx
@@ -2,7 +2,7 @@ import { FC, PropsWithChildren } from "react";
 
 const StandardTHead: FC<PropsWithChildren> = ({ children }) => (
   <thead>
-    <tr className="bg-gray-100 text-gray-500 [&>th]:truncate [&>th]:px-2 [&>th]:py-2">
+    <tr className="bg-gray-100 text-gray-500 [&>th]:truncate [&>th]:px-1 [&>th]:py-2">
       {children}
     </tr>
   </thead>

--- a/src/execution/address/AddressTokens.tsx
+++ b/src/execution/address/AddressTokens.tsx
@@ -2,9 +2,9 @@ import { Switch } from "@headlessui/react";
 import { getAddress } from "ethers";
 import { FC, useContext, useMemo, useState } from "react";
 import ContentFrame from "../../components/ContentFrame";
+import StandardScrollableTable from "../../components/StandardScrollableTable";
 import StandardTBody from "../../components/StandardTBody";
 import StandardTHead from "../../components/StandardTHead";
-import StandardTable from "../../components/StandardTable";
 import { useTokenSet } from "../../kleros/useTokenList";
 import { useERC20Holdings } from "../../ots2/usePrototypeTransferHooks";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
@@ -39,10 +39,10 @@ const AddressTokens: FC<AddressAwareComponentProps> = ({ address }) => {
             filterApplied={enabled}
             applyFilter={setEnabled}
           />
-          <StandardTable>
+          <StandardScrollableTable>
             <StandardTHead>
               <th className="w-96">Token</th>
-              <th>Balance</th>
+              <th className="w-80">Balance</th>
             </StandardTHead>
             <StandardTBody>
               {tokenList.map((t) => (
@@ -53,7 +53,7 @@ const AddressTokens: FC<AddressAwareComponentProps> = ({ address }) => {
                 />
               ))}
             </StandardTBody>
-          </StandardTable>
+          </StandardScrollableTable>
           <TotalBar
             erc20List={erc20List}
             filteredList={filteredList}

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -4,9 +4,10 @@ import ContentFrame from "../../components/ContentFrame";
 import { balancePreset } from "../../components/FiatValue";
 import InfoRow from "../../components/InfoRow";
 import NativeTokenAmountAndFiat from "../../components/NativeTokenAmountAndFiat";
+import StandardScrollableTable from "../../components/StandardScrollableTable";
+import StandardTBody from "../../components/StandardTBody";
 import TransactionLink from "../../components/TransactionLink";
 import { useProxyAttributes } from "../../ots2/usePrototypeTransferHooks";
-import PendingResults from "../../search/PendingResults";
 import ResultHeader from "../../search/ResultHeader";
 import TransactionItem from "../../search/TransactionItem";
 import UndefinedPageControl from "../../search/UndefinedPageControl";
@@ -22,6 +23,7 @@ import DecoratedAddressLink from "../components/DecoratedAddressLink";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import { AddressAwareComponentProps } from "../types";
 import PendingItem from "./PendingItem";
+import PendingPage from "./PendingPage";
 
 const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   address,
@@ -139,25 +141,26 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
           )}
         </BlockNumberContext.Provider>
         <NavBar address={address} page={page} controller={controller} />
-        <ResultHeader
-          feeDisplay={feeDisplay}
-          feeDisplayToggler={feeDisplayToggler}
-        />
-        {page ? (
-          <>
-            {page.map((tx) => (
-              <TransactionItem
-                key={tx.hash}
-                tx={tx}
-                selectedAddress={address}
-                feeDisplay={feeDisplay}
-              />
-            ))}
-            <NavBar address={address} page={page} controller={controller} />
-          </>
-        ) : (
-          <PendingResults />
-        )}
+        <StandardScrollableTable isAuto={true}>
+          <ResultHeader
+            feeDisplay={feeDisplay}
+            feeDisplayToggler={feeDisplayToggler}
+          />
+          {page ? (
+            <StandardTBody>
+              {page.map((tx) => (
+                <TransactionItem
+                  key={tx.hash}
+                  tx={tx}
+                  selectedAddress={address}
+                  feeDisplay={feeDisplay}
+                />
+              ))}
+            </StandardTBody>
+          ) : (
+            <PendingPage rows={1} cols={8} />
+          )}
+        </StandardScrollableTable>
       </StandardSelectionBoundary>
     </ContentFrame>
   );

--- a/src/execution/address/GenericTransactionSearchResult.tsx
+++ b/src/execution/address/GenericTransactionSearchResult.tsx
@@ -81,7 +81,7 @@ const GenericTransactionSearchResult = <T extends { hash: string }>({
             total={total}
             totalFormatter={totalFormatter}
           />
-          <StandardScrollableTable isAuto={false}>
+          <StandardScrollableTable>
             {header}
             {items !== undefined ? (
               <StandardSelectionBoundary>

--- a/src/execution/address/GenericTransactionSearchResult.tsx
+++ b/src/execution/address/GenericTransactionSearchResult.tsx
@@ -1,8 +1,8 @@
 import { FC } from "react";
 import ContentFrame from "../../components/ContentFrame";
+import StandardScrollableTable from "../../components/StandardScrollableTable";
 import StandardTBody from "../../components/StandardTBody";
 import StandardTHead from "../../components/StandardTHead";
-import StandardTable from "../../components/StandardTable";
 import { PAGE_SIZE } from "../../params";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
 import { getTotalFormatter } from "../../search/messages";
@@ -81,7 +81,7 @@ const GenericTransactionSearchResult = <T extends { hash: string }>({
             total={total}
             totalFormatter={totalFormatter}
           />
-          <StandardTable>
+          <StandardScrollableTable isAuto={false}>
             {header}
             {items !== undefined ? (
               <StandardSelectionBoundary>
@@ -94,7 +94,7 @@ const GenericTransactionSearchResult = <T extends { hash: string }>({
             ) : (
               <PendingPage rows={PAGE_SIZE} cols={columns} />
             )}
-          </StandardTable>
+          </StandardScrollableTable>
           {total !== undefined && (
             <SearchResultNavBar
               pageNumber={pageNumber}

--- a/src/execution/block/BlockTransactionResults.tsx
+++ b/src/execution/block/BlockTransactionResults.tsx
@@ -1,7 +1,8 @@
 import { FC, memo } from "react";
 import ContentFrame from "../../components/ContentFrame";
+import StandardScrollableTable from "../../components/StandardScrollableTable";
+import StandardTBody from "../../components/StandardTBody";
 import { PAGE_SIZE } from "../../params";
-import PendingResults from "../../search/PendingResults";
 import ResultHeader from "../../search/ResultHeader";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
 import TransactionItem from "../../search/TransactionItem";
@@ -9,6 +10,7 @@ import { totalTransactionsFormatter } from "../../search/messages";
 import { useFeeToggler } from "../../search/useFeeToggler";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import { ProcessedTransaction } from "../../types";
+import PendingPage from "../address/PendingPage";
 
 type BlockTransactionResultsProps = {
   page?: ProcessedTransaction[];
@@ -33,24 +35,34 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
         total={total}
         totalFormatter={totalTransactionsFormatter}
       />
-      <ResultHeader
-        feeDisplay={feeDisplay}
-        feeDisplayToggler={feeDisplayToggler}
-      />
-      {page ? (
-        <StandardSelectionBoundary>
-          {page.map((tx) => (
-            <TransactionItem key={tx.hash} tx={tx} feeDisplay={feeDisplay} />
-          ))}
-          <SearchResultNavBar
-            pageNumber={pageNumber}
-            pageSize={PAGE_SIZE}
-            total={total}
-            totalFormatter={totalTransactionsFormatter}
-          />
-        </StandardSelectionBoundary>
-      ) : (
-        <PendingResults />
+      <StandardScrollableTable isAuto={true}>
+        <ResultHeader
+          feeDisplay={feeDisplay}
+          feeDisplayToggler={feeDisplayToggler}
+        />
+        {page ? (
+          <StandardSelectionBoundary>
+            <StandardTBody>
+              {page.map((tx) => (
+                <TransactionItem
+                  key={tx.hash}
+                  tx={tx}
+                  feeDisplay={feeDisplay}
+                />
+              ))}
+            </StandardTBody>
+          </StandardSelectionBoundary>
+        ) : (
+          <PendingPage rows={1} cols={8} />
+        )}
+      </StandardScrollableTable>
+      {page && (
+        <SearchResultNavBar
+          pageNumber={pageNumber}
+          pageSize={PAGE_SIZE}
+          total={total}
+          totalFormatter={totalTransactionsFormatter}
+        />
       )}
     </ContentFrame>
   );

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -13,13 +13,13 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
 }) => (
   <StandardTHead>
     <th className="min-w-16 max-w-50">Txn Hash</th>
-    <th className="min-w-16 max-w-32">Method</th>
+    <th>Method</th>
     <th className="w-28">Block</th>
     <th className="w-36">Age</th>
     <th>From</th>
     <th>To</th>
-    <th className="min-w-16 max-w-42">Value</th>
-    <th className="min-w-16 max-w-24">
+    <th className="min-w-52">Value</th>
+    <th className="w-40">
       <button
         className="text-link-blue hover:text-link-blue-hover"
         onClick={feeDisplayToggler}

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import StandardTHead from "../components/StandardTHead";
 import { FeeDisplay } from "./useFeeToggler";
 
 export type ResultHeaderProps = {
@@ -10,15 +11,15 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
 }) => (
-  <div className="grid grid-cols-12 gap-x-1 border-b border-t border-gray-200 bg-gray-100 px-2 py-2 text-sm font-bold text-gray-500">
-    <div className="col-span-2">Txn Hash</div>
-    <div>Method</div>
-    <div>Block</div>
-    <div>Age</div>
-    <div className="col-span-2 ml-1">From</div>
-    <div className="col-span-2 ml-1">To</div>
-    <div className="col-span-2">Value</div>
-    <div>
+  <StandardTHead>
+    <th className="min-w-16 max-w-50">Txn Hash</th>
+    <th className="min-w-16 max-w-32">Method</th>
+    <th className="w-28">Block</th>
+    <th className="w-36">Age</th>
+    <th>From</th>
+    <th>To</th>
+    <th className="min-w-16 max-w-42">Value</th>
+    <th className="min-w-16 max-w-24">
       <button
         className="text-link-blue hover:text-link-blue-hover"
         onClick={feeDisplayToggler}
@@ -27,8 +28,8 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
         {feeDisplay === FeeDisplay.TX_FEE_USD && "Txn Fee (USD)"}
         {feeDisplay === FeeDisplay.GAS_PRICE && "Gas Price"}
       </button>
-    </div>
-  </div>
+    </th>
+  </StandardTHead>
 );
 
 export default React.memo(ResultHeader);

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -12,14 +12,14 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
   feeDisplayToggler,
 }) => (
   <StandardTHead>
-    <th className="min-w-16 max-w-50">Txn Hash</th>
+    <th>Txn Hash</th>
     <th>Method</th>
     <th className="w-28">Block</th>
     <th className="w-36">Age</th>
     <th>From</th>
     <th>To</th>
     <th className="min-w-52">Value</th>
-    <th className="w-40">
+    <th>
       <button
         className="text-link-blue hover:text-link-blue-hover"
         onClick={feeDisplayToggler}

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -64,7 +64,9 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
           {tx.to !== null && <MethodName data={tx.data} to={tx.to} />}
         </td>
         <td className="max-w-28">
-          <BlockLink blockTag={tx.blockNumber} />
+          <span className="pr-1">
+            <BlockLink blockTag={tx.blockNumber} />
+          </span>
         </td>
         <td className="min-w-36 max-w-36">
           <TimestampAge timestamp={tx.timestamp} />

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -69,7 +69,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         <td className="min-w-36 max-w-36">
           <TimestampAge timestamp={tx.timestamp} />
         </td>
-        <td className="max-w-52">
+        <td className="max-w-56">
           <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
             <span className="truncate">
               {tx.from && (
@@ -87,7 +87,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             </span>
           </span>
         </td>
-        <td className="max-w-52">
+        <td className="max-w-56">
           <span
             className="col-span-2 flex items-baseline"
             title={tx.to ?? tx.createdContractAddress}

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -52,7 +52,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
   return (
     <BlockNumberContext.Provider value={tx.blockNumber}>
       <tr>
-        <td className="max-w-36">
+        <td className="max-w-52">
           <TransactionLink
             txHash={tx.hash}
             fail={tx.status === 0}
@@ -114,7 +114,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         <td className="min-w-48 max-w-48">
           <NativeTokenAmount value={tx.value} />
         </td>
-        <td className="min-w-40 max-w-40">
+        <td className="min-w-16 max-w-28">
           <span className="truncate font-balance text-xs text-gray-500">
             {feeDisplay === FeeDisplay.TX_FEE && formatValue(tx.fee, 18)}
             {feeDisplay === FeeDisplay.TX_FEE_USD && (

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -52,7 +52,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
   return (
     <BlockNumberContext.Provider value={tx.blockNumber}>
       <tr>
-        <td className="max-w-52">
+        <td className="max-w-[14.5rem]">
           <TransactionLink
             txHash={tx.hash}
             fail={tx.status === 0}
@@ -69,7 +69,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         <td className="min-w-36 max-w-36">
           <TimestampAge timestamp={tx.timestamp} />
         </td>
-        <td className="max-w-56">
+        <td className="max-w-[14.5rem]">
           <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
             <span className="truncate">
               {tx.from && (
@@ -87,7 +87,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             </span>
           </span>
         </td>
-        <td className="max-w-56">
+        <td className="max-w-[14.5rem]">
           <span
             className="col-span-2 flex items-baseline"
             title={tx.to ?? tx.createdContractAddress}

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -59,17 +59,17 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             blob={tx.type === 3}
           />
         </td>
-        {/* Set min-w-36 to reduce changing column widths when methods of different lengths show*/}
-        <td className="max-w-24 min-w-24">
+        {/* Set both min and max widths to reduce column width changes when items of different lengths appear */}
+        <td className="min-w-32 max-w-32">
           {tx.to !== null && <MethodName data={tx.data} to={tx.to} />}
         </td>
         <td className="max-w-28">
           <BlockLink blockTag={tx.blockNumber} />
         </td>
-        <td className="max-w-24">
+        <td className="min-w-36 max-w-36">
           <TimestampAge timestamp={tx.timestamp} />
         </td>
-        <td className="max-w-48">
+        <td className="max-w-52">
           <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
             <span className="truncate">
               {tx.from && (
@@ -87,7 +87,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             </span>
           </span>
         </td>
-        <td className="max-w-48">
+        <td className="max-w-52">
           <span
             className="col-span-2 flex items-baseline"
             title={tx.to ?? tx.createdContractAddress}
@@ -111,10 +111,10 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             </span>
           </span>
         </td>
-        <td className="min-w-28 max-w-28">
+        <td className="min-w-48 max-w-48">
           <NativeTokenAmount value={tx.value} />
         </td>
-        <td className="min-w-24 max-w-24">
+        <td className="min-w-40 max-w-40">
           <span className="truncate font-balance text-xs text-gray-500">
             {feeDisplay === FeeDisplay.TX_FEE && formatValue(tx.fee, 18)}
             {feeDisplay === FeeDisplay.TX_FEE_USD && (

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -51,79 +51,79 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
 
   return (
     <BlockNumberContext.Provider value={tx.blockNumber}>
-      <div
-        className={`grid grid-cols-12 items-baseline gap-x-1 border-t border-gray-200 text-sm ${
-          flash
-            ? "bg-amber-100 hover:bg-amber-200"
-            : "hover:bg-skin-table-hover"
-        } px-2 py-3`}
-      >
-        <span className="col-span-2">
+      <tr>
+        <td className="max-w-36">
           <TransactionLink
             txHash={tx.hash}
             fail={tx.status === 0}
             blob={tx.type === 3}
           />
-        </span>
-        {tx.to !== null ? (
-          <MethodName data={tx.data} to={tx.to} />
-        ) : (
-          <span></span>
-        )}
-        <span>
+        </td>
+        {/* Set min-w-36 to reduce changing column widths when methods of different lengths show*/}
+        <td className="max-w-24 min-w-24">
+          {tx.to !== null && <MethodName data={tx.data} to={tx.to} />}
+        </td>
+        <td className="max-w-28">
           <BlockLink blockTag={tx.blockNumber} />
-        </span>
-        <TimestampAge timestamp={tx.timestamp} />
-        <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
-          <span className="truncate">
-            {tx.from && (
-              <TransactionAddress
-                address={tx.from}
-                selectedAddress={selectedAddress}
-                miner={tx.miner === tx.from}
+        </td>
+        <td className="max-w-24">
+          <TimestampAge timestamp={tx.timestamp} />
+        </td>
+        <td className="max-w-48">
+          <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
+            <span className="truncate">
+              {tx.from && (
+                <TransactionAddress
+                  address={tx.from}
+                  selectedAddress={selectedAddress}
+                />
+              )}
+            </span>
+            <span>
+              <TransactionDirection
+                direction={undefined}
+                flags={sendsToMiner ? Flags.MINER : undefined}
               />
-            )}
+            </span>
           </span>
-          <span>
-            <TransactionDirection
-              direction={direction}
-              flags={sendsToMiner ? Flags.MINER : undefined}
-            />
+        </td>
+        <td className="max-w-48">
+          <span
+            className="col-span-2 flex items-baseline"
+            title={tx.to ?? tx.createdContractAddress}
+          >
+            <span className="truncate">
+              {tx.to ? (
+                <TransactionAddress
+                  address={tx.to}
+                  selectedAddress={selectedAddress}
+                  miner={tx.miner === tx.to}
+                  showCodeIndicator
+                />
+              ) : (
+                <TransactionAddress
+                  address={tx.createdContractAddress!}
+                  selectedAddress={selectedAddress}
+                  creation
+                  showCodeIndicator
+                />
+              )}
+            </span>
           </span>
-        </span>
-        <span
-          className="col-span-2 flex items-baseline"
-          title={tx.to ?? tx.createdContractAddress}
-        >
-          <span className="truncate">
-            {tx.to ? (
-              <TransactionAddress
-                address={tx.to}
-                selectedAddress={selectedAddress}
-                miner={tx.miner === tx.to}
-                showCodeIndicator
-              />
-            ) : (
-              <TransactionAddress
-                address={tx.createdContractAddress!}
-                selectedAddress={selectedAddress}
-                creation
-                showCodeIndicator
-              />
-            )}
-          </span>
-        </span>
-        <span className="col-span-2 truncate">
+        </td>
+        <td className="min-w-28 max-w-28">
           <NativeTokenAmount value={tx.value} />
-        </span>
-        <span className="truncate font-balance text-xs text-gray-500">
-          {feeDisplay === FeeDisplay.TX_FEE && formatValue(tx.fee, 18)}
-          {feeDisplay === FeeDisplay.TX_FEE_USD && (
-            <TransactionItemFiatFee blockTag={tx.blockNumber} fee={tx.fee} />
-          )}
-          {feeDisplay === FeeDisplay.GAS_PRICE && formatValue(tx.gasPrice, 9)}
-        </span>
-      </div>
+        </td>
+        <td className="min-w-24 max-w-24">
+          <span className="truncate font-balance text-xs text-gray-500">
+            {feeDisplay === FeeDisplay.TX_FEE && formatValue(tx.fee, 18)}
+            {feeDisplay === FeeDisplay.TX_FEE_USD && (
+              <TransactionItemFiatFee blockTag={tx.blockNumber} fee={tx.fee} />
+            )}
+            {feeDisplay === FeeDisplay.GAS_PRICE && formatValue(tx.gasPrice, 9)}
+          </span>
+        </td>
+      </tr>
     </BlockNumberContext.Provider>
   );
 };


### PR DESCRIPTION
Closes #291.

Uses `table-auto` and a combination of min width and max width classes to enable columns to expand as the viewport width increases. I specifically aimed to prevent column widths from changing when flipping pages.

The PendingResults component is no longer used. We should decide whether that animation should be used in PendingPage or not.