### PR TITLE
Add Optimism L1 Epoch to block page with optional L1 explorer URL

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -134,3 +134,17 @@ Example for Ethereum mainnet:
   }
 }
 ```
+
+### Optimism-specific
+
+For chains which follow the OP Stack, configure the `opChainSettings` key in the config:
+* `l1ExplorerURL`: The root URL of a block explorer for the layer-1 of this chain, without a trailing forward slash. This appears on block pages in the "L1 Epoch" row.
+
+Example for Sepolia:
+```json
+{
+  "opChainSettings": {
+    "l1ExplorerURL": "https://sepolia.otterscan.io"
+  }
+}
+```

--- a/src/abi/optimism/L1Block.json
+++ b/src/abi/optimism/L1Block.json
@@ -1,0 +1,9 @@
+[
+  {
+    "inputs": [],
+    "name": "number",
+    "outputs": [{ "internalType": "uint64", "name": "", "type": "uint64" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/components/ExternalBlockLink.tsx
+++ b/src/components/ExternalBlockLink.tsx
@@ -1,0 +1,46 @@
+import { faCube } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { BlockTag } from "ethers";
+import { FC, memo } from "react";
+import { blockURL } from "../url";
+import { commify } from "../utils/utils";
+import ExternalLink from "./ExternalLink";
+
+type ExternalBlockLinkProps = {
+  blockTag: BlockTag;
+  explorerUrl?: string;
+};
+
+const ExternalBlockLink: FC<ExternalBlockLinkProps> = ({
+  explorerUrl,
+  blockTag,
+}) => {
+  let text = blockTag;
+  let isNum = typeof blockTag === "bigint" || typeof blockTag === "number";
+  if (isNum) {
+    text = commify(blockTag);
+  }
+
+  const interior = (
+    <div
+      className={`flex-inline items-baseline space-x-1 break-all ${isNum ? "font-blocknum" : "font-hash"}`}
+    >
+      <span className="text-blue-400">
+        <FontAwesomeIcon className="self-center" icon={faCube} size="1x" />
+      </span>
+      <span>{text.toString()}</span>
+    </div>
+  );
+
+  if (explorerUrl) {
+    return (
+      <ExternalLink href={explorerUrl + blockURL(blockTag)}>
+        {interior}
+      </ExternalLink>
+    );
+  }
+
+  return interior;
+};
+
+export default memo(ExternalBlockLink);

--- a/src/execution/BlockDetails.tsx
+++ b/src/execution/BlockDetails.tsx
@@ -6,6 +6,7 @@ import { NavLink } from "react-router-dom";
 import BlockLink from "../components/BlockLink";
 import BlockNotFound from "../components/BlockNotFound";
 import ContentFrame from "../components/ContentFrame";
+import ExternalBlockLink from "../components/ExternalBlockLink";
 import FormattedBalance from "../components/FormattedBalance";
 import HexValue from "../components/HexValue";
 import InfoRow from "../components/InfoRow";
@@ -16,7 +17,7 @@ import RelativePosition from "../components/RelativePosition";
 import Timestamp from "../components/Timestamp";
 import { blockTxsURL } from "../url";
 import { useChainInfo } from "../useChainInfo";
-import { useBlockData } from "../useErigonHooks";
+import { useBlockData, useL1Epoch } from "../useErigonHooks";
 import { RuntimeContext } from "../useRuntime";
 import { useBlockPageTitle } from "../useTitle";
 import { commify } from "../utils/utils";
@@ -28,7 +29,7 @@ interface BlockDetailsProps {
 }
 
 const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
-  const { provider } = useContext(RuntimeContext);
+  const { config, provider } = useContext(RuntimeContext);
   if (blockNumberOrHash === undefined) {
     throw new Error("blockNumberOrHash couldn't be undefined here");
   }
@@ -51,6 +52,10 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
     block?.baseFeePerGas && block.baseFeePerGas * gasUsedWithoutDepositTx;
   const gasUsedPerc =
     block && Number((block.gasUsed * 10000n) / block.gasLimit) / 100;
+
+  const l1Epoch = useL1Epoch(provider, block ? block.number : null);
+  const l1ExplorerUrl: string | undefined =
+    config?.opChainSettings?.l1ExplorerURL;
 
   return (
     <>
@@ -171,6 +176,14 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
           {block.parentBeaconBlockRoot && (
             <InfoRow title="Parent Beacon Block Root">
               <HexValue value={block.parentBeaconBlockRoot} />
+            </InfoRow>
+          )}
+          {l1Epoch !== undefined && l1Epoch !== null && (
+            <InfoRow title="L1 Epoch">
+              <ExternalBlockLink
+                blockTag={l1Epoch}
+                explorerUrl={l1ExplorerUrl}
+              />
             </InfoRow>
           )}
           <InfoRow title="Sha3Uncles">

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -174,6 +174,17 @@ export type OtterscanConfig = {
    * of the native token and all other tokens.
    */
   priceOracleInfo?: PriceOracleInfo;
+
+  /**
+   * Optional settings for chains that follow the OP Stack.
+   */
+  opChainSettings?: {
+    /**
+     * The root URL of a block explorer for the layer-1 of this chain, without
+     * a trailing forward slash, e.g. "https://sepolia.otterscan.io".
+     */
+    l1ExplorerURL?: string;
+  };
 };
 
 /**

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -824,10 +824,8 @@ const l1EpochFetcher =
       provider,
     ).attach(l1BlockContractAddress) as Contract;
     try {
-      console.log("FETCHING");
       return l1BlockContract.number({ blockTag });
     } catch (err) {
-      // Call failed
       return null;
     }
   };


### PR DESCRIPTION
Adds the L1 Epoch fetched from the L1Block contract's "number" function to block pages, and also adds a config option for an L1 block explorer which turns this number into a link.

With an L1 block explorer URL configured:
![image](https://github.com/otterscan/otterscan/assets/125761775/852bfdf3-fd4f-4b5d-8b26-261dc1f25a90)

Without an L1 block explorer URL configured:
![image](https://github.com/otterscan/otterscan/assets/125761775/6090d748-6d53-4200-a560-ad192e9dac89)

Closes #1880 
Closes #1881 