### PR TITLE
Restore bottom navbar in address transaction results

### DIFF
--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -173,6 +173,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
             <PendingPage rows={1} cols={8} />
           )}
         </StandardScrollableTable>
+        <NavBar address={address} page={page} controller={controller} />
       </StandardSelectionBoundary>
     </ContentFrame>
   );


### PR DESCRIPTION
Previously:
![image](https://github.com/otterscan/otterscan/assets/125761775/3bafe7b1-a64b-433c-b510-0226fb85f6f0)

Now:
![image](https://github.com/otterscan/otterscan/assets/125761775/055c04f3-5ff6-4497-95cd-2661b3caa6c0)
