### PR TITLE
Add turn down symbol to Optimism L1 deposit transactions in list

### DIFF
--- a/src/components/TransactionLink.stories.tsx
+++ b/src/components/TransactionLink.stories.tsx
@@ -28,3 +28,10 @@ export const BlobTx: Story = {
     blob: true,
   },
 };
+
+export const DepositTx: Story = {
+  args: {
+    ...SimpleTx.args,
+    deposit: true,
+  },
+};

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -33,7 +33,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({
       </span>
     )}
     {deposit && (
-      <span className="text-gray-600" title="Deposit transaction">
+      <span className="text-emerald-600" title="Deposit transaction">
         <FontAwesomeIcon icon={faTurnDown} />
       </span>
     )}

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -1,6 +1,7 @@
 import {
   faExclamationCircle,
   faSplotch,
+  faTurnDown,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, memo } from "react";
@@ -11,9 +12,15 @@ type TransactionLinkProps = {
   txHash: string;
   fail?: boolean;
   blob?: boolean;
+  deposit?: boolean;
 };
 
-const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
+const TransactionLink: FC<TransactionLinkProps> = ({
+  txHash,
+  fail,
+  blob,
+  deposit = false,
+}) => (
   <span className="flex-no-wrap flex space-x-1">
     {fail && (
       <span className="text-red-600" title="Transaction reverted">
@@ -23,6 +30,11 @@ const TransactionLink: FC<TransactionLinkProps> = ({ txHash, fail, blob }) => (
     {blob && (
       <span className="text-rose-400" title="Blob transaction">
         <FontAwesomeIcon icon={faSplotch} />
+      </span>
+    )}
+    {deposit && (
+      <span className="text-gray-600" title="Deposit transaction">
+        <FontAwesomeIcon icon={faTurnDown} />
       </span>
     )}
     <span className="truncate">

--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -19,7 +19,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({
   txHash,
   fail,
   blob,
-  deposit = false,
+  deposit,
 }) => (
   <span className="flex-no-wrap flex space-x-1">
     {fail && (

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -41,6 +41,7 @@ const ERC20Item: FC<ERC20ItemProps> = ({
             txHash={hash}
             fail={status === 0}
             blob={type === 3}
+            deposit={type === 126}
           />
         </td>
         <td>{to !== null && <MethodName data={data} to={to} />}</td>

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -57,6 +57,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             txHash={tx.hash}
             fail={tx.status === 0}
             blob={tx.type === 3}
+            deposit={tx.type === 126}
           />
         </td>
         {/* Set both min and max widths to reduce column width changes when items of different lengths appear */}


### PR DESCRIPTION
Closes #1851 

Example:
![image](https://github.com/otterscan/otterscan/assets/125761775/0e38d5a8-30db-496b-b8c0-a22892fa1b9a)
