### PR TITLE
Add L1 attributes tx addresses

### DIFF
--- a/src/api/address-resolver/hardcoded-addresses/10.json
+++ b/src/api/address-resolver/hardcoded-addresses/10.json
@@ -1,0 +1,4 @@
+{
+  "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001": "L1: Attributes Depositor",
+  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeployed Contract"
+}

--- a/src/api/address-resolver/hardcoded-addresses/10.json
+++ b/src/api/address-resolver/hardcoded-addresses/10.json
@@ -1,4 +1,4 @@
 {
   "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001": "L1: Attributes Depositor",
-  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeployed Contract"
+  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeploy"
 }

--- a/src/api/address-resolver/hardcoded-addresses/11155420.json
+++ b/src/api/address-resolver/hardcoded-addresses/11155420.json
@@ -1,0 +1,4 @@
+{
+  "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001": "L1: Attributes Depositor",
+  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeployed Contract"
+}

--- a/src/api/address-resolver/hardcoded-addresses/11155420.json
+++ b/src/api/address-resolver/hardcoded-addresses/11155420.json
@@ -1,4 +1,4 @@
 {
   "0xDeaDDEaDDeAdDeAdDEAdDEaddeAddEAdDEAd0001": "L1: Attributes Depositor",
-  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeployed Contract"
+  "0x4200000000000000000000000000000000000015": "L1: Attributes Predeploy"
 }


### PR DESCRIPTION
Reference: https://specs.optimism.io/protocol/deposits.html#l1-attributes-deposited-transaction

Added for op-mainnet and op-sepolia. For other superchain chains it should be the same, but I didn't add now because (1) I don't have nodes for all of them in order to test (2) we should add more addresses as I'm studying the op-stack specs.