### PR TITLE
Use nightly Foundry release artifacts in e2e tests

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -124,8 +124,8 @@ jobs:
           sudo apt install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Download Anvil
         run: |
-          wget -O ./forge.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly-f625d0fa7c51e65b4bf1e8f7931cd1c6e2e285e9/foundry_nightly_linux_amd64.tar.gz
-          tar -xzf ./forge.tar.gz anvil
+          wget -O ./foundry.tar.gz https://github.com/foundry-rs/foundry/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz
+          tar -xzf ./foundry.tar.gz anvil
       - name: Load devnet config
         id: load-devnet-config
         run: |

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -648,12 +648,12 @@ export const useTransactionError = (
     const readCodes = async () => {
       const result = (await provider.send("ots_getTransactionError", [
         txHash,
-      ])) as string;
+      ])) as string | null;
 
       // Empty or success
-      if (result === "0x") {
+      if (result === "0x" || typeof result !== "string") {
         setErrorMsg(undefined);
-        setData(result);
+        setData("0x");
         setCustomError(false);
         return;
       }


### PR DESCRIPTION
The Foundry repo has a nightly release system which updates the same link with different artifacts each night. With this PR, we'll use those nightly artifacts rather than a particular monthly one.

Closes #2063 