### PR TITLE
Add error boundary component ErrorFallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-chartjs-2": "^5.2.0",
         "react-content-loader": "^6.2.1",
         "react-dom": "^18.2.0",
+        "react-error-boundary": "^4.0.12",
         "react-helmet-async": "^2.0.4",
         "react-image": "^4.1.0",
         "react-intersection-observer": "^9.5.3",
@@ -14227,6 +14228,17 @@
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
@@ -27196,6 +27208,14 @@
           "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
           "dev": true
         }
+      }
+    },
+    "react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-chartjs-2": "^5.2.0",
     "react-content-loader": "^6.2.1",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-helmet-async": "^2.0.4",
     "react-image": "^4.1.0",
     "react-intersection-observer": "^9.5.3",

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router-dom";
 import Header from "./Header";
+import ErrorFallback from "./components/ErrorFallback";
 import { SourcifySource } from "./sourcify/useSourcify";
 import { AppConfig, AppConfigContext } from "./useAppConfig";
 
@@ -18,7 +20,9 @@ const Main: React.FC = () => {
   return (
     <AppConfigContext.Provider value={appConfig}>
       <Header />
-      <Outlet />
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        <Outlet />
+      </ErrorBoundary>
     </AppConfigContext.Provider>
   );
 };

--- a/src/components/ErrorFallback.stories.tsx
+++ b/src/components/ErrorFallback.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from "@storybook/react";
+import ErrorFallback from "./ErrorFallback";
+
+const meta = {
+  component: ErrorFallback,
+} satisfies Meta<typeof ErrorFallback>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExampleError: Story = {
+  args: {
+    error: new Error("Example error"),
+  },
+};

--- a/src/components/ErrorFallback.tsx
+++ b/src/components/ErrorFallback.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { FallbackProps } from "react-error-boundary";
+import StandardSubtitle from "../components/StandardSubtitle";
+import ContentFrame from "./ContentFrame";
+import ExternalLink from "./ExternalLink";
+import StandardFrame from "./StandardFrame";
+
+const ErrorFallback: React.FC<FallbackProps> = ({ error }) => (
+  <StandardFrame>
+    <ContentFrame>
+      <div className="pt-2">
+        <StandardSubtitle>Something went wrong!</StandardSubtitle>
+      </div>
+
+      <div className="p-2">
+        <div className="text-lg pb-2">Otterscan encountered an error.</div>
+
+        <div>
+          Please help us fix this error by creating a new issue at{" "}
+          <ExternalLink href={"https://github.com/otterscan/otterscan/issues"}>
+            the Otterscan issue tracker
+          </ExternalLink>
+          . In the issue description, include both the network name/chain ID and
+          the following error trace:
+        </div>
+
+        <pre className="bg-red-100 text-xs mt-2 rounded p-2 border border-red-500 mb-2">
+          {document.location.pathname + "\n\n" + error.toString() + "\n\n"}
+
+          {error.stack}
+        </pre>
+      </div>
+    </ContentFrame>
+  </StandardFrame>
+);
+
+export default ErrorFallback;


### PR DESCRIPTION
Current look:
![image](https://github.com/otterscan/otterscan/assets/125761775/42849726-d70c-45a4-ab35-c9c3a2fa2902)

Because the position of the error boundary is above the react-router-dom outlet, navigation stops working after the error happens, i.e. you can only navigate to the home page. If this is a problem, I suppose we can add an error boundary to each page so the react-router navigation remains functional.

Closes #1750.