### PR TITLE
Add address tags to address page title and subtitle

### DIFF
--- a/src/api/address-resolver/CompositeAddressResolver.ts
+++ b/src/api/address-resolver/CompositeAddressResolver.ts
@@ -1,14 +1,14 @@
 import { AbstractProvider } from "ethers";
-import { IAddressResolver } from "./address-resolver";
+import { AddressResolver } from "./address-resolver";
 
-export type SelectedResolvedName<T> = [IAddressResolver<T>, T] | null;
+export type SelectedResolvedName<T> = [AddressResolver<T>, T] | null;
 
 export class CompositeAddressResolver<T = any>
-  implements IAddressResolver<SelectedResolvedName<T>>
+  implements AddressResolver<SelectedResolvedName<T>>
 {
-  private resolvers: IAddressResolver<T>[] = [];
+  private resolvers: AddressResolver<T>[] = [];
 
-  addResolver(resolver: IAddressResolver<T>) {
+  addResolver(resolver: AddressResolver<T>) {
     this.resolvers.push(resolver);
   }
 
@@ -29,5 +29,23 @@ export class CompositeAddressResolver<T = any>
     }
 
     return null;
+  }
+
+  resolveToString(
+    resolvedAddress: SelectedResolvedName<T> | undefined,
+  ): string | undefined {
+    if (!resolvedAddress) {
+      return undefined;
+    }
+    return resolvedAddress[0].resolveToString(resolvedAddress[1]);
+  }
+
+  trusted(
+    resolvedAddress: SelectedResolvedName<T> | undefined,
+  ): boolean | undefined {
+    if (!resolvedAddress) {
+      return undefined;
+    }
+    return resolvedAddress[0].trusted(resolvedAddress[1]);
   }
 }

--- a/src/api/address-resolver/ENSAddressResolver.ts
+++ b/src/api/address-resolver/ENSAddressResolver.ts
@@ -1,7 +1,7 @@
 import { AbstractProvider } from "ethers";
-import { IAddressResolver } from "./address-resolver";
+import { BasicAddressResolver } from "./address-resolver";
 
-export class ENSAddressResolver implements IAddressResolver<string> {
+export class ENSAddressResolver extends BasicAddressResolver {
   async resolveAddress(
     provider: AbstractProvider,
     address: string,
@@ -11,5 +11,9 @@ export class ENSAddressResolver implements IAddressResolver<string> {
       return undefined;
     }
     return name;
+  }
+
+  trusted(resolvedAddress: string | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/ERCTokenResolver.ts
+++ b/src/api/address-resolver/ERCTokenResolver.ts
@@ -1,11 +1,11 @@
 import { AbstractProvider, Contract, ZeroAddress } from "ethers";
 import erc20 from "../../abi/erc20.json";
 import { TokenMeta } from "../../types";
-import { IAddressResolver } from "./address-resolver";
+import { AddressResolver } from "./address-resolver";
 
 const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
 
-export class ERCTokenResolver implements IAddressResolver<TokenMeta> {
+export class ERCTokenResolver implements AddressResolver<TokenMeta> {
   async resolveAddress(
     provider: AbstractProvider,
     address: string,
@@ -40,5 +40,16 @@ export class ERCTokenResolver implements IAddressResolver<TokenMeta> {
       // is not a token
     }
     return undefined;
+  }
+
+  resolveToString(resolvedAddress: TokenMeta | undefined): string | undefined {
+    if (resolvedAddress === undefined) {
+      return undefined;
+    }
+    return `${resolvedAddress.name} (${resolvedAddress.symbol})`;
+  }
+
+  trusted(resolvedAddress: TokenMeta | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/HardcodedAddressResolver.ts
+++ b/src/api/address-resolver/HardcodedAddressResolver.ts
@@ -1,9 +1,9 @@
 import { JsonRpcApiProvider } from "ethers";
-import { IAddressResolver } from "./address-resolver";
+import { BasicAddressResolver } from "./address-resolver";
 
 type HardcodedAddressMap = Record<string, string | undefined>;
 
-export class HardcodedAddressResolver implements IAddressResolver<string> {
+export class HardcodedAddressResolver extends BasicAddressResolver {
   async resolveAddress(
     provider: JsonRpcApiProvider,
     address: string,
@@ -18,5 +18,9 @@ export class HardcodedAddressResolver implements IAddressResolver<string> {
       // Ignore on purpose
       return undefined;
     }
+  }
+
+  trusted(resolvedAddress: string | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/UniswapV1Resolver.ts
+++ b/src/api/address-resolver/UniswapV1Resolver.ts
@@ -67,7 +67,7 @@ export class UniswapV1Resolver extends AddressResolver<UniswapV1PairMeta> {
     if (resolvedAddress === undefined) {
       return undefined;
     }
-    return "Uniswap V1: " + resolvedAddress.token.symbol;
+    return `Uniswap V1: ${resolvedAddress.token.symbol}`;
   }
 
   trusted(resolvedAddress: UniswapV1PairMeta | undefined): boolean | undefined {

--- a/src/api/address-resolver/UniswapV1Resolver.ts
+++ b/src/api/address-resolver/UniswapV1Resolver.ts
@@ -1,7 +1,7 @@
 import { AbstractProvider, Contract } from "ethers";
 import { ChecksummedAddress, TokenMeta } from "../../types";
 import { ERCTokenResolver } from "./ERCTokenResolver";
-import { IAddressResolver } from "./address-resolver";
+import { AddressResolver } from "./address-resolver";
 
 const UNISWAP_V1_FACTORY = "0xc0a47dFe034B400B47bDaD5FecDa2621de6c4d95";
 
@@ -27,7 +27,7 @@ export type UniswapV1PairMeta = {
 
 const ercResolver = new ERCTokenResolver();
 
-export class UniswapV1Resolver implements IAddressResolver<UniswapV1PairMeta> {
+export class UniswapV1Resolver extends AddressResolver<UniswapV1PairMeta> {
   async resolveAddress(
     provider: AbstractProvider,
     address: string,
@@ -59,5 +59,18 @@ export class UniswapV1Resolver implements IAddressResolver<UniswapV1PairMeta> {
       // is not a token
     }
     return undefined;
+  }
+
+  resolveToString(
+    resolvedAddress: UniswapV1PairMeta | undefined,
+  ): string | undefined {
+    if (resolvedAddress === undefined) {
+      return undefined;
+    }
+    return "Uniswap V1: " + resolvedAddress.token.symbol;
+  }
+
+  trusted(resolvedAddress: UniswapV1PairMeta | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/UniswapV2Resolver.ts
+++ b/src/api/address-resolver/UniswapV2Resolver.ts
@@ -97,7 +97,7 @@ export class UniswapV2Resolver extends AddressResolver<UniswapV2PairMeta> {
     if (resolvedAddress === undefined) {
       return undefined;
     }
-    return `Uniswap V2 LP (${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol})`;
+    return `Uniswap V2 LP: ${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol}`;
   }
 
   trusted(resolvedAddress: UniswapV2PairMeta | undefined): boolean | undefined {

--- a/src/api/address-resolver/UniswapV2Resolver.ts
+++ b/src/api/address-resolver/UniswapV2Resolver.ts
@@ -1,7 +1,7 @@
 import { AbstractProvider, Contract, ZeroAddress } from "ethers";
 import { ChecksummedAddress, TokenMeta } from "../../types";
 import { ERCTokenResolver } from "./ERCTokenResolver";
-import { IAddressResolver } from "./address-resolver";
+import { AddressResolver } from "./address-resolver";
 
 const UNISWAP_V2_FACTORY = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f";
 
@@ -37,7 +37,7 @@ export type UniswapV2PairMeta = {
 
 const ercResolver = new ERCTokenResolver();
 
-export class UniswapV2Resolver implements IAddressResolver<UniswapV2PairMeta> {
+export class UniswapV2Resolver extends AddressResolver<UniswapV2PairMeta> {
   async resolveAddress(
     provider: AbstractProvider,
     address: string,
@@ -89,5 +89,18 @@ export class UniswapV2Resolver implements IAddressResolver<UniswapV2PairMeta> {
       // is not a token
     }
     return undefined;
+  }
+
+  resolveToString(
+    resolvedAddress: UniswapV2PairMeta | undefined,
+  ): string | undefined {
+    if (resolvedAddress === undefined) {
+      return undefined;
+    }
+    return `Uniswap V2 LP (${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol})`;
+  }
+
+  trusted(resolvedAddress: UniswapV2PairMeta | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/UniswapV3Resolver.ts
+++ b/src/api/address-resolver/UniswapV3Resolver.ts
@@ -1,7 +1,7 @@
 import { AbstractProvider, Contract, ZeroAddress } from "ethers";
 import { ChecksummedAddress, TokenMeta } from "../../types";
 import { ERCTokenResolver } from "./ERCTokenResolver";
-import { IAddressResolver } from "./address-resolver";
+import { AddressResolver } from "./address-resolver";
 
 const UNISWAP_V3_FACTORY = "0x1F98431c8aD98523631AE4a59f267346ea31F984";
 
@@ -39,7 +39,7 @@ export type UniswapV3PairMeta = {
 
 const ercResolver = new ERCTokenResolver();
 
-export class UniswapV3Resolver implements IAddressResolver<UniswapV3PairMeta> {
+export class UniswapV3Resolver implements AddressResolver<UniswapV3PairMeta> {
   async resolveAddress(
     provider: AbstractProvider,
     address: string,
@@ -97,5 +97,18 @@ export class UniswapV3Resolver implements IAddressResolver<UniswapV3PairMeta> {
       // is not a token
     }
     return undefined;
+  }
+
+  resolveToString(
+    resolvedAddress: UniswapV3PairMeta | undefined,
+  ): string | undefined {
+    if (resolvedAddress === undefined) {
+      return undefined;
+    }
+    return `Uniswap V3 LP (${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol}/${Number(resolvedAddress.fee) / 10000}%)`;
+  }
+
+  trusted(resolvedAddress: UniswapV3PairMeta | undefined): boolean | undefined {
+    return true;
   }
 }

--- a/src/api/address-resolver/UniswapV3Resolver.ts
+++ b/src/api/address-resolver/UniswapV3Resolver.ts
@@ -105,7 +105,7 @@ export class UniswapV3Resolver implements AddressResolver<UniswapV3PairMeta> {
     if (resolvedAddress === undefined) {
       return undefined;
     }
-    return `Uniswap V3 LP (${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol}/${Number(resolvedAddress.fee) / 10000}%)`;
+    return `Uniswap V3 LP: ${resolvedAddress.token0.symbol}/${resolvedAddress.token1.symbol}/${Number(resolvedAddress.fee) / 10000}%`;
   }
 
   trusted(resolvedAddress: UniswapV3PairMeta | undefined): boolean | undefined {

--- a/src/api/address-resolver/address-resolver.ts
+++ b/src/api/address-resolver/address-resolver.ts
@@ -1,11 +1,20 @@
 import { AbstractProvider } from "ethers";
 import React from "react";
 
-export interface IAddressResolver<T> {
-  resolveAddress(
+export abstract class AddressResolver<T> {
+  abstract resolveAddress(
     provider: AbstractProvider,
     address: string,
   ): Promise<T | undefined>;
+
+  abstract resolveToString(resolvedAddress: T | undefined): string | undefined;
+  abstract trusted(resolvedAddress: T | undefined): boolean | undefined;
+}
+
+export abstract class BasicAddressResolver extends AddressResolver<string> {
+  resolveToString(resolvedAddress: string | undefined): string | undefined {
+    return resolvedAddress;
+  }
 }
 
 export type ResolvedAddressRenderer<T> = (

--- a/src/api/address-resolver/index.ts
+++ b/src/api/address-resolver/index.ts
@@ -14,7 +14,7 @@ import { HardcodedAddressResolver } from "./HardcodedAddressResolver";
 import { UniswapV1Resolver } from "./UniswapV1Resolver";
 import { UniswapV2Resolver } from "./UniswapV2Resolver";
 import { UniswapV3Resolver } from "./UniswapV3Resolver";
-import { IAddressResolver, ResolvedAddressRenderer } from "./address-resolver";
+import { AddressResolver, ResolvedAddressRenderer } from "./address-resolver";
 
 export type ResolvedAddresses = Record<string, SelectedResolvedName<any>>;
 
@@ -38,14 +38,14 @@ const _defaultResolver = new CompositeAddressResolver();
 _defaultResolver.addResolver(ercTokenResolver);
 _defaultResolver.addResolver(hardcodedResolver);
 
-const resolvers: Record<string, IAddressResolver<SelectedResolvedName<any>>> = {
+const resolvers: Record<string, AddressResolver<SelectedResolvedName<any>>> = {
   "1": _mainnetResolver,
   "0": _defaultResolver,
 };
 
 export const getResolver = (
   chainId: bigint,
-): IAddressResolver<SelectedResolvedName<any>> => {
+): AddressResolver<SelectedResolvedName<any>> => {
   const res = resolvers[chainId.toString()];
   if (res === undefined) {
     return resolvers["0"]; // default MAGIC NUMBER
@@ -54,7 +54,7 @@ export const getResolver = (
 };
 
 export const resolverRendererRegistry = new Map<
-  IAddressResolver<any>,
+  AddressResolver<any>,
   ResolvedAddressRenderer<any>
 >();
 resolverRendererRegistry.set(ensResolver, ensRenderer);

--- a/src/execution/address/AddressSubtitle.tsx
+++ b/src/execution/address/AddressSubtitle.tsx
@@ -31,7 +31,7 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
   let resolvedNameTrusted = resolvedAddress
     ? resolvedAddress[0].trusted(resolvedAddress[1])
     : undefined;
-  if (isENS) {
+  if (isENS && !resolvedName) {
     resolvedName = "ENS: " + addressOrName;
     resolvedNameTrusted = true;
   }

--- a/src/execution/address/AddressSubtitle.tsx
+++ b/src/execution/address/AddressSubtitle.tsx
@@ -1,9 +1,12 @@
+import { faTag } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, useContext } from "react";
 import Blockies from "react-blockies";
 import Copy from "../../components/Copy";
 import Faucet from "../../components/Faucet";
 import StandardSubtitle from "../../components/StandardSubtitle";
 import { useChainInfo } from "../../useChainInfo";
+import { useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
 import { AddressAwareComponentProps } from "../types";
 import AddressAttributes from "./AddressAttributes";
@@ -18,8 +21,20 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
   isENS,
   addressOrName,
 }) => {
-  const { config } = useContext(RuntimeContext);
+  const { config, provider } = useContext(RuntimeContext);
   const { faucets } = useChainInfo();
+
+  const resolvedAddress = useResolvedAddress(provider, address);
+  let resolvedName = resolvedAddress
+    ? resolvedAddress[0].resolveToString(resolvedAddress[1])
+    : undefined;
+  let resolvedNameTrusted = resolvedAddress
+    ? resolvedAddress[0].trusted(resolvedAddress[1])
+    : undefined;
+  if (isENS) {
+    resolvedName = "ENS: " + addressOrName;
+    resolvedNameTrusted = true;
+  }
 
   return (
     <StandardSubtitle>
@@ -39,12 +54,12 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
         <Copy value={address} rounded />
         {/* Only display faucets for testnets who actually have any */}
         {faucets && faucets.length > 0 && <Faucet address={address} rounded />}
-        {isENS && (
-          <span className="rounded-lg bg-gray-200 px-2 py-1 text-xs text-gray-500">
-            ENS: {addressOrName}
-          </span>
-        )}
         {config?.experimental && <AddressAttributes address={address} full />}
+        {resolvedName && resolvedNameTrusted && (
+          <div className="rounded-lg bg-gray-200 px-2 py-1 text-sm text-gray-500">
+            <FontAwesomeIcon icon={faTag} size="1x" /> {resolvedName}
+          </div>
+        )}
       </div>
     </StandardSubtitle>
   );

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -16,6 +16,7 @@ import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary
 import { ProcessedTransaction } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
 import { useAddressBalance, useContractCreator } from "../../useErigonHooks";
+import { useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
 import { usePageTitle } from "../../useTitle";
 import DecoratedAddressLink from "../components/DecoratedAddressLink";
@@ -33,8 +34,6 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   if (addressOrName === undefined) {
     throw new Error("addressOrName couldn't be undefined here");
   }
-
-  usePageTitle(`Address ${addressOrName}`);
 
   const [searchParams] = useSearchParams();
   const hash = searchParams.get("h");
@@ -100,6 +99,19 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   const balance = useAddressBalance(provider, address);
   const creator = useContractCreator(provider, address);
   const proxyAttributes = useProxyAttributes(provider, address);
+  const resolvedAddress = useResolvedAddress(provider, address);
+  const resolvedName = resolvedAddress
+    ? resolvedAddress[0].resolveToString(resolvedAddress[1])
+    : undefined;
+  const resolvedNameTrusted = resolvedAddress
+    ? resolvedAddress[0].trusted(resolvedAddress[1])
+    : undefined;
+
+  usePageTitle(
+    resolvedName && resolvedNameTrusted
+      ? `${resolvedName} | Address ${addressOrName}`
+      : `Address ${addressOrName}`,
+  );
 
   return (
     <ContentFrame tabs>


### PR DESCRIPTION
Closes #1650

Adds a resolved tag string to the page title and also to a "tag" bullet in the address subtitle:
![image](https://github.com/otterscan/otterscan/assets/125761775/d896a5a5-7bde-4fec-9043-e0ff3bcf698b)
