### PR TITLE
Only run Pages deployment on pushes to develop

### DIFF
--- a/.github/workflows/integration-deployment.yaml
+++ b/.github/workflows/integration-deployment.yaml
@@ -2,6 +2,12 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  workflow_dispatch:
+
 jobs:
   deploy-mainnet:
     uses: ./.github/workflows/pages-deployment.yaml

--- a/.github/workflows/integration-deployment.yaml
+++ b/.github/workflows/integration-deployment.yaml
@@ -9,8 +9,24 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    outputs:
+      has-secrets: ${{ steps.has-secrets.outputs.defined }}
+    steps:
+      - name: Check if deployment secrets are available
+        id: has-secrets
+        shell: bash
+        run: |
+          if [ "${{ secrets.CLOUDFLARE_API_TOKEN }}" != '' ] && [ "${{ secrets.CLOUDFLARE_ACCOUNT_ID }}" != '' ] && [ "${{ secrets.CLOUDFLARE_INTEG_MAINNET_PROJECT }}" != '' ]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
   deploy-mainnet:
     uses: ./.github/workflows/pages-deployment.yaml
+    needs: [check-secrets]
+    if: ${{ needs.check-secrets.outputs.has-secrets == 'true' }}
     secrets:
       apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -18,6 +34,8 @@ jobs:
       viteConfigJson: ${{ secrets.CLOUDFLARE_INTEG_MAINNET_SETTINGS }}
   deploy-gnosis:
     uses: ./.github/workflows/pages-deployment.yaml
+    needs: [check-secrets]
+    if: ${{ needs.check-secrets.outputs.has-secrets == 'true' }}
     secrets:
       apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -25,6 +43,8 @@ jobs:
       viteConfigJson: ${{ secrets.CLOUDFLARE_INTEG_GNOSIS_SETTINGS }}
   deploy-op-mainnet:
     uses: ./.github/workflows/pages-deployment.yaml
+    needs: [check-secrets]
+    if: ${{ needs.check-secrets.outputs.has-secrets == 'true' }}
     secrets:
       apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -32,6 +52,8 @@ jobs:
       viteConfigJson: ${{ secrets.CLOUDFLARE_INTEG_OP_MAINNET_SETTINGS }}
   deploy-e3-sepolia:
     uses: ./.github/workflows/pages-deployment.yaml
+    needs: [check-secrets]
+    if: ${{ needs.check-secrets.outputs.has-secrets == 'true' }}
     secrets:
       apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/integration-deployment.yaml
+++ b/.github/workflows/integration-deployment.yaml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+    branches:
+      - develop
 jobs:
   deploy-mainnet:
     uses: ./.github/workflows/pages-deployment.yaml


### PR DESCRIPTION
Closes #2016.

I found no way around getting "workflow invalid" errors using conditional statements, so Otterscan forks will have to disable this workflow manually. But still, without this change, Otterscan contributors will always get a "workflow invalid" notification on every push by default. That is why this PR is necessary, and I think it reflects what we want anyway.