### PR TITLE
Scroll to log fragment and add log links

### DIFF
--- a/src/execution/transaction/Logs.tsx
+++ b/src/execution/transaction/Logs.tsx
@@ -9,11 +9,11 @@ type LogsProps = {
 };
 
 const Logs: FC<LogsProps> = ({ logs }) => {
-  let location = useLocation();
+  const location = useLocation();
   useEffect(() => {
     setTimeout(() => {
       if (location.hash) {
-        // Scroll to fragment, e.g. "#log-3"
+        // Scroll to fragment, e.g. "#3"
         let foundElement = document.getElementById(location.hash.slice(1));
         if (foundElement) {
           foundElement.scrollIntoView({

--- a/src/execution/transaction/Logs.tsx
+++ b/src/execution/transaction/Logs.tsx
@@ -1,5 +1,6 @@
 import { Log } from "ethers";
-import { FC, memo } from "react";
+import { FC, memo, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import ContentFrame from "../../components/ContentFrame";
 import LogEntry from "./LogEntry";
 
@@ -7,22 +8,38 @@ type LogsProps = {
   logs: Log[] | undefined;
 };
 
-const Logs: FC<LogsProps> = ({ logs }) => (
-  <ContentFrame tabs>
-    {logs && (
-      <>
-        {logs.length > 0 ? (
-          <>
-            {logs.map((l, i) => (
-              <LogEntry key={i} log={l} />
-            ))}
-          </>
-        ) : (
-          <div className="py-4 text-sm">Transaction didn't emit any logs</div>
-        )}
-      </>
-    )}
-  </ContentFrame>
-);
+const Logs: FC<LogsProps> = ({ logs }) => {
+  let location = useLocation();
+  useEffect(() => {
+    setTimeout(() => {
+      if (location.hash) {
+        // Scroll to fragment, e.g. "#log-3"
+        let foundElement = document.getElementById(location.hash.slice(1));
+        if (foundElement) {
+          foundElement.scrollIntoView({
+            behavior: "smooth",
+          });
+        }
+      }
+    }, 200);
+  }, [logs]);
+  return (
+    <ContentFrame tabs>
+      {logs && (
+        <>
+          {logs.length > 0 ? (
+            <>
+              {logs.map((l, i) => (
+                <LogEntry key={i} log={l} />
+              ))}
+            </>
+          ) : (
+            <div className="py-4 text-sm">Transaction didn't emit any logs</div>
+          )}
+        </>
+      )}
+    </ContentFrame>
+  );
+};
 
 export default memo(Logs);

--- a/src/execution/transaction/log/LogIndex.tsx
+++ b/src/execution/transaction/log/LogIndex.tsx
@@ -7,9 +7,9 @@ type LogIndexProps = {
 
 const LogIndex: FC<LogIndexProps> = ({ idx }) => (
   <Link
-    to={"#log-" + idx}
-    className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-500"
-    id={"log-" + idx}
+    to={`#${idx}`}
+    className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-500 hover:underline"
+    id={idx.toString()}
   >
     {idx}
   </Link>

--- a/src/execution/transaction/log/LogIndex.tsx
+++ b/src/execution/transaction/log/LogIndex.tsx
@@ -1,13 +1,18 @@
 import { FC } from "react";
+import { Link } from "react-router-dom";
 
 type LogIndexProps = {
   idx: number;
 };
 
 const LogIndex: FC<LogIndexProps> = ({ idx }) => (
-  <span className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-500">
+  <Link
+    to={"#log-" + idx}
+    className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-500"
+    id={"log-" + idx}
+  >
     {idx}
-  </span>
+  </Link>
 );
 
 export default LogIndex;


### PR DESCRIPTION
Closes #2102.

Adds links to each log circle and scrolls to a particular log index if a fragment is found in the page location.

There is a timeout because log components do not notify their parents that they have finished loading (i.e., expanded completely) unless we build out infrastructure for calling back to the parent, which I think is overkill for this feature. For a similar reason, we have to implement the scrolling logic in the Logs component because a particular log index element is created dynamically and does not exist at page load. We can switch from smooth to instant scrolling if there is a preference for that.