### PR TITLE
Support function return values in traces

### DIFF
--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -60,6 +60,11 @@ const ReadContract: React.FC<ContractsProps> = ({
                     <ReadFunction
                       func={FunctionFragment.from(fn)}
                       address={checksummedAddress}
+                      devMethod={
+                        match?.metadata?.output?.devdoc?.methods?.[
+                          FunctionFragment.from(fn).format("sighash")
+                        ]
+                      }
                       key={i}
                     />
                   ))}
@@ -78,6 +83,11 @@ const ReadContract: React.FC<ContractsProps> = ({
                             <ReadFunction
                               func={FunctionFragment.from(fn)}
                               address={checksummedAddress}
+                              devMethod={
+                                match?.metadata?.output?.devdoc?.methods?.[
+                                  FunctionFragment.from(fn).format("sighash")
+                                ]
+                              }
                               key={i}
                             />
                           ))}

--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -86,7 +86,7 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
   return (
     <div
       className={`ml-5 rounded border px-1 py-0.5 hover:border-gray-500 ${
-        expanded ? "w-full" : ""
+        expanded || retValExpanded ? "w-full" : ""
       }`}
     >
       <div className="flex items-baseline">

--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -1,5 +1,6 @@
 import { faBomb } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { AbiCoder } from "ethers";
 import React, { useContext, useState } from "react";
 import ExpanderSwitch from "../../components/ExpanderSwitch";
 import FormattedBalance from "../../components/FormattedBalance";
@@ -18,6 +19,7 @@ import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
 import FunctionSignature from "./FunctionSignature";
 import InputDecoder from "./decoder/InputDecoder";
+import OutputDecoder from "./decoder/OutputDecoder";
 
 type TraceInputProps = {
   t: TraceEntry;
@@ -51,6 +53,7 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
   });
   const userDoc = metadata?.output.userdoc;
   const devDoc = metadata?.output.devdoc;
+  // TODO: Consider checking stateVariables too
   const userMethod = sourcifyTxDesc
     ? userDoc?.methods[sourcifyTxDesc.signature]
     : undefined;
@@ -60,7 +63,25 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
   const txDesc = sourcifyTxDesc ?? fourBytesTxDesc;
 
   const [expanded, setExpanded] = useState<boolean>(false);
+  const [retValExpanded, setRetValExpanded] = useState<boolean>(false);
   const isContractCreation = t.type === "CREATE" || t.type === "CREATE2";
+
+  const hasRetVal = t.output !== undefined && t.output !== "0x";
+  const retValExpander = (
+    <>
+      <span className="whitespace-nowrap px-1">
+        <span className="text-gray-500">returns</span>
+      </span>
+      <span>
+        (
+        <ExpanderSwitch
+          expanded={retValExpanded}
+          setExpanded={setRetValExpanded}
+        />
+        {!retValExpanded && ")"}
+      </span>
+    </>
+  );
 
   return (
     <div
@@ -103,6 +124,8 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
               {(!(hasParams || hasSmallData || isContractCreation) ||
                 !expanded) && <>)</>}
             </span>
+
+            {!expanded && hasRetVal && retValExpander}
           </>
         )}
       </div>
@@ -115,6 +138,28 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
               hasParamNames={txDesc === sourcifyTxDesc}
               data={t.input}
               userMethod={userMethod}
+              devMethod={devMethod}
+            />
+          </div>
+          <div className="flex items-baseline">
+            ) {hasRetVal && retValExpander}
+          </div>
+        </>
+      )}
+      {t.output !== undefined && t.output !== "0x" && retValExpanded && (
+        <>
+          <div className="my-2 ml-5 mr-1">
+            <OutputDecoder
+              args={
+                txDesc
+                  ? AbiCoder.defaultAbiCoder().decode(
+                      txDesc.fragment.outputs,
+                      t.output,
+                    )
+                  : undefined
+              }
+              paramTypes={txDesc?.fragment?.outputs}
+              data={t.output}
               devMethod={devMethod}
             />
           </div>

--- a/src/execution/transaction/decoder/DecodedParamsTable.tsx
+++ b/src/execution/transaction/decoder/DecodedParamsTable.tsx
@@ -46,7 +46,11 @@ const DecodedParamsTable: FC<DecodedParamsTableProps> = ({
           i={i}
           r={r}
           paramType={paramTypes[i]}
-          help={devMethod?.params?.[paramTypes[i].name]}
+          help={
+            devMethod?.[defaultNameBase === "ret" ? "returns" : "params"]?.[
+              paramTypes[i].name !== "" ? paramTypes[i].name : "_" + i
+            ]
+          }
           defaultNameBase={defaultNameBase}
         />
       ))}

--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -1,0 +1,54 @@
+import { Tab } from "@headlessui/react";
+import { ParamType, Result } from "ethers";
+import React from "react";
+import ModeTab from "../../../components/ModeTab";
+import StandardTextarea from "../../../components/StandardTextarea";
+import { DevMethod } from "../../../sourcify/useSourcify";
+import DecodedParamsTable from "./DecodedParamsTable";
+
+type OutputDecoderProps = {
+  args: Result | undefined;
+  paramTypes: readonly ParamType[] | null | undefined;
+  data: string;
+  devMethod?: DevMethod;
+};
+
+const OutputDecoder: React.FC<OutputDecoderProps> = ({
+  args,
+  paramTypes,
+  data,
+  devMethod,
+}) => (
+  <Tab.Group>
+    <Tab.List className="mb-1 flex space-x-1">
+      <ModeTab disabled={!paramTypes}>Decoded</ModeTab>
+      <ModeTab>Raw</ModeTab>
+    </Tab.List>
+    <Tab.Panels>
+      <Tab.Panel>
+        {data === "0x" ? (
+          <>No data</>
+        ) : paramTypes === undefined || args === undefined ? (
+          <>Waiting for data...</>
+        ) : paramTypes === null ? (
+          <>Can't decode data</>
+        ) : (
+          <div className="space-y-2">
+            <DecodedParamsTable
+              args={args}
+              paramTypes={paramTypes}
+              hasParamNames={true}
+              devMethod={devMethod}
+              defaultNameBase="ret"
+            />
+          </div>
+        )}
+      </Tab.Panel>
+      <Tab.Panel>
+        <StandardTextarea value={data} />
+      </Tab.Panel>
+    </Tab.Panels>
+  </Tab.Group>
+);
+
+export default OutputDecoder;

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -405,6 +405,7 @@ export type TraceEntry = {
   to: string;
   value: bigint;
   input: string;
+  output?: string;
 };
 
 export type TraceGroup = TraceEntry & {


### PR DESCRIPTION
Closes #1530

![image](https://github.com/otterscan/otterscan/assets/125761775/0120c5c6-012a-4065-a442-6f9cd0de1328)

The PR includes devdoc support for return values, and the same decoder is applied to the Read Contract page.