### PR TITLE
Add Dencun blob tx type

### DIFF
--- a/src/components/TransactionType.tsx
+++ b/src/components/TransactionType.tsx
@@ -25,6 +25,13 @@ const TransactionType: React.FC<TransactionTypeProps> = ({ type }) => {
         </ExternalLink>
       );
       break;
+    case 3:
+      description = (
+        <ExternalLink href="https://eips.ethereum.org/EIPS/eip-4844">
+          EIP-4844 (Blob)
+        </ExternalLink>
+      );
+      break;
     default:
       description = "unknown";
   }

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -341,7 +341,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
       >
         <TransactionType type={txData.type} />
       </InfoRow>
-      {txData.type === 2 && (
+      {(txData.type === 2 || txData.type === 3) && (
         <>
           <InfoRow title="Max Priority Fee Per Gas">
             <FormattedBalance

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -110,7 +110,7 @@ const blockTransactionsFetcher: Fetcher<
       }
 
       let effectiveGasPrice: bigint;
-      if (t.type === 2) {
+      if (t.type === 2 || t.type === 3) {
         const tip =
           t.maxFeePerGas! - _block.baseFeePerGas! < t.maxPriorityFeePerGas!
             ? t.maxFeePerGas! - _block.baseFeePerGas!

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -316,7 +316,9 @@ class Formatter {
     */
 
     if (
-      (transaction.type === 1 || transaction.type === 2) &&
+      (transaction.type === 1 ||
+        transaction.type === 2 ||
+        transaction.type === 3) &&
       transaction.accessList == null
     ) {
       transaction.accessList = [];


### PR DESCRIPTION
Part of #1727

This PR adds a link to EIP-4844 for type-3 transactions and shows relevant EIP-1559 fields:
![image](https://github.com/otterscan/otterscan/assets/125761775/4c21d6e4-abdb-4045-9547-a51301d6caf0)

I've saved the other Dencun work I've done for when we get better ethers support for type-3 transactions, which will appear in its next minor release.