### PR TITLE
Add token price resolvers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -99,3 +99,38 @@ Example:
   }
 }
 ```
+
+### Token price oracles
+
+Otterscan makes use of on-chain [Chainlink data feeds](https://docs.chain.link/data-feeds/price-feeds) for fetching historical price data from Chainlink smart contracts compatible with the [AggregatorV3 interface](https://docs.chain.link/data-feeds/api-reference) which act as price oracles. The native token price is fetched from a Chainlink data feed smart contract. The Ethereum mainnet has a registry which Otterscan uses to look up token prices for supported tokens. On other chains, and for tokens not in the registry, Otterscan can estimate a token's price using information from on-chain decentralized exchanges.
+
+**NOTE:** The prices estimated from on-chain decentralized exchanges can be manipulated, especially when tokens have low liquidity or are unable to be traded normally. This price estimation feature returns "best guess" prices; Otterscan certainly cannot guarantee that all tokens with an estimated price have a liquid market or that the prices shown are accurate.
+
+To configure Otterscan's price oracle usage, configure the `priceOracleInfo` key in the config:
+* `nativeTokenPrice`: If configured, shows the native token price at the top of the page.
+  * `ethUSDOracleAddress`: AggregatorV3-compatible smart contract that returns the price of the native token in USD. If Chainlink does not support your chain, you may consider deploying a smart contract which implements the AggregatorV3 interface yet derives price data from on-chain sources.
+  * `ethUSDOracleDecimals`: Number of decimals used by the oracle smart contract.
+* `wrappedEthAddress`: The address of the wrapped native token contract, which should match the WETH variable in Uniswap router contracts. This is used to estimate the price of tokens which have at least one Uniswap pool paired with the wrapped native token.
+* `uniswapV2`: If configured, uses UniswapV2 pairs as sources of price information.
+  * `factoryAddress`: The UniswapV2 factory address.
+* `uniswapV3`: If configured, uses UniswapV3 pools as sources of price information. Pools at the 0.01%, 0.05%, 0.3%, and 1% price tiers are queried.
+  * `factoryAddress`: The UniswapV3 factory address.
+
+Example for Ethereum mainnet:
+```json
+{
+  "priceOracleInfo": {
+    "nativeTokenPrice": {
+      "ethUSDOracleAddress": "0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419",
+      "ethUSDOracleDecimals": 8
+    },
+    "wrappedEthAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "uniswapV2": {
+      "factoryAddress": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
+    },
+    "uniswapV3": {
+      "factoryAddress": "0x1F98431c8aD98523631AE4a59f267346ea31F984"
+    }
+  }
+}
+```

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -44,7 +44,8 @@ const Header: FC = () => {
           </div>
         </div>
         <div className="flex items-baseline gap-x-3">
-          {provider?._network.chainId === 1n && (
+          {(provider?._network.chainId === 1n ||
+            config?.priceOracleInfo?.chainlink?.ethUSDOracleAddress) && (
             <div className="hidden lg:inline">
               <PriceBox />
             </div>

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -45,7 +45,7 @@ const Header: FC = () => {
         </div>
         <div className="flex items-baseline gap-x-3">
           {(provider?._network.chainId === 1n ||
-            config?.priceOracleInfo?.chainlink?.ethUSDOracleAddress) && (
+            config?.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleAddress) && (
             <div className="hidden lg:inline">
               <PriceBox />
             </div>

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -1,13 +1,16 @@
 import { faGasPump } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { formatUnits } from "ethers";
+import { FixedNumber } from "ethers";
 import React, { useContext, useMemo } from "react";
 import { formatValue } from "./components/formatter";
 import { useChainInfo } from "./useChainInfo";
 import { useLatestBlockHeader } from "./useLatestBlock";
-import { useETHUSDRawOracle, useFastGasRawOracle } from "./usePriceOracle";
+import {
+  formatFiatValue,
+  useETHUSDRawOracle,
+  useFastGasRawOracle,
+} from "./usePriceOracle";
 import { RuntimeContext } from "./useRuntime";
-import { commify } from "./utils/utils";
 
 // TODO: encapsulate this magic number
 const ETH_FEED_DEFAULT_DECIMALS = 8n;
@@ -29,15 +32,13 @@ const PriceBox: React.FC = () => {
       return [undefined, undefined];
     }
 
-    const price: bigint =
-      latestPriceData.answer /
-      10n **
-        (BigInt(
-          config?.priceOracleInfo?.chainlink?.ethUSDOracleDecimals ??
-            ETH_FEED_DEFAULT_DECIMALS,
-        ) -
-          2n);
-    const formattedPrice = commify(formatUnits(price, 2));
+    const priceDecimals =
+      config?.priceOracleInfo?.chainlink?.ethUSDOracleDecimals ??
+      ETH_FEED_DEFAULT_DECIMALS;
+    const formattedPrice = formatFiatValue(
+      FixedNumber.fromValue(latestPriceData.answer, priceDecimals),
+      2,
+    );
 
     const timestamp = new Date(Number(latestPriceData.updatedAt) * 1000);
     return [formattedPrice, timestamp];

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -33,7 +33,7 @@ const PriceBox: React.FC = () => {
     }
 
     const priceDecimals =
-      config?.priceOracleInfo?.chainlink?.ethUSDOracleDecimals ??
+      config?.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleDecimals ??
       ETH_FEED_DEFAULT_DECIMALS;
     const formattedPrice = formatFiatValue(
       FixedNumber.fromValue(latestPriceData.answer, priceDecimals),

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -10,10 +10,10 @@ import { RuntimeContext } from "./useRuntime";
 import { commify } from "./utils/utils";
 
 // TODO: encapsulate this magic number
-const ETH_FEED_DECIMALS = 8n;
+const ETH_FEED_DEFAULT_DECIMALS = 8n;
 
 const PriceBox: React.FC = () => {
-  const { provider } = useContext(RuntimeContext);
+  const { config, provider } = useContext(RuntimeContext);
   const {
     nativeCurrency: { symbol },
   } = useChainInfo();
@@ -30,7 +30,13 @@ const PriceBox: React.FC = () => {
     }
 
     const price: bigint =
-      latestPriceData.answer / 10n ** (ETH_FEED_DECIMALS - 2n);
+      latestPriceData.answer /
+      10n **
+        (BigInt(
+          config?.priceOracleInfo?.chainlink?.ethUSDOracleDecimals ??
+            ETH_FEED_DEFAULT_DECIMALS,
+        ) -
+          2n);
     const formattedPrice = commify(formatUnits(price, 2));
 
     const timestamp = new Date(Number(latestPriceData.updatedAt) * 1000);

--- a/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
@@ -15,7 +15,7 @@ export default class UniswapV2PriceResolver implements TokenPriceResolver {
     referenceTokenAddress: string,
     targetTokenAddress: string,
     blockTag: BlockTag = "latest",
-  ): Promise<bigint | undefined> {
+  ): Promise<{ price: bigint; confidence: bigint } | undefined> {
     const factoryAbi = [
       "function getPair(address tokenA, address tokenB) view returns (address pair)",
     ];
@@ -54,8 +54,11 @@ export default class UniswapV2PriceResolver implements TokenPriceResolver {
       // Not enough liquidity
       return undefined;
     }
-    return (
-      (10n ** 18n * reserves[1 - targetTokenIndex]) / reserves[targetTokenIndex]
-    );
+    return {
+      price:
+        (10n ** 18n * reserves[1 - targetTokenIndex]) /
+        reserves[targetTokenIndex],
+      confidence: reserves[1 - targetTokenIndex],
+    };
   }
 }

--- a/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
@@ -1,9 +1,10 @@
 import { AbstractProvider, BlockTag, Contract } from "ethers";
-import { TokenPriceResolver } from "../token-price-resolver";
+import { PriceOracleSource, TokenPriceResolver } from "../token-price-resolver";
 
 export default class UniswapV2PriceResolver implements TokenPriceResolver {
   factoryAddress: string;
   minEthInPool: bigint;
+  source: PriceOracleSource = "Uniswap";
 
   constructor(factoryAddress: string, minEthInPool: bigint = 10n ** 17n) {
     this.factoryAddress = factoryAddress;

--- a/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
@@ -43,7 +43,7 @@ export default class UniswapV2PriceResolver implements TokenPriceResolver {
 
     let reserves: [bigint, bigint];
     try {
-      reserves = await pairContract["getReserves"]({ blockTag });
+      reserves = await pairContract.getReserves({ blockTag });
     } catch (err) {
       return undefined;
     }

--- a/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV2PriceResolver.ts
@@ -1,0 +1,61 @@
+import { AbstractProvider, BlockTag, Contract } from "ethers";
+import { TokenPriceResolver } from "../token-price-resolver";
+
+export default class UniswapV2PriceResolver implements TokenPriceResolver {
+  factoryAddress: string;
+  minEthInPool: bigint;
+
+  constructor(factoryAddress: string, minEthInPool: bigint = 10n ** 17n) {
+    this.factoryAddress = factoryAddress;
+    this.minEthInPool = minEthInPool;
+  }
+
+  async resolveTokenPrice(
+    provider: AbstractProvider,
+    referenceTokenAddress: string,
+    targetTokenAddress: string,
+    blockTag: BlockTag = "latest",
+  ): Promise<bigint | undefined> {
+    const factoryAbi = [
+      "function getPair(address tokenA, address tokenB) view returns (address pair)",
+    ];
+    const factoryContract = new Contract(
+      this.factoryAddress,
+      factoryAbi,
+      provider,
+    );
+
+    let pairAddress;
+    try {
+      pairAddress = await factoryContract.getPair(
+        targetTokenAddress,
+        referenceTokenAddress,
+      );
+    } catch (err) {
+      return undefined;
+    }
+
+    const abiPair = [
+      "function getReserves() view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)",
+    ];
+
+    const pairContract = new Contract(pairAddress, abiPair, provider);
+
+    let reserves: [bigint, bigint];
+    try {
+      reserves = await pairContract["getReserves"]({ blockTag });
+    } catch (err) {
+      return undefined;
+    }
+
+    const targetTokenIndex =
+      BigInt(targetTokenAddress) < BigInt(referenceTokenAddress) ? 0 : 1;
+    if (reserves[1 - targetTokenIndex] < this.minEthInPool) {
+      // Not enough liquidity
+      return undefined;
+    }
+    return (
+      (10n ** 18n * reserves[1 - targetTokenIndex]) / reserves[targetTokenIndex]
+    );
+  }
+}

--- a/src/api/token-price-resolver/resolvers/UniswapV3PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV3PriceResolver.ts
@@ -1,0 +1,120 @@
+import { AbstractProvider, BlockTag, Contract, ZeroAddress } from "ethers";
+import erc20 from "../../../abi/erc20.json";
+import { TokenPriceResolver } from "../token-price-resolver";
+
+const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
+
+export default class UniswapV3PriceResolver implements TokenPriceResolver {
+  factoryAddress: string;
+  minEthInPool: bigint;
+
+  constructor(factoryAddress: string, minEthInPool: bigint = 10n ** 17n) {
+    this.factoryAddress = factoryAddress;
+    this.minEthInPool = minEthInPool;
+  }
+
+  async resolveTokenPrice(
+    provider: AbstractProvider,
+    referenceTokenAddress: string,
+    targetTokenAddress: string,
+    blockTag: BlockTag = "latest",
+  ): Promise<{ price: bigint; confidence: bigint } | undefined> {
+    const factoryAbi = [
+      "function getPool(address tokenA, address tokenB, uint24 feeTier) view returns (address pair)",
+    ];
+    const factoryContract = new Contract(
+      this.factoryAddress,
+      factoryAbi,
+      provider,
+    );
+
+    let poolAddresses: string[];
+    try {
+      poolAddresses = await Promise.all(
+        [100n, 500n, 3000n, 10000n].map((feeTier) =>
+          factoryContract.getPool(
+            targetTokenAddress,
+            referenceTokenAddress,
+            feeTier,
+            { blockTag },
+          ),
+        ),
+      );
+      poolAddresses = poolAddresses.filter(
+        (poolAddress) =>
+          poolAddress !== "0x0000000000000000000000000000000000000000",
+      );
+    } catch (err) {
+      return undefined;
+    }
+
+    const abiPool = [
+      "function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint8 feeProtocol, bool unlocked)",
+    ];
+
+    const poolContracts = poolAddresses.map(
+      (poolAddress) => new Contract(poolAddress, abiPool, provider),
+    );
+
+    let sqrtPriceX96s: bigint[];
+    try {
+      sqrtPriceX96s = await Promise.all(
+        poolContracts.map((poolContract) => poolContract.slot0({ blockTag })),
+      ).then((slot0Values) =>
+        slot0Values.map((slot0Value) => slot0Value.sqrtPriceX96),
+      );
+    } catch (err) {
+      return undefined;
+    }
+
+    // Use whichever pool has the most reference tokens available, regardless of positions.
+    // This approach may include pools with no available liquidity if all positions fall outside
+    // the actual token price.
+    const referenceToken = ERC20_PROTOTYPE.connect(provider).attach(
+      referenceTokenAddress,
+    ) as Contract;
+    let refTokenLiquidity: bigint[];
+    try {
+      refTokenLiquidity = await Promise.all(
+        poolAddresses.map((poolAddress) =>
+          referenceToken.balanceOf(poolAddress),
+        ),
+      );
+    } catch (err) {
+      return undefined;
+    }
+
+    if (refTokenLiquidity.length === 0) {
+      return undefined;
+    }
+
+    const findLargestValue = (arr: bigint[]): [number, bigint] =>
+      arr.reduce(
+        (acc, cur, idx) => (cur > acc[1] ? [idx, cur] : acc),
+        [0, -1n],
+      );
+    const [largestIndex, largestLiquidity]: [number, bigint] =
+      findLargestValue(refTokenLiquidity);
+
+    if (largestLiquidity < this.minEthInPool) {
+      return undefined;
+    }
+
+    const targetTokenIndex =
+      BigInt(targetTokenAddress) < BigInt(referenceTokenAddress) ? 0 : 1;
+    // sqrtPriceX96 = (x / y)^0.5 / 2^96, so (x / y) = sqrtPriceX96^2 / (2^96)^2
+    if (targetTokenIndex === 0) {
+      return {
+        price:
+          (10n ** 18n * sqrtPriceX96s[largestIndex] ** 2n) / 2n ** (96n * 2n),
+        confidence: largestLiquidity / 2n,
+      };
+    } else {
+      return {
+        price:
+          (10n ** 18n * 2n ** (96n * 2n)) / sqrtPriceX96s[largestIndex] ** 2n,
+        confidence: largestLiquidity / 2n,
+      };
+    }
+  }
+}

--- a/src/api/token-price-resolver/resolvers/UniswapV3PriceResolver.ts
+++ b/src/api/token-price-resolver/resolvers/UniswapV3PriceResolver.ts
@@ -1,12 +1,13 @@
 import { AbstractProvider, BlockTag, Contract, ZeroAddress } from "ethers";
 import erc20 from "../../../abi/erc20.json";
-import { TokenPriceResolver } from "../token-price-resolver";
+import { PriceOracleSource, TokenPriceResolver } from "../token-price-resolver";
 
 const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
 
 export default class UniswapV3PriceResolver implements TokenPriceResolver {
   factoryAddress: string;
   minEthInPool: bigint;
+  source: PriceOracleSource = "Uniswap";
 
   constructor(factoryAddress: string, minEthInPool: bigint = 10n ** 17n) {
     this.factoryAddress = factoryAddress;

--- a/src/api/token-price-resolver/token-price-resolver.ts
+++ b/src/api/token-price-resolver/token-price-resolver.ts
@@ -6,13 +6,15 @@ export abstract class TokenPriceResolver {
    * @param provider - The provider to the make calls
    * @param referenceTokenAddress - Token address of the reference token, e.g. WETH
    * @param targetTokenAddress - Token address for which we want to fetch price data
-   * @returns A promise resolving into a bigint representing the reference token value of 1e18 units of the target token,
-     or undefined if no such price can be calculated.
+   * @returns A promise resolving into an object containing price, a bigint representing
+     the reference token value of 1e18 units of the target token, and confidence, a
+     measure of the estimated amount of pair liquidity in the pool to back the price.
+     If no such price can be calculated, promise instead resolves to undefined.
    */
   abstract resolveTokenPrice(
     provider: AbstractProvider,
     referenceTokenAddress: string,
     targetTokenAddress: string,
     blockTag?: BlockTag,
-  ): Promise<bigint | undefined>;
+  ): Promise<{ price: bigint; confidence: bigint } | undefined>;
 }

--- a/src/api/token-price-resolver/token-price-resolver.ts
+++ b/src/api/token-price-resolver/token-price-resolver.ts
@@ -1,0 +1,18 @@
+import { AbstractProvider, BlockTag } from "ethers";
+
+export abstract class TokenPriceResolver {
+  /**
+   * Fetches the current token price in the reference token per 1e18 of the target token
+   * @param provider - The provider to the make calls
+   * @param referenceTokenAddress - Token address of the reference token, e.g. WETH
+   * @param targetTokenAddress - Token address for which we want to fetch price data
+   * @returns A promise resolving into a bigint representing the reference token value of 1e18 units of the target token,
+     or undefined if no such price can be calculated.
+   */
+  abstract resolveTokenPrice(
+    provider: AbstractProvider,
+    referenceTokenAddress: string,
+    targetTokenAddress: string,
+    blockTag?: BlockTag,
+  ): Promise<bigint | undefined>;
+}

--- a/src/api/token-price-resolver/token-price-resolver.ts
+++ b/src/api/token-price-resolver/token-price-resolver.ts
@@ -1,5 +1,7 @@
 import { AbstractProvider, BlockTag } from "ethers";
 
+export type PriceOracleSource = "Chainlink" | "Uniswap" | "Equivalence";
+
 export abstract class TokenPriceResolver {
   /**
    * Fetches the current token price in the reference token per 1e18 of the target token
@@ -17,4 +19,7 @@ export abstract class TokenPriceResolver {
     targetTokenAddress: string,
     blockTag?: BlockTag,
   ): Promise<{ price: bigint; confidence: bigint } | undefined>;
+
+  // Indicates where the price data came from
+  public abstract readonly source: PriceOracleSource;
 }

--- a/src/components/FiatValue.tsx
+++ b/src/components/FiatValue.tsx
@@ -1,5 +1,6 @@
 import { FixedNumber } from "ethers";
 import { FC, memo } from "react";
+import { PriceOracleSource } from "../api/token-price-resolver/token-price-resolver";
 import { formatFiatValue } from "../usePriceOracle";
 
 const DEFAULT_DECIMALS = 2;
@@ -33,6 +34,25 @@ export const rewardPreset = {
   bgColor: "bg-amber-100",
   fgColor: "text-amber-600",
 } satisfies FiatBoxProps;
+
+export const uniswapPreset = {
+  borderColor: "border-fuchsia-200",
+  bgColor: "bg-fuchsia-100",
+  fgColor: "text-fuchsia-600",
+} satisfies FiatBoxProps;
+
+export function getPriceOraclePreset(
+  source: PriceOracleSource | undefined,
+): FiatBoxProps {
+  switch (source) {
+    case "Chainlink":
+    case "Equivalence":
+      return neutralPreset;
+    case "Uniswap":
+      return uniswapPreset;
+  }
+  return neutralPreset;
+}
 
 type FiatValueProps = FiatBoxProps & {
   value: FixedNumber;

--- a/src/components/InternalTransfer.tsx
+++ b/src/components/InternalTransfer.tsx
@@ -34,10 +34,8 @@ const InternalTransfer: FC<InternalTransferProps> = ({
     block?.miner !== undefined && internalOp.from === block.miner;
   const toMiner = block?.miner !== undefined && internalOp.to === block.miner;
 
-  const blockETHUSDPrice: bigint | undefined = useETHUSDOracle(
-    provider,
-    txData.confirmedData?.blockNumber,
-  );
+  const { price: blockETHUSDPrice, decimals: ethPriceDecimals } =
+    useETHUSDOracle(provider, txData.confirmedData?.blockNumber);
   const fromHasCode = useHasCode(
     provider,
     internalOp.from,
@@ -106,8 +104,7 @@ const InternalTransfer: FC<InternalTransferProps> = ({
               amount={internalOp.value}
               amountDecimals={decimals}
               quote={blockETHUSDPrice}
-              // TODO: migrate to SWR and standardize this magic number
-              quoteDecimals={8}
+              quoteDecimals={Number(ethPriceDecimals)}
             />
           )}
         </div>

--- a/src/components/USDAmount.tsx
+++ b/src/components/USDAmount.tsx
@@ -26,7 +26,7 @@ const USDAmount: FC<USDAmountProps> = ({
   const fiatAmount = FixedNumber.fromValue(
     value,
     decimals,
-    `ufixed256x${decimals}`,
+    `ufixed512x${decimals}`,
   );
 
   return <FiatValue value={fiatAmount} {...neutralPreset} />;

--- a/src/components/USDAmount.tsx
+++ b/src/components/USDAmount.tsx
@@ -1,12 +1,13 @@
 import { FixedNumber } from "ethers";
 import { FC, memo } from "react";
-import FiatValue, { neutralPreset } from "./FiatValue";
+import FiatValue, { FiatBoxProps, neutralPreset } from "./FiatValue";
 
 type USDAmountProps = {
   amount: bigint;
   amountDecimals: number;
   quote: bigint;
   quoteDecimals: number;
+  colorScheme?: FiatBoxProps;
 };
 
 // TODO: fix the duplication mess with other currency display components
@@ -20,6 +21,7 @@ const USDAmount: FC<USDAmountProps> = ({
   amountDecimals,
   quote,
   quoteDecimals,
+  colorScheme = neutralPreset,
 }) => {
   const value = amount * quote;
   const decimals = amountDecimals + quoteDecimals;
@@ -29,7 +31,7 @@ const USDAmount: FC<USDAmountProps> = ({
     `ufixed512x${decimals}`,
   );
 
-  return <FiatValue value={fiatAmount} {...neutralPreset} />;
+  return <FiatValue value={fiatAmount} {...colorScheme} />;
 };
 
 export default memo(USDAmount);

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -20,7 +20,12 @@ const TokenBalance: FC<TokenBalanceProps> = ({
   const { provider } = useContext(RuntimeContext);
   const balance = useTokenBalance(provider, holderAddress, tokenAddress);
   const metadata = useTokenMetadata(provider, tokenAddress);
-  const [quote, decimals] = useTokenUSDOracle(provider, "latest", tokenAddress);
+  const [quote, decimals] = useTokenUSDOracle(
+    provider,
+    "latest",
+    tokenAddress,
+    metadata?.decimals !== undefined ? BigInt(metadata?.decimals) : undefined,
+  );
 
   return (
     <tr>

--- a/src/execution/address/TokenBalance.tsx
+++ b/src/execution/address/TokenBalance.tsx
@@ -1,4 +1,5 @@
 import { FC, useContext } from "react";
+import { getPriceOraclePreset } from "../../components/FiatValue";
 import USDAmount from "../../components/USDAmount";
 import { useTokenBalance } from "../../ots2/usePrototypeTransferHooks";
 import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
@@ -20,7 +21,11 @@ const TokenBalance: FC<TokenBalanceProps> = ({
   const { provider } = useContext(RuntimeContext);
   const balance = useTokenBalance(provider, holderAddress, tokenAddress);
   const metadata = useTokenMetadata(provider, tokenAddress);
-  const [quote, decimals] = useTokenUSDOracle(
+  const {
+    price: quote,
+    decimals,
+    source: priceSource,
+  } = useTokenUSDOracle(
     provider,
     "latest",
     tokenAddress,
@@ -48,7 +53,8 @@ const TokenBalance: FC<TokenBalanceProps> = ({
               amount={balance}
               amountDecimals={metadata.decimals}
               quote={quote}
-              quoteDecimals={decimals}
+              quoteDecimals={Number(decimals ?? 0)}
+              colorScheme={getPriceOraclePreset(priceSource)}
             />
           )}
       </td>

--- a/src/execution/transaction/TokenTransferItem.tsx
+++ b/src/execution/transaction/TokenTransferItem.tsx
@@ -17,8 +17,15 @@ type TokenTransferItemProps = {
 const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
   const { provider } = useContext(RuntimeContext);
   const blockNumber = useBlockNumberContext();
-  const [quote, decimals] = useTokenUSDOracle(provider, blockNumber, t.token);
   const tokenMeta = useTokenMetadata(provider, t.token);
+  const [quote, decimals] = useTokenUSDOracle(
+    provider,
+    blockNumber !== undefined && typeof blockNumber === "number"
+      ? blockNumber - 1
+      : blockNumber,
+    t.token,
+    tokenMeta?.decimals !== undefined ? BigInt(tokenMeta?.decimals) : undefined,
+  );
 
   return (
     <div className="flex items-baseline space-x-2 truncate px-2 py-1 hover:bg-gray-100">

--- a/src/execution/transaction/TokenTransferItem.tsx
+++ b/src/execution/transaction/TokenTransferItem.tsx
@@ -18,6 +18,9 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
   const { provider } = useContext(RuntimeContext);
   const blockNumber = useBlockNumberContext();
   const tokenMeta = useTokenMetadata(provider, t.token);
+  // NOTE: Prices are estimated from the previous block so as not to skew the
+  // estimate in favor of future price movements within this block, including
+  // those possibly coming from this transaction.
   const [quote, decimals] = useTokenUSDOracle(
     provider,
     blockNumber !== undefined && typeof blockNumber === "number"

--- a/src/execution/transaction/TokenTransferItem.tsx
+++ b/src/execution/transaction/TokenTransferItem.tsx
@@ -1,6 +1,7 @@
 import { faCaretRight, faSackDollar } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, memo, useContext } from "react";
+import { getPriceOraclePreset } from "../../components/FiatValue";
 import USDAmount from "../../components/USDAmount";
 import FormattedBalanceHighlighter from "../../selection/FormattedBalanceHighlighter";
 import { AddressContext, TokenTransfer } from "../../types";
@@ -21,7 +22,11 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
   // NOTE: Prices are estimated from the previous block so as not to skew the
   // estimate in favor of future price movements within this block, including
   // those possibly coming from this transaction.
-  const [quote, decimals] = useTokenUSDOracle(
+  const {
+    price: quote,
+    decimals,
+    source: priceSource,
+  } = useTokenUSDOracle(
     provider,
     blockNumber !== undefined && typeof blockNumber === "number"
       ? blockNumber - 1
@@ -66,7 +71,8 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
               amount={t.value}
               amountDecimals={tokenMeta.decimals}
               quote={quote}
-              quoteDecimals={decimals}
+              quoteDecimals={Number(decimals ?? 0)}
+              colorScheme={getPriceOraclePreset(priceSource)}
             />
           )}
         </div>

--- a/src/search/TransactionItemFiatFee.tsx
+++ b/src/search/TransactionItemFiatFee.tsx
@@ -14,10 +14,13 @@ const TransactionItemFiatFee: React.FC<TransactionItemFiatFeeProps> = ({
   fee,
 }) => {
   const { provider } = useContext(RuntimeContext);
-  const eth2USDValue = useETHUSDOracle(provider, blockTag);
+  const { price: eth2USDValue, decimals: ethPriceDecimals } = useETHUSDOracle(
+    provider,
+    blockTag,
+  );
   const fiatValue =
     eth2USDValue !== undefined
-      ? (fee * eth2USDValue) / 100_000_000n
+      ? (fee * eth2USDValue) / 10n ** ethPriceDecimals
       : undefined;
 
   return fiatValue ? (

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -41,6 +41,17 @@ export type ChainInfo = {
   };
 };
 
+export type PriceOracleInfo = {
+  chainlink?: {
+    ethUSDOracleAddress: string;
+    ethUSDOracleDecimals: number;
+  };
+  wrappedEthAddress?: string;
+  uniswapV2?: {
+    factoryAddress: string;
+  };
+};
+
 export const defaultChainInfo: ChainInfo = {
   name: "",
   faucets: [],
@@ -116,6 +127,8 @@ export type OtterscanConfig = {
    * "central_server" whose values are their respective root URLs.
    */
   sourcifySources?: { [key: string]: string };
+
+  priceOracleInfo?: PriceOracleInfo;
 };
 
 /**

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -41,15 +41,53 @@ export type ChainInfo = {
   };
 };
 
+/**
+ * Defines the sources for price information on the chain. Other than from
+ * trusted oracle sources, price information can be manipulated.
+ */
 export type PriceOracleInfo = {
-  chainlink?: {
+  /**
+   * If set, shows the native token price.
+   */
+  nativeTokenPrice?: {
+    /**
+     * A Chainlink AggregatorV3 compatible smart contract address acting
+     * as an oracle for the native token's price in USD.
+     *
+     * Note: You can deploy a contract that is compatible with the AggregatorV3
+     * interface but does not actually use Chainlink oracles; for instance,
+     * a custom contract that estimates the native token's USD price from an
+     * on-chain source could be deployed.
+     */
     ethUSDOracleAddress: string;
+    /**
+     * Number of decimals used by the oracle contract, output by calling
+     * `decimals()`.
+     */
     ethUSDOracleDecimals: number;
   };
+
+  /**
+   * The address of the wrapped native token contract, which should match the
+   * WETH variable in Uniswap router contracts. This is used to estimate the
+   * price of tokens which have at least one Uniswap pool with the wrapped
+   * native token.
+   */
   wrappedEthAddress?: string;
+
+  /**
+   * If defined, considers UniswapV2 pairs when estimating token prices for
+   * tokens which do not have a Chainlink oracle.
+   */
   uniswapV2?: {
     factoryAddress: string;
   };
+
+  /**
+   * If defined, considers UniswapV3 pairs when estimating token prices for
+   * tokens which do not have a Chainlink oracle. 0.01%, 0.05%, 0.3%, and 1%
+   * fee tiers are checked.
+   */
   uniswapV3?: {
     factoryAddress: string;
   };
@@ -131,6 +169,10 @@ export type OtterscanConfig = {
    */
   sourcifySources?: { [key: string]: string };
 
+  /**
+   * Optional custom price oracle information for estimating the current price
+   * of the native token and all other tokens.
+   */
   priceOracleInfo?: PriceOracleInfo;
 };
 

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -50,6 +50,9 @@ export type PriceOracleInfo = {
   uniswapV2?: {
     factoryAddress: string;
   };
+  uniswapV3?: {
+    factoryAddress: string;
+  };
 };
 
 export const defaultChainInfo: ChainInfo = {

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -765,7 +765,7 @@ const tokenMetadataFetcher =
       return {
         name,
         symbol,
-        decimals,
+        decimals: Number(decimals),
       };
     } catch (err) {
       // Ignore on purpose; this indicates the probe failed and the address

--- a/src/usePriceOracle.ts
+++ b/src/usePriceOracle.ts
@@ -41,6 +41,7 @@ const tokenEquivMap = new Map<
 ]);
 
 const mainnetPriceOracleInfo: PriceOracleInfo = {
+  wrappedEthAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   uniswapV2: {
     factoryAddress: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
   },


### PR DESCRIPTION
Adds support for using UniswapV2 and UniswapV3 spot prices for price estimations, enabling tokens without Chainlink data feeds to have their price estimates shown.

In addition, this change allows the native token USD price data feed contract address to be specified in the config.

Note that the UniswapV3 "is there enough liquidity to trust this price" check is subject to being incorrect if there is a substantial amount of out-of-range liquidity and little or no liquidity in the active range, e.g. if the true price of the token is higher than all active liquidity positions. If it's easy to calculate how much liquidity is on either side of the current token price without having to make too many extra calls, that could be a future improvement.

Other future improvement: Users may wish to know the source of the price data. We may also wish to change the background color of the price estimate based on the source of the information.

Closes #1879.