### PR TITLE
Add raw transaction broadcast page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,9 @@ const Validator = lazy(() => import("./consensus/Validator"));
 const London = lazy(() => import("./special/london/London"));
 const Faucets = lazy(() => import("./Faucets"));
 const PageNotFound = lazy(() => import("./PageNotFound"));
+const BroadcastTransactionPage = lazy(
+  () => import("./execution/BroadcastTransactionPage"),
+);
 
 const App = () => {
   const runtime = useRuntime();
@@ -109,6 +112,10 @@ const App = () => {
                       element={<Validator />}
                     />
                     <Route path="faucets/*" element={<Faucets />} />
+                    <Route
+                      path="broadcastTx"
+                      element={<BroadcastTransactionPage />}
+                    />
                     <Route path="*" element={<PageNotFound />} />
                   </Route>
                 </Routes>

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -2,11 +2,14 @@ import { faBars } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Menu } from "@headlessui/react";
 import React, { PropsWithChildren } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { SourcifySource } from "./sourcify/useSourcify";
 import { useAppConfigContext } from "./useAppConfig";
 
 const SourcifyMenu: React.FC = () => {
   const { sourcifySource, setSourcifySource } = useAppConfigContext();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <Menu>
@@ -29,6 +32,15 @@ const SourcifyMenu: React.FC = () => {
             onClick={() => setSourcifySource(SourcifySource.CENTRAL_SERVER)}
           >
             Sourcify Servers
+          </SourcifyMenuItem>
+          <div className="my-1 border-b border-gray-300" />
+          <SourcifyMenuItem
+            checked={location.pathname !== "/broadcastTx"}
+            onClick={() => {
+              navigate("/broadcastTx");
+            }}
+          >
+            Broadcast Transaction
           </SourcifyMenuItem>
         </Menu.Items>
       </div>

--- a/src/components/StandardTextarea.tsx
+++ b/src/components/StandardTextarea.tsx
@@ -1,12 +1,18 @@
 import { FC, TextareaHTMLAttributes } from "react";
 
-const StandardTextarea: FC<TextareaHTMLAttributes<HTMLTextAreaElement>> = ({
+interface StandardTextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  readOnly?: boolean;
+}
+
+const StandardTextarea: FC<StandardTextareaProps> = ({
+  readOnly = true,
   ...rest
 }) => (
   <textarea
-    className="h-40 w-full rounded border bg-gray-50 p-2 font-mono text-gray-500 focus:outline-none"
+    className={`h-40 w-full rounded border font-mono ${readOnly ? "bg-gray-50 text-gray-500" : "text-gray-800"} p-2 focus:outline-none`}
     {...rest}
-    readOnly
+    readOnly={readOnly}
   />
 );
 

--- a/src/execution/BroadcastTransactionPage.tsx
+++ b/src/execution/BroadcastTransactionPage.tsx
@@ -1,0 +1,91 @@
+import React, { useContext, useRef, useState } from "react";
+import ContentFrame from "../components/ContentFrame";
+import StandardFrame from "../components/StandardFrame";
+import StandardSubtitle from "../components/StandardSubtitle";
+import StandardTextarea from "../components/StandardTextarea";
+import TransactionLink from "../components/TransactionLink";
+import { RuntimeContext } from "../useRuntime";
+
+const BroadcastTransactionPage: React.FC = () => {
+  const { provider } = useContext(RuntimeContext);
+  const txFieldRef = useRef<HTMLTextAreaElement>(null);
+  const [rawTx, setRawTx] = useState<string>("");
+  const [resultState, setResultState] = useState<{
+    success: boolean | null;
+    result: string;
+  }>({ success: null, result: "" });
+
+  async function submitTx() {
+    console.log(rawTx, provider);
+    if (provider) {
+      const trimmedRawTx = rawTx.trim();
+      if (trimmedRawTx.length > 2) {
+        try {
+          const txHash = await provider.send("eth_sendRawTransaction", [
+            trimmedRawTx,
+          ]);
+          setResultState({ success: true, result: txHash });
+        } catch (e: any) {
+          setResultState({ success: false, result: e.toString() });
+        }
+      } else {
+        setResultState({
+          success: false,
+          result: "Please enter a raw signed transaction.",
+        });
+      }
+    }
+  }
+
+  return (
+    <StandardFrame>
+      <StandardSubtitle>Broadcast Transaction</StandardSubtitle>
+      <ContentFrame>
+        <div className="space-y-3 py-4">
+          <div>
+            This page lets you broadcast a raw signed transaction to the
+            network. Enter the transaction in hexadecimal format below:
+          </div>
+          <StandardTextarea
+            onChange={(e) => setRawTx(e.target.value)}
+            readOnly={false}
+            placeholder={"0x..."}
+          ></StandardTextarea>
+          <div>
+            <button
+              className="bg-skin-button-fill text-skin-button hover:bg-skin-button-hover-fill py-1 px-2 rounded border inline-flex items-center"
+              onClick={submitTx}
+            >
+              Send Transaction
+            </button>
+          </div>
+          {resultState.success === false && (
+            <div>
+              <div
+                className="bg-red-100 border border-red-400 text-red-700 px-4 py-2.5 rounded relative break-words"
+                role="alert"
+              >
+                <strong className="font-bold">Error!</strong> Failed to
+                broadcast transaction:{" "}
+                <div className="font-mono">{resultState.result}</div>
+              </div>
+            </div>
+          )}
+          {resultState.success && (
+            <div
+              className="bg-green-100 border border-green-300 text-green-700 px-4 py-2.5 rounded relative"
+              role="alert"
+            >
+              <strong className="font-bold">Success!</strong> Transaction hash:{" "}
+              <span className="flex">
+                <TransactionLink txHash={resultState.result} />
+              </span>
+            </div>
+          )}
+        </div>
+      </ContentFrame>
+    </StandardFrame>
+  );
+};
+
+export default BroadcastTransactionPage;


### PR DESCRIPTION
Closes #1965

This page is accessible from `/broadcastTx`. There is no link to it from elsewhere in Otterscan. I think we can add it as a menu item to what is currently the Sourcify source dropdown.

Example:
![image](https://github.com/otterscan/otterscan/assets/125761775/747273ef-650d-4dee-a529-d3f5fddfceb2)
