### PR TITLE
Use first April 2024 nightly Forge release in e2e test

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -124,7 +124,7 @@ jobs:
           sudo apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Download Anvil
         run: |
-          wget -O ./forge.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly-440ec525deb00b4dca138794865c27d1e8ea4d01/foundry_nightly_linux_amd64.tar.gz
+          wget -O ./forge.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9/foundry_nightly_linux_amd64.tar.gz
           tar -xzf ./forge.tar.gz anvil
       - name: Load devnet config
         id: load-devnet-config


### PR DESCRIPTION
Forge retains artifacts from the first nightly release of each month.

Fixes Anvil e2e test failures.