### PR TITLE
Add Docker env var for entire Otterscan config

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -42,6 +42,19 @@ By default it assumes your Erigon node is at `http://127.0.0.1:8545`. You can ov
 docker run --rm -p 5100:80 --name otterscan -d --env ERIGON_URL="<your-erigon-node-url>" otterscan/otterscan:<versiontag>
 ```
 
+You can override the entire Otterscan configuration with the `OTTERSCAN_CONFIG` env variable:
+
+```shell
+docker run --rm -p 5100:80 --name otterscan -d --env OTTERSCAN_CONFIG='{
+    "erigonURL": "http://127.0.0.1:8545",
+    "assetsURLPrefix": "http://127.0.0.1:5175",
+    "branding": {
+        "siteName": "My Otterscan",
+        "networkTitle": "Dev Network"
+    },
+}' otterscan/otterscan:latest
+```
+
 This is the preferred way to run Otterscan. You can read about other ways [here](./other-ways-to-run-otterscan.md).
 
 ## (Optional) Enable integration with beacon chain

--- a/docs/install.md
+++ b/docs/install.md
@@ -55,7 +55,9 @@ docker run --rm -p 5100:80 --name otterscan -d --env OTTERSCAN_CONFIG='{
 }' otterscan/otterscan:latest
 ```
 
-This is the preferred way to run Otterscan. You can read about other ways [here](./other-ways-to-run-otterscan.md).
+These settings overwrite the Otterscan config file on container startup. To disable this behavior, pass `--env DIABLE_CONFIG_OVERWRITE=1` to the Docker command.
+
+Running from Docker is the preferred way to run Otterscan. You can read about other ways [here](./other-ways-to-run-otterscan.md).
 
 ## (Optional) Enable integration with beacon chain
 

--- a/run-nginx.sh
+++ b/run-nginx.sh
@@ -19,5 +19,7 @@ else
 fi
 
 # Overwrite base image config.json with our own and let nginx do the rest
-echo $PARAMS > /usr/share/nginx/html/config.json
+if [ ! "$DISABLE_CONFIG_OVERWRITE" ]; then
+  echo $PARAMS > /usr/share/nginx/html/config.json
+fi
 exec nginx -g "daemon off;"

--- a/run-nginx.sh
+++ b/run-nginx.sh
@@ -1,17 +1,22 @@
 #!/bin/sh
 
-# Build a json from container init params
-PARAMS=$(jq -n \
-  --arg erigonURL "$ERIGON_URL" \
-  --arg beaconAPI "$BEACON_API_URL" \
-  --arg assetsURLPrefix "" \
-  --arg experimental "$OTS2" \
-  '{
-    erigonURL: $erigonURL,
-    beaconAPI: $beaconAPI,
-    assetsURLPrefix: $assetsURLPrefix,
-    experimental: $experimental,
-  }')
+# If complete config is provided, use it
+if [ "$OTTERSCAN_CONFIG" ]; then
+  PARAMS="$OTTERSCAN_CONFIG"
+else
+  # Build config JSON from container init params
+  PARAMS=$(jq -n \
+    --arg erigonURL "$ERIGON_URL" \
+    --arg beaconAPI "$BEACON_API_URL" \
+    --arg assetsURLPrefix "$ASSETS_URL_PREFIX" \
+    --arg experimental "$OTS2" \
+    '{
+      erigonURL: $erigonURL,
+      beaconAPI: $beaconAPI,
+      assetsURLPrefix: $assetsURLPrefix,
+      experimental: $experimental,
+    }')
+fi
 
 # Overwrite base image config.json with our own and let nginx do the rest
 echo $PARAMS > /usr/share/nginx/html/config.json


### PR DESCRIPTION
Closes #2074 via `OTTERSCAN_CONFIG` env var. Also adds `ASSETS_URL_PREFIX` for the assets URL and `DISABLE_CONFIG_OVERWRITE` if the user wants to mount the config file manually.