### PR TITLE
Show blob icon for blob txs in TransactionLink

### DIFF
--- a/src/components/TransactionLink.stories.tsx
+++ b/src/components/TransactionLink.stories.tsx
@@ -21,3 +21,10 @@ export const FailedTx: Story = {
     fail: true,
   },
 };
+
+export const BlobTx: Story = {
+  args: {
+    ...SimpleTx.args,
+    blob: true,
+  },
+};

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -1,6 +1,6 @@
 import {
   faExclamationCircle,
-  faMound,
+  faSplotch,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, memo } from "react";
@@ -22,7 +22,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
     )}
     {blob && (
       <span className="text-purple-400" title="Blob transaction">
-        <FontAwesomeIcon icon={faMound} />
+        <FontAwesomeIcon icon={faSplotch} />
       </span>
     )}
     <span className="truncate">

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -21,7 +21,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
       </span>
     )}
     {blob && (
-      <span className="text-pink-400" title="Blob transaction">
+      <span className="text-rose-400" title="Blob transaction">
         <FontAwesomeIcon icon={faSplotch} />
       </span>
     )}

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -1,4 +1,7 @@
-import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons";
+import {
+  faExclamationCircle,
+  faMound,
+} from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
@@ -7,13 +10,19 @@ import { transactionURL } from "../url";
 type TransactionLinkProps = {
   txHash: string;
   fail?: boolean;
+  blob?: boolean;
 };
 
-const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail }) => (
+const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
   <span className="flex-no-wrap flex space-x-1">
     {fail && (
       <span className="text-red-600" title="Transaction reverted">
         <FontAwesomeIcon icon={faExclamationCircle} />
+      </span>
+    )}
+    {blob && (
+      <span className="text-purple-400" title="Blob transaction">
+        <FontAwesomeIcon icon={faMound} />
       </span>
     )}
     <span className="truncate">

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -21,7 +21,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
       </span>
     )}
     {blob && (
-      <span className="text-purple-400" title="Blob transaction">
+      <span className="text-pink-400" title="Blob transaction">
         <FontAwesomeIcon icon={faSplotch} />
       </span>
     )}

--- a/src/execution/address/AddressERC20Results.tsx
+++ b/src/execution/address/AddressERC20Results.tsx
@@ -38,6 +38,7 @@ const AddressERC20Results: FC<AddressAwareComponentProps> = ({ address }) => {
           from: m.receipt.from,
           to: m.receipt.to,
           value: m.transaction.value,
+          type: m.transaction.type,
         }),
       ),
     [results],

--- a/src/execution/address/AddressERC721Results.tsx
+++ b/src/execution/address/AddressERC721Results.tsx
@@ -38,6 +38,7 @@ const AddressERC721Results: FC<AddressAwareComponentProps> = ({ address }) => {
           from: m.receipt.from,
           to: m.receipt.to,
           value: m.transaction.value,
+          type: m.transaction.type,
         }),
       ),
     [results],

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -18,6 +18,7 @@ export type ERC20ItemProps = AddressAwareComponentProps & {
   from: string | undefined;
   to: string | null;
   value: bigint;
+  type: number;
 };
 
 const ERC20Item: FC<ERC20ItemProps> = ({
@@ -30,12 +31,17 @@ const ERC20Item: FC<ERC20ItemProps> = ({
   from,
   to,
   value,
+  type,
 }) => {
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>
         <td>
-          <TransactionLink txHash={hash} fail={status === 0} />
+          <TransactionLink
+            txHash={hash}
+            fail={status === 0}
+            blob={type === 3}
+          />
         </td>
         <td>{to !== null && <MethodName data={data} to={to} />}</td>
         <td>

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -59,7 +59,11 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         } px-2 py-3`}
       >
         <span className="col-span-2">
-          <TransactionLink txHash={tx.hash} fail={tx.status === 0} />
+          <TransactionLink
+            txHash={tx.hash}
+            fail={tx.status === 0}
+            blob={tx.type === 3}
+          />
         </span>
         {tx.to !== null ? (
           <MethodName data={tx.data} to={tx.to} />

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -34,6 +34,7 @@ export const rawToProcessed = (provider: JsonRpcApiProvider, _rawRes: any) => {
         timestamp: formatter.number(_rawReceipt.timestamp),
         idx: _receipt.index,
         hash: t.hash,
+        type: t.type,
         from: t.from,
         to: t.to ?? null,
         createdContractAddress: _receipt.contractAddress ?? undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export type ProcessedTransaction = {
   to: string | null;
   createdContractAddress?: string;
   value: bigint;
+  type: number;
   fee: bigint;
   gasPrice: bigint;
   data: string;

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -130,6 +130,7 @@ const blockTransactionsFetcher: Fetcher<
         to: t.to ?? null,
         createdContractAddress: _receipt.contractAddress ?? undefined,
         value: t.value,
+        type: t.type,
         fee: formatter.bigInt(_receipt.gasUsed) * effectiveGasPrice,
         gasPrice: effectiveGasPrice,
         data: t.data,


### PR DESCRIPTION
Closes #1768

Currently, this uses the `text-purple-400` color as I proposed in #1768, but we can change it to blue:
![image](https://github.com/otterscan/otterscan/assets/125761775/3b15b652-9109-43cd-a09b-a0caded1db0d)
