### PR TITLE
Add experimental support for GitHub address label backend

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ const Validator = lazy(() => import("./consensus/Validator"));
 const London = lazy(() => import("./special/london/London"));
 const Faucets = lazy(() => import("./Faucets"));
 const PageNotFound = lazy(() => import("./PageNotFound"));
+const Settings = lazy(() => import("./Settings"));
 
 const App = () => {
   const runtime = useRuntime();
@@ -109,6 +110,7 @@ const App = () => {
                       element={<Validator />}
                     />
                     <Route path="faucets/*" element={<Faucets />} />
+                    <Route path="settings/*" element={<Settings />} />
                     <Route path="*" element={<PageNotFound />} />
                   </Route>
                 </Routes>

--- a/src/Settings.tsx
+++ b/src/Settings.tsx
@@ -1,0 +1,103 @@
+import React, { ChangeEvent, useEffect, useState } from "react";
+import {
+  GitHubCustomLabelFetcher,
+  setNestedProperty,
+} from "./api/address-resolver/CustomLabelResolver";
+import ContentFrame from "./components/ContentFrame";
+import StandardFrame from "./components/StandardFrame";
+import StandardSubtitle from "./components/StandardSubtitle";
+import { usePageTitle } from "./useTitle";
+
+async function saveSetting(e: ChangeEvent<HTMLInputElement>): Promise<void> {
+  const settingName = e.target.getAttribute("data-setting-name");
+  if (settingName === null) {
+    throw new Error("Setting requires data-setting-name to be set");
+  }
+  const settingsObj = await JSON.parse(
+    localStorage.getItem("settings") || "{}",
+  );
+  setNestedProperty(settingsObj, settingName, e.target.value);
+  await localStorage.setItem("settings", JSON.stringify(settingsObj));
+  // Synchronize label fetcher state without requiring a reload
+  if (settingName.startsWith("github-address-labels.")) {
+    await GitHubCustomLabelFetcher.getInstance().loadSettings();
+  }
+}
+
+type SettingsType = {
+  "github-address-labels"?: {
+    username?: string;
+    "repo-name"?: string;
+    token?: string;
+  };
+};
+
+const Settings: React.FC = () => {
+  usePageTitle("Settings");
+
+  const [settingsState, setSettingsState] = useState<SettingsType>({});
+
+  useEffect(() => {
+    (async function () {
+      const settingsObj = JSON.parse(
+        (await localStorage.getItem("settings")) || "{}",
+      );
+      setSettingsState(settingsObj);
+    })();
+  }, []);
+
+  return (
+    <StandardFrame>
+      <StandardSubtitle>Settings</StandardSubtitle>
+      <ContentFrame>
+        <div className="p-4">
+          <h3 className="mb-4">GitHub Address Labels</h3>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">
+              GitHub Username
+              <input
+                data-setting-name="github-address-labels.username"
+                type="text"
+                onChange={saveSetting}
+                className="mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white"
+                defaultValue={
+                  settingsState?.["github-address-labels"]?.["username"] ?? ""
+                }
+              />
+            </label>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">
+              Repository Name
+              <input
+                data-setting-name="github-address-labels.repo-name"
+                type="text"
+                onChange={saveSetting}
+                className="mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white"
+                defaultValue={
+                  settingsState?.["github-address-labels"]?.["repo-name"] ?? ""
+                }
+              />
+            </label>
+          </div>
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700">
+              GitHub API Token
+              <input
+                data-setting-name="github-address-labels.token"
+                type="text"
+                onChange={saveSetting}
+                className="mt-1 block w-full rounded-md bg-gray-100 border-transparent focus:border-gray-500 focus:bg-white"
+                defaultValue={
+                  settingsState?.["github-address-labels"]?.["token"] ?? ""
+                }
+              />
+            </label>
+          </div>
+        </div>
+      </ContentFrame>
+    </StandardFrame>
+  );
+};
+
+export default Settings;

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -1,12 +1,16 @@
 import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Menu } from "@headlessui/react";
-import React, { PropsWithChildren } from "react";
+import React, { PropsWithChildren, useContext } from "react";
+import { useNavigate } from "react-router-dom";
 import { SourcifySource } from "./sourcify/useSourcify";
 import { useAppConfigContext } from "./useAppConfig";
+import { RuntimeContext } from "./useRuntime";
 
 const SourcifyMenu: React.FC = () => {
+  const { config } = useContext(RuntimeContext);
   const { sourcifySource, setSourcifySource } = useAppConfigContext();
+  const navigate = useNavigate();
 
   return (
     <Menu>
@@ -30,6 +34,19 @@ const SourcifyMenu: React.FC = () => {
           >
             Sourcify Servers
           </SourcifyMenuItem>
+          {config?.WIP_customAddressLabels && (
+            <>
+              <div className="my-1 h-0.5 bg-gray bg-opacity-5" />
+              <SourcifyMenuItem
+                checked={false}
+                onClick={() => {
+                  navigate("/settings");
+                }}
+              >
+                Settings
+              </SourcifyMenuItem>
+            </>
+          )}
         </Menu.Items>
       </div>
     </Menu>

--- a/src/api/address-resolver/CustomLabelResolver.ts
+++ b/src/api/address-resolver/CustomLabelResolver.ts
@@ -6,8 +6,8 @@ type AddressMap = Record<string, string | undefined>;
 /*
     A singleton class so addresses aren't fetched more than once
 */
-export class CustomLabelFetcher {
-  private static instance: CustomLabelFetcher;
+export class LocalStorageCustomLabelFetcher {
+  private static instance: LocalStorageCustomLabelFetcher;
   private fetchedLabels: Map<string, string> = new Map();
   private localStorageLabels: Map<string, string> = new Map();
   private fetched: boolean = false;
@@ -17,11 +17,12 @@ export class CustomLabelFetcher {
 
   private constructor() {}
 
-  public static getInstance(): CustomLabelFetcher {
-    if (!CustomLabelFetcher.instance) {
-      CustomLabelFetcher.instance = new CustomLabelFetcher();
+  public static getInstance(): LocalStorageCustomLabelFetcher {
+    if (!LocalStorageCustomLabelFetcher.instance) {
+      LocalStorageCustomLabelFetcher.instance =
+        new LocalStorageCustomLabelFetcher();
     }
-    return CustomLabelFetcher.instance;
+    return LocalStorageCustomLabelFetcher.instance;
   }
 
   public async fetchLabels(localOnly: boolean = false) {
@@ -99,7 +100,7 @@ export class CustomLabelFetcher {
     }
   }
 
-  public getAllAddresses(): string[] {
+  public async getAllAddresses(): Promise<string[]> {
     return Array.from(this.localStorageLabels.keys());
   }
 
@@ -109,12 +110,256 @@ export class CustomLabelFetcher {
   }
 }
 
+export function getNestedProperty(
+  obj: any,
+  path: string,
+  defaultValue: any,
+): any {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length; i++) {
+    if (current[parts[i]] === undefined) {
+      return defaultValue;
+    }
+    current = current[parts[i]];
+  }
+  return current;
+}
+
+export function setNestedProperty(obj: any, path: string, value: any) {
+  const parts = path.split(".");
+  let current = obj;
+  for (let i = 0; i < parts.length - 1; i++) {
+    if (current[parts[i]] === undefined) current[parts[i]] = {};
+    current = current[parts[i]];
+  }
+  current[parts[parts.length - 1]] = value;
+}
+
+export class GitHubCustomLabelFetcher {
+  private static instance: GitHubCustomLabelFetcher;
+  private fetchedLabels: Map<string, string | null> = new Map();
+
+  private token: string | null = null;
+  private owner: string | null = null;
+  private repo: string | null = null;
+
+  async loadSettings() {
+    const settings = JSON.parse(
+      (await localStorage.getItem("settings")) || "{}",
+    );
+    this.token = getNestedProperty(
+      settings,
+      "github-address-labels.token",
+      null,
+    );
+    this.owner = getNestedProperty(
+      settings,
+      "github-address-labels.username",
+      null,
+    );
+    this.repo = getNestedProperty(
+      settings,
+      "github-address-labels.repo-name",
+      null,
+    );
+  }
+
+  getSettings(): {
+    token: string | null;
+    owner: string | null;
+    repo: string | null;
+  } {
+    return { token: this.token, owner: this.owner, repo: this.repo };
+  }
+
+  private constructor(loadSettings: boolean) {
+    if (loadSettings) {
+      this.loadSettings();
+    }
+  }
+
+  public static getInstance(): GitHubCustomLabelFetcher {
+    if (!GitHubCustomLabelFetcher.instance) {
+      GitHubCustomLabelFetcher.instance = new GitHubCustomLabelFetcher(true);
+    }
+    return GitHubCustomLabelFetcher.instance;
+  }
+
+  public static async getLoadedInstance(): Promise<GitHubCustomLabelFetcher> {
+    if (!GitHubCustomLabelFetcher.instance) {
+      GitHubCustomLabelFetcher.instance = new GitHubCustomLabelFetcher(false);
+      await GitHubCustomLabelFetcher.instance.loadSettings();
+    }
+    return GitHubCustomLabelFetcher.instance;
+  }
+
+  async updateLabels(newItem: { [address: string]: string }) {
+    if (!this.token || !this.owner || !this.repo) {
+      return;
+    }
+    for (const [address, value] of Object.entries(newItem)) {
+      let sha: string | undefined;
+      const shaResp = await getRepoItem(
+        this.token,
+        this.owner,
+        this.repo,
+        address,
+      );
+      if (shaResp.status === 404) {
+        sha = undefined;
+      } else {
+        const jsonRes = await shaResp.json();
+        sha = jsonRes.sha;
+      }
+      if (!value) {
+        await updateFileInRepo(
+          this.owner,
+          this.repo,
+          address,
+          null,
+          this.token,
+          sha,
+        );
+        this.fetchedLabels.set(address, null);
+      } else {
+        await updateFileInRepo(
+          this.owner,
+          this.repo,
+          address,
+          value,
+          this.token,
+          sha,
+        );
+        this.fetchedLabels.set(address, value);
+      }
+    }
+  }
+
+  async getItem(key: string): Promise<string | undefined> {
+    console.log("Github:", this.token, this.owner, this.repo);
+    if (!this.token || !this.owner || !this.repo) {
+      return undefined;
+    }
+    const savedLabel = this.fetchedLabels.get(key);
+    if (savedLabel !== undefined) {
+      return savedLabel === null ? undefined : savedLabel!;
+    }
+    const fetchResult = await getRepoItem(
+      this.token,
+      this.owner,
+      this.repo,
+      key,
+    );
+    if (fetchResult.status === 404) {
+      this.fetchedLabels.set(key, null);
+      return undefined;
+    } else if (fetchResult.ok) {
+      const jsonContent = await fetchResult.json();
+      const content = atob(jsonContent.content);
+      this.fetchedLabels.set(key, content);
+      return content;
+    }
+    // Some error when fetching
+    return undefined;
+  }
+
+  async getAllAddresses(): Promise<string[]> {
+    if (!this.owner || !this.repo || !this.token) {
+      return [];
+    }
+    return getRepoFileList(this.owner, this.repo, this.token);
+  }
+}
+
+async function getRepoFileList(
+  owner: string,
+  repo: string,
+  token: string,
+): Promise<string[]> {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contents`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  const files = await response.json();
+  return files.map((file: any) => file.name);
+}
+
+async function updateFileInRepo(
+  owner: string,
+  repo: string,
+  path: string,
+  content: string | null,
+  token: string,
+  sha: string | undefined,
+) {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+    {
+      method: content === null ? "DELETE" : "PUT",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: "Update " + path,
+        committer: { name: owner, email: owner },
+        content: content !== null ? btoa(content) : undefined,
+        sha,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    console.error("Error:", response.status, response.statusText);
+  }
+}
+
+async function getRepoItem(
+  token: string,
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<Response> {
+  const response = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/contents/${path}`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+    },
+  );
+
+  return response;
+}
+
+export const CustomLabelFetcher = GitHubCustomLabelFetcher;
+
 export class CustomLabelResolver extends BasicAddressResolver {
   async resolveAddress(
     provider: JsonRpcApiProvider,
     address: string,
   ): Promise<string | undefined> {
-    const labelFetcher = CustomLabelFetcher.getInstance();
+    const labelFetcher = await GitHubCustomLabelFetcher.getLoadedInstance();
     const label = await labelFetcher.getItem(address);
     return label;
   }

--- a/src/execution/address/EditableAddressTag.tsx
+++ b/src/execution/address/EditableAddressTag.tsx
@@ -25,7 +25,7 @@ async function setAddressLabel(address: string, label: string | null) {
 
 export async function clearAllLabels() {
   const customLabelFetcher = CustomLabelFetcher.getInstance();
-  const addresses: string[] = customLabelFetcher.getAllAddresses();
+  const addresses: string[] = await customLabelFetcher.getAllAddresses();
   await customLabelFetcher.updateLabels(
     addresses.reduce(
       (obj: Record<string, string>, key: string) => ({ ...obj, [key]: "" }),


### PR DESCRIPTION
Adds a settings page at `/settings` where GitHub credentials (username/repo name/API token) can be set. No requests are made to GitHub unless all three are configured. This page is accessible from a button in what is currently the Sourcify options menu.

![image](https://github.com/otterscan/otterscan/assets/125761775/11719005-434a-43b6-9334-6af777939f84)


If GitHub credentials are configured, Otterscan will fetch and update labels from the target repository.

I plan to add the "local storage only" backend as an option in the settings page.