### PR TITLE
Feature/parent beacon block root link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ const AllERC1155 = lazy(() => import("./token/AllERC1155"));
 const AllERC1167 = lazy(() => import("./token/AllERC1167"));
 const Epoch = lazy(() => import("./consensus/Epoch"));
 const Slot = lazy(() => import("./consensus/Slot"));
+const SlotByBlockRoot = lazy(() => import("./consensus/slot/SlotByBlockRoot"));
 const Validator = lazy(() => import("./consensus/Validator"));
 const London = lazy(() => import("./special/london/London"));
 const Faucets = lazy(() => import("./Faucets"));
@@ -99,6 +100,10 @@ const App = () => {
                     )}
                     <Route path="epoch/:epochNumber/*" element={<Epoch />} />
                     <Route path="slot/:slotNumber/*" element={<Slot />} />
+                    <Route
+                      path="slotByBlockRoot/:blockRoot/*"
+                      element={<SlotByBlockRoot />}
+                    />
                     <Route
                       path="validator/:validatorIndex/*"
                       element={<Validator />}

--- a/src/consensus/components/SlotLink.stories.tsx
+++ b/src/consensus/components/SlotLink.stories.tsx
@@ -10,19 +10,19 @@ type Story = StoryObj<typeof meta>;
 
 export const GenesisSlot: Story = {
   args: {
-    slotNumber: 0,
+    slot: 0,
   },
 };
 
 export const RecentMainnetSlotNumber: Story = {
   args: {
-    slotNumber: 5_700_000,
+    slot: 5_700_000,
   },
 };
 
 export const BigSlotNumber: Story = {
   args: {
-    slotNumber: 5_700_000_000,
+    slot: 5_700_000_000,
   },
 };
 

--- a/src/consensus/components/SlotLink.stories.tsx
+++ b/src/consensus/components/SlotLink.stories.tsx
@@ -46,3 +46,9 @@ export const SlotContainingSlashing: Story = {
     slashings: true,
   },
 };
+
+export const BlockRoot: Story = {
+  args: {
+    slot: "0x1baac88e41f597e21a780e89dfe7add5da50e522ee4b535e7799995d807ad743",
+  },
+};

--- a/src/consensus/components/SlotLink.tsx
+++ b/src/consensus/components/SlotLink.tsx
@@ -5,30 +5,31 @@ import { FC, memo } from "react";
 import { NavLink } from "react-router-dom";
 import { slotURL } from "../../url";
 import { commify } from "../../utils/utils";
-import { SlotAwareComponentProps } from "../types";
 
-type SlotLinkProps = SlotAwareComponentProps & {
+type SlotLinkProps = {
+  slot: number | string;
   missed?: boolean;
   scheduled?: boolean;
   slashings?: boolean;
 };
 
 const SlotLink: FC<SlotLinkProps> = ({
-  slotNumber,
+  slot,
   missed,
   scheduled,
   slashings,
 }) => {
-  let text = commify(slotNumber);
+  const isNum = typeof slot === "number";
+  let text = isNum ? commify(slot) : slot;
 
   return (
     <NavLink
-      className={`flex items-baseline space-x-2 ${
+      className={`flex items-baseline ${
         missed
           ? "text-red-500 line-through hover:text-red-800"
           : "text-link-blue hover:text-link-blue-hover"
-      } font-blocknum`}
-      to={slotURL(slotNumber)}
+      } ${isNum ? "font-blocknum space-x-2" : "font-hash space-x-1"}`}
+      to={slotURL(slot)}
     >
       <FontAwesomeIcon
         className={`self-center ${slashings ? "text-red-600" : ""}`}

--- a/src/consensus/epoch/LoadingSlotItem.tsx
+++ b/src/consensus/epoch/LoadingSlotItem.tsx
@@ -14,7 +14,7 @@ const LoadingSlotItem: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
   return (
     <tr>
       <td>
-        <SlotLink slotNumber={slotNumber} scheduled />
+        <SlotLink slot={slotNumber} scheduled />
       </td>
       <td>
         <ContentLoader viewBox="0 0 30 4">

--- a/src/consensus/epoch/ScheduledOrMissedSlotItem.tsx
+++ b/src/consensus/epoch/ScheduledOrMissedSlotItem.tsx
@@ -25,11 +25,7 @@ const ScheduledOrMissedSlotItem: FC<ScheduledOrMissedSlotItemProps> = ({
   return (
     <tr>
       <td>
-        <SlotLink
-          slotNumber={slotNumber}
-          missed={missed}
-          scheduled={scheduled}
-        />
+        <SlotLink slot={slotNumber} missed={missed} scheduled={scheduled} />
       </td>
       <td className={`${isValidating ? "italic text-gray-400" : ""}`}>
         {missed && "Missed"}

--- a/src/consensus/epoch/StoredSlotItem.tsx
+++ b/src/consensus/epoch/StoredSlotItem.tsx
@@ -19,7 +19,7 @@ const StoredSlotItem: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
     <tr>
       <td>
         <SlotLink
-          slotNumber={slotNumber}
+          slot={slotNumber}
           slashings={
             slot.data.message.body.attester_slashings.length !== 0 ||
             slot.data.message.body.proposer_slashings.length !== 0

--- a/src/consensus/slot/Attestations.tsx
+++ b/src/consensus/slot/Attestations.tsx
@@ -23,7 +23,7 @@ const Attestations: FC = () => {
       {isLoading ? (
         <OverviewSkeleton />
       ) : error ? (
-        <SlotNotFound slotNumber={slotAsNumber} />
+        <SlotNotFound slot={slotAsNumber} />
       ) : (
         <>
           {slot.data.message.body.attestations.map((att: any, i: any) => (

--- a/src/consensus/slot/Overview.tsx
+++ b/src/consensus/slot/Overview.tsx
@@ -51,7 +51,7 @@ const Overview: FC = () => {
       {isLoading ? (
         <OverviewSkeleton />
       ) : error ? (
-        <SlotNotFound slotNumber={slotAsNumber} />
+        <SlotNotFound slot={slotAsNumber} />
       ) : (
         <>
           <InfoRow title="Timestamp">

--- a/src/consensus/slot/SlotByBlockRoot.tsx
+++ b/src/consensus/slot/SlotByBlockRoot.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import StandardFrame from "../../components/StandardFrame";
+import { useSlot } from "../../useConsensus";
+import SlotNotFound from "./SlotNotFound";
+
+const SlotByBlockRoot: React.FC = () => {
+  const { blockRoot } = useParams();
+  if (blockRoot === undefined) {
+    throw new Error("SlotByBlockRoot: blockRoot is undefined");
+  }
+  const { slot, error, isLoading } = useSlot(blockRoot);
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (slot && slot.data.message.slot) {
+      navigate("/slot/" + slot.data.message.slot, {
+        replace: true,
+      });
+    }
+  }, [slot]);
+
+  return (
+    <StandardFrame>
+      {(!slot && !isLoading) || error ? (
+        <SlotNotFound slot={blockRoot} />
+      ) : (
+        <></>
+      )}
+    </StandardFrame>
+  );
+};
+
+export default React.memo(SlotByBlockRoot);

--- a/src/consensus/slot/SlotNotFound.tsx
+++ b/src/consensus/slot/SlotNotFound.tsx
@@ -2,18 +2,25 @@ import { FC, memo } from "react";
 import { useHeadSlotNumber } from "../../useConsensus";
 import { commify } from "../../utils/utils";
 import SlotLink from "../components/SlotLink";
-import { SlotAwareComponentProps } from "../types";
 
-const SlotNotFound: FC<SlotAwareComponentProps> = ({ slotNumber }) => {
+interface SlotNotFoundProps {
+  slot: number | string;
+}
+
+const SlotNotFound: FC<SlotNotFoundProps> = ({ slot }) => {
   const headSlotNumber = useHeadSlotNumber();
 
   return (
     <div className="space-y-2 py-4 text-sm">
-      <p>Slot {commify(slotNumber)} data not found.</p>
-      {headSlotNumber !== undefined && slotNumber > headSlotNumber ? (
+      <p>
+        Slot {typeof slot === "number" ? commify(slot) : slot} data not found.
+      </p>
+      {headSlotNumber !== undefined &&
+      typeof slot === "number" &&
+      slot > headSlotNumber ? (
         <p className="flex space-x-2">
           <span>Head slot is:</span>
-          <SlotLink slotNumber={headSlotNumber} />
+          <SlotLink slot={headSlotNumber} />
         </p>
       ) : (
         <>

--- a/src/execution/BlockDetails.tsx
+++ b/src/execution/BlockDetails.tsx
@@ -15,6 +15,7 @@ import NativeTokenPrice from "../components/NativeTokenPrice";
 import PercentageBar from "../components/PercentageBar";
 import RelativePosition from "../components/RelativePosition";
 import Timestamp from "../components/Timestamp";
+import SlotLink from "../consensus/components/SlotLink";
 import { blockTxsURL } from "../url";
 import { useChainInfo } from "../useChainInfo";
 import { useBlockData, useL1Epoch } from "../useErigonHooks";
@@ -175,7 +176,11 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
           </InfoRow>
           {block.parentBeaconBlockRoot && (
             <InfoRow title="Parent Beacon Block Root">
-              <HexValue value={block.parentBeaconBlockRoot} />
+              {config?.beaconAPI === undefined ? (
+                <HexValue value={block.parentBeaconBlockRoot} />
+              ) : (
+                <SlotLink slot={block.parentBeaconBlockRoot} />
+              )}
             </InfoRow>
           )}
           {l1Epoch !== undefined && l1Epoch !== null && (

--- a/src/url.ts
+++ b/src/url.ts
@@ -22,7 +22,8 @@ export const chainInfoURL = (
 
 export const epochURL = (epochNumber: number) => `/epoch/${epochNumber}`;
 
-export const slotURL = (slotNumber: number) => `/slot/${slotNumber}`;
+export const slotURL = (slot: number | string) =>
+  typeof slot === "number" ? `/slot/${slot}` : `/slotByBlockRoot/${slot}`;
 
 export const slotAttestationsURL = (slotNumber: number) =>
   `/slot/${slotNumber}/attestations`;

--- a/src/useConsensus.ts
+++ b/src/useConsensus.ts
@@ -66,12 +66,12 @@ const useBeaconHeaderURL = (tag: string) => {
   return `${config.beaconAPI}/eth/v1/beacon/headers/${tag}`;
 };
 
-const useBeaconBlockURL = (slotNumber: number) => {
+const useBeaconBlockURL = (slot: number | string) => {
   const { config } = useContext(RuntimeContext);
   if (config?.beaconAPI === undefined) {
     return null;
   }
-  return `${config.beaconAPI}/eth/v2/beacon/blocks/${slotNumber}`;
+  return `${config.beaconAPI}/eth/v2/beacon/blocks/${slot}`;
 };
 
 const useBlockRootURL = (slotNumber: number) => {
@@ -110,8 +110,8 @@ const useCommitteeURL = (
   return `${config.beaconAPI}/eth/v1/beacon/states/head/committees?epoch=${epochNumber}&slot=${slotNumber}&index=${committeeIndex}`;
 };
 
-export const useSlot = (slotNumber: number) => {
-  const url = useBeaconBlockURL(slotNumber);
+export const useSlot = (slot: number | string) => {
+  const url = useBeaconBlockURL(slot);
   const { data, error, isLoading, isValidating } = useSWR(
     url,
     jsonFetcherWithErrorHandling,


### PR DESCRIPTION
Closes #1855 and closes #1727.

![image](https://github.com/otterscan/otterscan/assets/125761775/88b105b8-b44b-481b-93b0-92df3fac7e8b)

I tried to align it as close as possible with the parent block hash. It turns out that fa-square and fa-cube have different widths.