### PR TITLE
Add e2e tests with Anvil backend

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -110,3 +110,49 @@ jobs:
         with:
           name: Cypress Devnet Screenshots
           path: cypress/screenshots
+
+  e2e-test-anvil:
+    name: Run E2E tests on an Anvil devnet
+    runs-on: ubuntu-latest
+    needs: [check-secrets]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up xvfb
+        run: |
+          sudo apt update
+          sudo apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      - name: Download Anvil
+        run: |
+          wget -O ./forge.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly-440ec525deb00b4dca138794865c27d1e8ea4d01/foundry_nightly_linux_amd64.tar.gz
+          tar -xzf ./forge.tar.gz anvil
+      - name: Load devnet config
+        id: load-devnet-config
+        run: |
+          OTTERSCAN_CONFIG="$(cat cypress/support/devnet-config.json | sed 's/localhost/127.0.0.1/')"
+          OTTERSCAN_CONFIG=$(echo $OTTERSCAN_CONFIG)
+          echo "config=$OTTERSCAN_CONFIG" >> $GITHUB_OUTPUT
+      - name: Run Cypress tests on Anvil devnet
+        uses: cypress-io/github-action@v6
+        with:
+          start: |
+            sh ./scripts/run-anvil-devnet.sh
+            npm run start
+          # Cypress can't detect Anvil's RPC server, so we have to assume it is up
+          wait-on: "http://localhost:5173"
+          spec: "cypress/e2e/devnet/**/*.cy.ts,cypress/e2e/*.cy.ts"
+          tag: ${{needs.check-secrets.outputs.e2e-cypress-record-key == 'true' && 'anvil' || ''}}
+          record: |
+            ${{needs.check-secrets.outputs.e2e-cypress-record-key == 'true' && 'true' || 'false'}}
+        env:
+          VITE_CONFIG_JSON: ${{steps.load-devnet-config.outputs.config}}
+          CYPRESS_RECORD_KEY: ${{secrets.E2E_CYPRESS_RECORD_KEY}}
+          CYPRESS_DEVNET_ERIGON_URL: "http://127.0.0.1:8545"
+          CYPRESS_DEVNET_SOURCIFY_SOURCE: "http://127.0.0.1:7077"
+          CYPRESS_DEVNET_ACCOUNT_KEY: "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+      - name: Upload screenshots from failing tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: Cypress Devnet Screenshots
+          path: cypress/screenshots

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -27,7 +27,8 @@ Cypress.Commands.add("sendTx", (txReq) => {
         Cypress.env("DEVNET_ERIGON_URL"),
       );
       const wallet = new ethers.Wallet(
-        ethers.sha256(ethers.toUtf8Bytes("erigon devnet key")),
+        Cypress.env("DEVNET_ACCOUNT_KEY") ||
+          ethers.sha256(ethers.toUtf8Bytes("erigon devnet key")),
         provider,
       );
       const tx = await wallet.sendTransaction(txReq);

--- a/scripts/run-anvil-devnet.sh
+++ b/scripts/run-anvil-devnet.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+./anvil --chain-id 1337


### PR DESCRIPTION
Closes #1853 

Currently, an anvil binary from a fixed recent nightly version is downloaded and used for the backend.