### PR TITLE
Trace: Ensure address labels are font-sans

### DIFF
--- a/src/execution/transaction/Trace.tsx
+++ b/src/execution/transaction/Trace.tsx
@@ -19,7 +19,7 @@ const Trace: React.FC<TraceProps> = ({ txData }) => {
       <div className="mb-5 mt-4 flex flex-col items-start space-y-3 overflow-x-auto font-code text-sm">
         {traces ? (
           <>
-            <div className="rounded border px-1 py-0.5 hover:border-gray-500">
+            <div className="rounded border px-1 py-0.5 hover:border-gray-500 font-sans">
               <TransactionAddress address={txData.from} />
             </div>
             <div className="ml-5 space-y-3 self-stretch">

--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -76,7 +76,7 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
           </span>
         ) : (
           <>
-            <span>
+            <span className="font-sans">
               <TransactionAddress
                 address={t.to}
                 showCodeIndicator


### PR DESCRIPTION
Closes #1913

![image](https://github.com/otterscan/otterscan/assets/125761775/3c10da44-ae69-4ff4-84e3-1cb3789baf5d)
