### PR TITLE
Add blob details to transaction page

### DIFF
--- a/src/execution/Block.tsx
+++ b/src/execution/Block.tsx
@@ -150,6 +150,17 @@ const Block: FC = () => {
               <PercentageBar perc={gasUsedPerc!} />
             </div>
           </InfoRow>
+          {block.blobGasUsed !== null && block.blobGasUsed !== undefined && (
+            <InfoRow title="Blob Gas Used">
+              {block.blobGasUsed.toString()}
+            </InfoRow>
+          )}
+          {block.excessBlobGas !== null &&
+            block.excessBlobGas !== undefined && (
+              <InfoRow title="Excess Blob Gas">
+                {commify(block.excessBlobGas)}
+              </InfoRow>
+            )}
           <InfoRow title="Extra Data">
             {extraStr} (Hex:{" "}
             <span className="break-all font-data">{block.extraData}</span>)
@@ -169,12 +180,22 @@ const Block: FC = () => {
           <InfoRow title="Parent Hash">
             <BlockLink blockTag={block.parentHash} />
           </InfoRow>
+          {block.parentBeaconBlockRoot && (
+            <InfoRow title="Parent Beacon Block Root">
+              <HexValue value={block.parentBeaconBlockRoot} />
+            </InfoRow>
+          )}
           <InfoRow title="Sha3Uncles">
             <HexValue value={block.sha3Uncles} />
           </InfoRow>
-          <InfoRow title="StateRoot">
+          <InfoRow title="State Root">
             <HexValue value={block.stateRoot} />
           </InfoRow>
+          {block.receiptsRoot !== null && block.receiptsRoot !== undefined && (
+            <InfoRow title="Receipts Root">
+              <HexValue value={block.receiptsRoot} />
+            </InfoRow>
+          )}
           <InfoRow title="Nonce">
             <span className="font-data">{block.nonce}</span>
           </InfoRow>

--- a/src/execution/Block.tsx
+++ b/src/execution/Block.tsx
@@ -152,7 +152,7 @@ const Block: FC = () => {
           </InfoRow>
           {block.blobGasUsed !== null && block.blobGasUsed !== undefined && (
             <InfoRow title="Blob Gas Used">
-              {block.blobGasUsed.toString()}
+              {commify(block.blobGasUsed)}
             </InfoRow>
           )}
           {block.excessBlobGas !== null &&

--- a/src/execution/feeCalc.ts
+++ b/src/execution/feeCalc.ts
@@ -1,0 +1,65 @@
+import { TransactionData } from "../types";
+
+const feeTypes = ["blob", "burned", "tip"];
+type FeeType = (typeof feeTypes)[number];
+export function calculateFee(
+  txData: TransactionData,
+  block: { baseFeePerGas: bigint | null } | null | undefined,
+): { totalFees: bigint; feeDist: Record<FeeType, bigint> } {
+  // Require receipt
+  if (!txData.confirmedData || !block) {
+    return {
+      totalFees: 0n,
+      feeDist: feeTypes.reduce(
+        (obj: Partial<Record<FeeType, bigint>>, newType: FeeType) => {
+          obj[newType] = 0n;
+          return obj;
+        },
+        {} as Partial<Record<FeeType, bigint>>,
+      ) as Record<FeeType, bigint>,
+    };
+  }
+  const blobFee =
+    txData.confirmedData!.blobGasUsed && txData.confirmedData!.blobGasUsed
+      ? txData.confirmedData!.blobGasUsed! * txData.confirmedData!.blobGasPrice!
+      : 0n;
+  const paidFees = txData.gasPrice! * txData.confirmedData!.gasUsed;
+  const burntFees = block
+    ? block.baseFeePerGas! * txData.confirmedData!.gasUsed
+    : 0n;
+
+  const fees: Record<FeeType, bigint> = {
+    blob: blobFee,
+    burned: burntFees,
+    tip: paidFees - burntFees,
+  };
+  const totalFees = Object.values(fees).reduce((a, b) => a + b, 0n);
+
+  return {
+    totalFees,
+    feeDist: fees,
+  };
+}
+
+export function getFeePercents(
+  feeDist: Record<FeeType, bigint>,
+): Record<FeeType, number> {
+  const totalFees = Object.values(feeDist).reduce((a, b) => a + b, 0n);
+  if (totalFees === 0n) {
+    return feeTypes.reduce(
+      (obj: Partial<Record<FeeType, number>>, newType: FeeType) => {
+        obj[newType] = 0;
+        return obj;
+      },
+      {} as Partial<Record<FeeType, number>>,
+    ) as Record<FeeType, number>;
+  }
+  const feePerc: { [K in FeeType]: number } = Object.keys(feeDist).reduce(
+    (acc, key) => ({
+      ...acc,
+      [key]: Number((feeDist[key] * 10000n) / totalFees) / 100,
+    }),
+    {} as Partial<{ [K in FeeType]: number }>,
+  ) as { [K in FeeType]: number };
+  return feePerc;
+}

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -49,9 +49,9 @@ import {
   useTransactionError,
 } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
-import { calculateFee } from "../../utils/feeCalc";
 import { commify } from "../../utils/utils";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
+import { calculateFee } from "../feeCalc";
 import NavNonce from "./NavNonce";
 import RewardSplit from "./RewardSplit";
 import TokenTransferItem from "./TokenTransferItem";

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -459,16 +459,18 @@ const Details: FC<DetailsProps> = ({ txData }) => {
         )}
       {txData.blobVersionedHashes && (
         <InfoRow title="Blob Versioned Hashes">
-          {txData.blobVersionedHashes.map(
-            (blobVersionedHash: string, i: number) => (
-              <div key={i} className="flex items-baseline space-x-2">
-                <span className="font-hash" data-test="tx-hash">
-                  {blobVersionedHash}
-                </span>
-                <Copy value={blobVersionedHash} />
-              </div>
-            ),
-          )}
+          <div className="space-y-1">
+            {txData.blobVersionedHashes.map(
+              (blobVersionedHash: string, i: number) => (
+                <div key={i} className="flex items-baseline space-x-2">
+                  <span className="font-hash" data-test="tx-hash">
+                    {blobVersionedHash}
+                  </span>
+                  <Copy value={blobVersionedHash} />
+                </div>
+              ),
+            )}
+          </div>
         </InfoRow>
       )}
       {txData.confirmedData && (

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -49,6 +49,7 @@ import {
   useTransactionError,
 } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
+import { calculateFee } from "../../utils/feeCalc";
 import { commify } from "../../utils/utils";
 import TransactionAddressWithCopy from "../components/TransactionAddressWithCopy";
 import NavNonce from "./NavNonce";
@@ -115,6 +116,8 @@ const Details: FC<DetailsProps> = ({ txData }) => {
     : undefined;
   const [expanded, setExpanded] = useState<boolean>(false);
   const [showFunctionHelp, setShowFunctionHelp] = useState<boolean>(false);
+
+  const { totalFees } = calculateFee(txData, block);
 
   return (
     <ContentFrame tabs>
@@ -422,13 +425,59 @@ const Details: FC<DetailsProps> = ({ txData }) => {
           )
         </InfoRow>
       )}
+      {txData.maxFeePerBlobGas !== undefined && (
+        <InfoRow title="Max Fee Per Blob Gas">
+          <FormattedBalance value={txData.maxFeePerBlobGas!} symbol={symbol} />{" "}
+          (
+          <FormattedBalance
+            value={txData.maxFeePerBlobGas!}
+            decimals={9}
+            symbol="Gwei"
+          />
+          )
+        </InfoRow>
+      )}
+      {txData.confirmedData !== undefined &&
+        txData.confirmedData.blobGasPrice !== undefined && (
+          <InfoRow title="Blob Gas Price">
+            <div className="flex items-baseline space-x-1">
+              <span>
+                <FormattedBalance
+                  value={txData.confirmedData.blobGasPrice}
+                  symbol={symbol}
+                />{" "}
+                (
+                <FormattedBalance
+                  value={txData.confirmedData.blobGasPrice}
+                  decimals={9}
+                  symbol="Gwei"
+                />
+                )
+              </span>
+            </div>
+          </InfoRow>
+        )}
+      {txData.blobVersionedHashes && (
+        <InfoRow title="Blob Versioned Hashes">
+          {txData.blobVersionedHashes.map(
+            (blobVersionedHash: string, i: number) => (
+              <div key={i} className="flex items-baseline space-x-2">
+                <span className="font-hash" data-test="tx-hash">
+                  {blobVersionedHash}
+                </span>
+                <Copy value={blobVersionedHash} />
+              </div>
+            ),
+          )}
+        </InfoRow>
+      )}
       {txData.confirmedData && (
         <>
           <InfoRow title="Transaction Fee">
             <div className="space-y-3">
               <div>
                 <NativeTokenAmountAndFiat
-                  value={txData.confirmedData.fee}
+                  value={totalFees}
                   blockTag={txData.confirmedData.blockNumber}
                   {...feePreset}
                 />

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -7,7 +7,7 @@ import { TransactionData } from "../../types";
 import { useChainInfo } from "../../useChainInfo";
 import { useBlockDataFromTransaction } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
-import { calculateFee, getFeePercents } from "../../utils/feeCalc";
+import { calculateFee, getFeePercents } from "../feeCalc";
 
 type RewardSplitProps = {
   txData: TransactionData;

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -1,4 +1,4 @@
-import { faBurn, faCoins } from "@fortawesome/free-solid-svg-icons";
+import { faBurn, faCoins, faSplotch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useContext } from "react";
 import FormattedBalance from "../../components/FormattedBalance";
@@ -7,6 +7,7 @@ import { TransactionData } from "../../types";
 import { useChainInfo } from "../../useChainInfo";
 import { useBlockDataFromTransaction } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
+import { calculateFee, getFeePercents } from "../../utils/feeCalc";
 
 type RewardSplitProps = {
   txData: TransactionData;
@@ -20,20 +21,15 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
   const {
     nativeCurrency: { symbol },
   } = useChainInfo();
-  const paidFees = txData.gasPrice! * txData.confirmedData!.gasUsed;
-  const burntFees = block
-    ? block.baseFeePerGas! * txData.confirmedData!.gasUsed
-    : 0n;
 
-  const minerReward = paidFees - burntFees;
-  const burntPerc = Number((burntFees * 10000n) / paidFees) / 100;
-  const minerPerc = Math.round((100 - burntPerc) * 100) / 100;
+  const { totalFees, feeDist } = calculateFee(txData, block);
+  const feePerc = getFeePercents(feeDist);
 
   return (
     <div className="inline-block">
       <div className="grid grid-cols-2 items-center gap-x-2 gap-y-1 text-sm">
         <PercentageGauge
-          perc={burntPerc}
+          perc={feePerc.burned}
           bgColor="bg-orange-100"
           bgColorPerc="bg-orange-500"
           textColor="text-orange-800"
@@ -45,14 +41,14 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
             </span>
             <span>
               <span className="line-through">
-                <FormattedBalance value={burntFees} />
+                <FormattedBalance value={feeDist.burned} />
               </span>{" "}
               {symbol}
             </span>
           </span>
         </div>
         <PercentageGauge
-          perc={minerPerc}
+          perc={feePerc.tip}
           bgColor="bg-amber-100"
           bgColorPerc="bg-amber-300"
           textColor="text-amber-700"
@@ -63,10 +59,30 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
               <FontAwesomeIcon icon={faCoins} size="1x" />
             </span>
             <span>
-              <FormattedBalance value={minerReward} symbol={symbol} />
+              <FormattedBalance value={feeDist.tip} symbol={symbol} />
             </span>
           </span>
         </div>
+        {feeDist.blob > 0n && (
+          <>
+            <PercentageGauge
+              perc={feePerc.blob}
+              bgColor="bg-rose-100"
+              bgColorPerc="bg-rose-300"
+              textColor="text-rose-700"
+            />
+            <div className="flex items-baseline space-x-1">
+              <span className="flex space-x-1">
+                <span className="text-rose-300" title="Blob fee">
+                  <FontAwesomeIcon icon={faSplotch} size="1x" />
+                </span>
+                <span>
+                  <FormattedBalance value={feeDist.blob} symbol={symbol} />
+                </span>
+              </span>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export type TransactionData = {
   gasLimit: bigint;
   nonce: bigint;
   data: string;
+  maxFeePerBlobGas?: bigint | undefined;
+  blobVersionedHashes?: string[] | undefined;
   confirmedData?: ConfirmedTransactionData | undefined;
 };
 
@@ -59,6 +61,8 @@ export type ConfirmedTransactionData = {
   fee: bigint;
   gasUsed: bigint;
   logs: Log[];
+  blobGasPrice?: bigint;
+  blobGasUsed?: bigint;
 };
 
 // The VOID...

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -232,6 +232,8 @@ export const useTxData = (
           gasLimit: _response.gasLimit,
           nonce: BigInt(_response.nonce),
           data: _response.data,
+          maxFeePerBlobGas: _response.maxFeePerBlobGas ?? undefined,
+          blobVersionedHashes: _response.blobVersionedHashes ?? undefined,
           confirmedData:
             _receipt === null
               ? undefined
@@ -245,6 +247,8 @@ export const useTxData = (
                   fee: _response.gasPrice! * _receipt.gasUsed,
                   gasUsed: _receipt.gasUsed,
                   logs: Array.from(_receipt.logs),
+                  blobGasPrice: _receipt.blobGasPrice ?? undefined,
+                  blobGasUsed: _receipt.blobGasUsed ?? undefined,
                 },
         });
       } catch (err) {

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -46,6 +46,9 @@ class Formatter {
       transactions: Formatter.allowNull(Formatter.arrayOf(Formatter.hash), []),
 
       baseFeePerGas: Formatter.allowNull(Formatter.bigInt),
+
+      blobGasUsed: Formatter.allowNull(Formatter.bigInt, null),
+      excessBlobGas: Formatter.allowNull(Formatter.bigInt, null),
     },
     receipt: {
       to: Formatter.allowNull(Formatter.address, null),
@@ -67,6 +70,9 @@ class Formatter {
       effectiveGasPrice: Formatter.allowNull(Formatter.bigInt),
       status: Formatter.allowNull(Formatter.number, null),
       type: Formatter.number,
+
+      blobGasPrice: Formatter.allowNull(Formatter.bigInt),
+      blobGasUsed: Formatter.allowNull(Formatter.bigInt),
     },
     receiptLog: {
       transactionIndex: Formatter.number,
@@ -104,6 +110,12 @@ class Formatter {
       value: Formatter.bigInt,
       nonce: Formatter.number,
       data: Formatter.data,
+
+      maxFeePerBlobGas: Formatter.allowNull(Formatter.bigInt, null),
+      blobVersionedHashes: Formatter.allowNull(
+        Formatter.arrayOf(Formatter.hash),
+        null,
+      ),
 
       r: Formatter.allowNull(Formatter.uint256),
       s: Formatter.allowNull(Formatter.uint256),
@@ -352,27 +364,10 @@ class Formatter {
         chainId = BigInt(chainId);
       }
 
-      // TODO: v shouldn't exist on this type, so double check that removing this doesn't break anything
-      /*
-      if (typeof(chainId) !== "bigint" && result.v != null) {
-          chainId = (result.v - 35) / 2;
-          if (chainId < 0) { chainId = 0; }
-          chainId = parseInt(chainId);
-      }
-      */
-
       if (typeof chainId !== "bigint") {
         chainId = 0n;
       }
     }
-
-    // 0x0000... should actually be null
-    // TODO: Remove?
-    /*
-    if (result.blockHash && result.blockHash.replace(/0/g, "") === "x") {
-        result.blockHash = null;
-    }
-    */
 
     const signature = Signature.from({
       r: parsedTx.r,

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -41,6 +41,9 @@ class Formatter {
       miner: Formatter.address,
       extraData: Formatter.data,
 
+      receiptsRoot: Formatter.allowNull(Formatter.hash),
+      stateRoot: Formatter.allowNull(Formatter.hash),
+
       // TODO: Are there any situations where fetching only the block header
       // might cause ethers to believe the block has no transactions?
       transactions: Formatter.allowNull(Formatter.arrayOf(Formatter.hash), []),
@@ -49,6 +52,8 @@ class Formatter {
 
       blobGasUsed: Formatter.allowNull(Formatter.bigInt, null),
       excessBlobGas: Formatter.allowNull(Formatter.bigInt, null),
+
+      parentBeaconBlockRoot: Formatter.allowNull(Formatter.hash, null),
     },
     receipt: {
       to: Formatter.allowNull(Formatter.address, null),


### PR DESCRIPTION
Related: #1727 

Adds blob information to the transaction page and includes the blob fee in the transaction fee section. Note that the blob fee is not yet included in the Transaction Fee column yet for the address and block pages.

![image](https://github.com/otterscan/otterscan/assets/125761775/40ce4d08-7adc-4cda-b6ca-54bec0c4125f)

Closes #1756