### PR TITLE
Add dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark:bg-white dark-mode">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,5 +1,4 @@
 import React, { useContext } from "react";
-import ThemeToggler from "./components/ThemeToggler";
 import { RuntimeContext } from "./useRuntime";
 
 const Footer: React.FC = () => {
@@ -7,9 +6,6 @@ const Footer: React.FC = () => {
 
   return (
     <>
-      <div className="bg-white">
-        <ThemeToggler />
-      </div>
       <div
         className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
           provider?._network.chainId === 1n

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -8,8 +8,8 @@ const Footer: React.FC = () => {
     <div
       className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
         provider?._network.chainId === 1n
-          ? "bg-link-blue text-gray-200"
-          : "bg-orange-400 text-white"
+          ? "bg-link-blue text-gray-200 dark:text-gray-900"
+          : "bg-orange-400 text-white dark:text-black"
       } text-center`}
     >
       {provider ? (

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,23 +1,29 @@
 import React, { useContext } from "react";
+import ThemeToggler from "./components/ThemeToggler";
 import { RuntimeContext } from "./useRuntime";
 
 const Footer: React.FC = () => {
   const { provider, config } = useContext(RuntimeContext);
 
   return (
-    <div
-      className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
-        provider?._network.chainId === 1n
-          ? "bg-link-blue dark:bg-link-blue-light text-gray-200 dark:text-gray-800"
-          : "bg-orange-400 text-white dark:text-gray-900"
-      } text-center`}
-    >
-      {provider ? (
-        <>Using Erigon node at {config?.erigonURL}</>
-      ) : (
-        <>Waiting for the provider...</>
-      )}
-    </div>
+    <>
+      <div className="bg-white">
+        <ThemeToggler />
+      </div>
+      <div
+        className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
+          provider?._network.chainId === 1n
+            ? "bg-link-blue dark:bg-link-blue-light text-gray-200 dark:text-gray-800"
+            : "bg-orange-400 text-white dark:text-gray-900"
+        } text-center`}
+      >
+        {provider ? (
+          <>Using Erigon node at {config?.erigonURL}</>
+        ) : (
+          <>Waiting for the provider...</>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -8,8 +8,8 @@ const Footer: React.FC = () => {
     <div
       className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
         provider?._network.chainId === 1n
-          ? "bg-link-blue text-gray-200 dark:text-gray-900"
-          : "bg-orange-400 text-white dark:text-black"
+          ? "bg-link-blue dark:bg-link-blue-light text-gray-200 dark:text-gray-800"
+          : "bg-orange-400 text-white dark:text-gray-900"
       } text-center`}
     >
       {provider ? (

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,6 +3,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, lazy, memo, useContext, useState } from "react";
 import { NavLink } from "react-router-dom";
 import Logo from "./Logo";
+import SourcifyMenu from "./SourcifyMenu";
 import Timestamp from "./components/Timestamp";
 import { useGenericSearch } from "./search/search";
 import { blockURL, slotURL } from "./url";
@@ -26,78 +27,84 @@ const Home: FC = () => {
   usePageTitle("Home");
 
   return (
-    <div className="flex grow flex-col items-center pb-5">
-      {isScanning && <CameraScanner turnOffScan={() => setScanning(false)} />}
-      <div className="mb-10 mt-5 flex max-h-64 grow items-end">
-        <Logo />
+    <>
+      <div className="flex justify-end py-2 px-3 lg:px-9">
+        <SourcifyMenu />
       </div>
-      <form
-        className="flex min-w-[24rem] w-1/3 flex-col"
-        onSubmit={handleSubmit}
-        autoComplete="off"
-        spellCheck={false}
-      >
-        <div className="mb-10 flex">
-          <input
-            className="w-full rounded-l border-b border-l border-t px-2 py-1 focus:outline-none"
-            type="text"
-            size={50}
-            data-test="home-search-input"
-            placeholder={`Search by address / txn hash / block number${
-              provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
-              null
-                ? " / ENS name"
-                : ""
-            }`}
-            onChange={handleChange}
-            ref={searchRef}
-            autoFocus
-          />
-          <button
-            className="flex items-center justify-center rounded-r border bg-skin-button-fill px-2 py-1 text-base text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"
-            type="button"
-            onClick={() => setScanning(true)}
-            title="Scan an ETH address using your camera"
-          >
-            <FontAwesomeIcon icon={faQrcode} />
-          </button>
+      <div className="flex grow flex-col items-center pb-5">
+        {isScanning && <CameraScanner turnOffScan={() => setScanning(false)} />}
+        <div className="mb-10 mt-5 flex max-h-64 grow items-end">
+          <Logo />
         </div>
-        <button
-          className="mx-auto mb-10 rounded bg-skin-button-fill px-3 py-1 hover:bg-skin-button-hover-fill focus:outline-none"
-          type="submit"
+        <form
+          className="flex min-w-[24rem] w-1/3 flex-col"
+          onSubmit={handleSubmit}
+          autoComplete="off"
+          spellCheck={false}
         >
-          Search
-        </button>
-      </form>
-      {!(config?.branding?.hideAnnouncements ?? false) &&
-        config?.experimental && (
-          <NavLink
-            className="text-md font-bold text-green-600 hover:text-green-800"
-            to="contracts/all"
+          <div className="mb-10 flex">
+            <input
+              className="w-full rounded-l border-b border-l border-t px-2 py-1 focus:outline-none"
+              type="text"
+              size={50}
+              data-test="home-search-input"
+              placeholder={`Search by address / txn hash / block number${
+                provider?._network.getPlugin(
+                  "org.ethers.plugins.network.Ens",
+                ) !== null
+                  ? " / ENS name"
+                  : ""
+              }`}
+              onChange={handleChange}
+              ref={searchRef}
+              autoFocus
+            />
+            <button
+              className="flex items-center justify-center rounded-r border bg-skin-button-fill px-2 py-1 text-base text-skin-button hover:bg-skin-button-hover-fill focus:outline-none"
+              type="button"
+              onClick={() => setScanning(true)}
+              title="Scan an ETH address using your camera"
+            >
+              <FontAwesomeIcon icon={faQrcode} />
+            </button>
+          </div>
+          <button
+            className="mx-auto mb-10 rounded bg-skin-button-fill px-3 py-1 hover:bg-skin-button-hover-fill focus:outline-none"
+            type="submit"
           >
-            🧪 EXPERIMENTAL CONTRACT BROWSER 🧪
+            Search
+          </button>
+        </form>
+        {!(config?.branding?.hideAnnouncements ?? false) &&
+          config?.experimental && (
+            <NavLink
+              className="text-md font-bold text-green-600 hover:text-green-800"
+              to="contracts/all"
+            >
+              🧪 EXPERIMENTAL CONTRACT BROWSER 🧪
+            </NavLink>
+          )}
+        {latestBlock && (
+          <NavLink
+            className="mt-5 flex flex-col items-center space-y-1 text-sm text-gray-500 hover:text-link-blue"
+            to={blockURL(latestBlock.number)}
+            data-test="home-latest-block-header"
+          >
+            <div>Latest block: {commify(latestBlock.number)}</div>
+            <Timestamp value={latestBlock.timestamp} />
           </NavLink>
         )}
-      {latestBlock && (
-        <NavLink
-          className="mt-5 flex flex-col items-center space-y-1 text-sm text-gray-500 hover:text-link-blue"
-          to={blockURL(latestBlock.number)}
-          data-test="home-latest-block-header"
-        >
-          <div>Latest block: {commify(latestBlock.number)}</div>
-          <Timestamp value={latestBlock.timestamp} />
-        </NavLink>
-      )}
-      {finalizedSlotNumber !== undefined && (
-        <NavLink
-          className="mt-5 flex flex-col items-center space-y-1 text-sm text-gray-500 hover:text-link-blue"
-          to={slotURL(finalizedSlotNumber)}
-        >
-          <div>Finalized slot: {commify(finalizedSlotNumber)}</div>
-          {slotTime && <Timestamp value={slotTime} />}
-        </NavLink>
-      )}
-    </div>
+        {finalizedSlotNumber !== undefined && (
+          <NavLink
+            className="mt-5 flex flex-col items-center space-y-1 text-sm text-gray-500 hover:text-link-blue"
+            to={slotURL(finalizedSlotNumber)}
+          >
+            <div>Finalized slot: {commify(finalizedSlotNumber)}</div>
+            {slotTime && <Timestamp value={slotTime} />}
+          </NavLink>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -28,7 +28,7 @@ const Home: FC = () => {
 
   return (
     <>
-      <div className="flex justify-end py-2 px-3 lg:px-9">
+      <div className="flex justify-end py-2 px-3 lg:px-9 h-[2.875rem]">
         <SourcifyMenu />
       </div>
       <div className="flex grow flex-col items-center pb-5">

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -83,7 +83,9 @@ export const SourcifyMenuItem: React.FC<
 export const SourcifyMenuTitle: React.FC<PropsWithChildren> = ({
   children,
 }) => (
-  <div className="border-b border-gray-300 px-2 py-1 text-xs">{children}</div>
+  <div className="border-b border-gray-300 px-2 py-1 text-xs select-none">
+    {children}
+  </div>
 );
 
 export default React.memo(SourcifyMenu);

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -40,6 +40,8 @@ const SourcifyMenu: React.FC = () => {
               <div className="my-1 border-b border-gray-300" />
             </>
           )}
+          <ThemeToggler />
+          <div className="my-1 border-b border-gray-300" />
           <SourcifyMenuItem
             checked={location.pathname !== "/broadcastTx"}
             onClick={() => {
@@ -48,8 +50,6 @@ const SourcifyMenu: React.FC = () => {
           >
             Broadcast Transaction
           </SourcifyMenuItem>
-          <div className="my-1 border-b border-gray-300" />
-          <ThemeToggler />
         </MenuItems>
       </div>
     </Menu>

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -3,11 +3,15 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import React, { PropsWithChildren } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import ThemeToggler from "./components/ThemeToggler";
 import { SourcifySource } from "./sourcify/useSourcify";
 import { useAppConfigContext } from "./useAppConfig";
 
 const SourcifyMenu: React.FC = () => {
-  const { sourcifySource, setSourcifySource } = useAppConfigContext();
+  const { sourcifySource, setSourcifySource } = useAppConfigContext() ?? {
+    sourcifySource: null,
+    setSourcifySource: (s: SourcifySource) => {},
+  };
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -18,22 +22,26 @@ const SourcifyMenu: React.FC = () => {
           <FontAwesomeIcon icon={faBars} size="1x" />
         </MenuButton>
         <MenuItems className="absolute right-0 mt-1 flex min-w-max flex-col rounded-b border bg-white p-1 text-sm">
-          <div className="border-b border-gray-300 px-2 py-1 text-xs">
-            Sourcify Datasource
-          </div>
-          <SourcifyMenuItem
-            checked={sourcifySource === SourcifySource.IPFS_IPNS}
-            onClick={() => setSourcifySource(SourcifySource.IPFS_IPNS)}
-          >
-            Resolve IPNS
-          </SourcifyMenuItem>
-          <SourcifyMenuItem
-            checked={sourcifySource === SourcifySource.CENTRAL_SERVER}
-            onClick={() => setSourcifySource(SourcifySource.CENTRAL_SERVER)}
-          >
-            Sourcify Servers
-          </SourcifyMenuItem>
-          <div className="my-1 border-b border-gray-300" />
+          {sourcifySource !== null && (
+            <>
+              <div className="border-b border-gray-300 px-2 py-1 text-xs">
+                Sourcify Datasource
+              </div>
+              <SourcifyMenuItem
+                checked={sourcifySource === SourcifySource.IPFS_IPNS}
+                onClick={() => setSourcifySource(SourcifySource.IPFS_IPNS)}
+              >
+                Resolve IPNS
+              </SourcifyMenuItem>
+              <SourcifyMenuItem
+                checked={sourcifySource === SourcifySource.CENTRAL_SERVER}
+                onClick={() => setSourcifySource(SourcifySource.CENTRAL_SERVER)}
+              >
+                Sourcify Servers
+              </SourcifyMenuItem>
+              <div className="my-1 border-b border-gray-300" />
+            </>
+          )}
           <SourcifyMenuItem
             checked={location.pathname !== "/broadcastTx"}
             onClick={() => {
@@ -41,6 +49,15 @@ const SourcifyMenu: React.FC = () => {
             }}
           >
             Broadcast Transaction
+          </SourcifyMenuItem>
+          <div className="my-1 border-b border-gray-300" />
+          <SourcifyMenuItem
+            checked={false}
+            onClick={(event) => {
+              event.preventDefault();
+            }}
+          >
+            <ThemeToggler />
           </SourcifyMenuItem>
         </MenuItems>
       </div>
@@ -50,7 +67,7 @@ const SourcifyMenu: React.FC = () => {
 
 type SourcifyMenuItemProps = {
   checked?: boolean;
-  onClick: () => void;
+  onClick: (event?: any) => void;
 };
 
 const SourcifyMenuItem: React.FC<PropsWithChildren<SourcifyMenuItemProps>> = ({

--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -24,9 +24,7 @@ const SourcifyMenu: React.FC = () => {
         <MenuItems className="absolute right-0 mt-1 flex min-w-max flex-col rounded-b border bg-white p-1 text-sm">
           {sourcifySource !== null && (
             <>
-              <div className="border-b border-gray-300 px-2 py-1 text-xs">
-                Sourcify Datasource
-              </div>
+              <SourcifyMenuTitle>Sourcify Datasource</SourcifyMenuTitle>
               <SourcifyMenuItem
                 checked={sourcifySource === SourcifySource.IPFS_IPNS}
                 onClick={() => setSourcifySource(SourcifySource.IPFS_IPNS)}
@@ -51,14 +49,7 @@ const SourcifyMenu: React.FC = () => {
             Broadcast Transaction
           </SourcifyMenuItem>
           <div className="my-1 border-b border-gray-300" />
-          <SourcifyMenuItem
-            checked={false}
-            onClick={(event) => {
-              event.preventDefault();
-            }}
-          >
-            <ThemeToggler />
-          </SourcifyMenuItem>
+          <ThemeToggler />
         </MenuItems>
       </div>
     </Menu>
@@ -70,11 +61,9 @@ type SourcifyMenuItemProps = {
   onClick: (event?: any) => void;
 };
 
-const SourcifyMenuItem: React.FC<PropsWithChildren<SourcifyMenuItemProps>> = ({
-  checked = false,
-  onClick,
-  children,
-}) => (
+export const SourcifyMenuItem: React.FC<
+  PropsWithChildren<SourcifyMenuItemProps>
+> = ({ checked = false, onClick, children }) => (
   <MenuItem>
     {({ focus }) => (
       <button
@@ -89,6 +78,12 @@ const SourcifyMenuItem: React.FC<PropsWithChildren<SourcifyMenuItemProps>> = ({
       </button>
     )}
   </MenuItem>
+);
+
+export const SourcifyMenuTitle: React.FC<PropsWithChildren> = ({
+  children,
+}) => (
+  <div className="border-b border-gray-300 px-2 py-1 text-xs">{children}</div>
 );
 
 export default React.memo(SourcifyMenu);

--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -43,7 +43,7 @@ const WarningHeader: React.FC = () => {
 
   return (
     <div
-      className="w-full bg-orange-400 px-2 py-1 text-center font-bold text-white"
+      className="w-full bg-orange-400 px-2 py-1 text-center font-bold text-white dark:text-gray-900"
       data-test="warning-header-network-name"
     >
       You are on {chainMsg}

--- a/src/components/ElementDiff.tsx
+++ b/src/components/ElementDiff.tsx
@@ -14,7 +14,7 @@ const ElementDiff: React.FC<ElementDiffProps> = ({
   <div className="flex flex-row overflow-hidden items-center gap-3">
     <div className="flex flex-col rounded overflow-hidden">
       {oldElem !== null && (
-        <div className="bg-opacity-10 bg-red-500 px-2 py-1">
+        <div className="bg-opacity-10 dark:bg-opacity-30 bg-red-500 px-2 py-1">
           <div className="flex items-start">
             <span className="text-gray-500 mr-4 font-data select-none">-</span>
             {oldElem}
@@ -22,7 +22,7 @@ const ElementDiff: React.FC<ElementDiffProps> = ({
         </div>
       )}
       {newElem !== null && (
-        <div className="bg-opacity-20 bg-green-300 px-2 py-1">
+        <div className="bg-opacity-20 dark:bg-green-300 bg-green-300 px-2 py-1">
           <div className="flex items-start">
             <span className="text-gray-500 mr-4 font-data select-none">+</span>
             {newElem}

--- a/src/components/ThemeToggler.stories.tsx
+++ b/src/components/ThemeToggler.stories.tsx
@@ -1,0 +1,11 @@
+import { Meta, StoryObj } from "@storybook/react";
+import ThemeToggler from "./ThemeToggler";
+
+const meta = {
+  component: ThemeToggler,
+} satisfies Meta<typeof ThemeToggler>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -2,8 +2,20 @@ import { faMoon, faSun } from "@fortawesome/free-regular-svg-icons";
 import { faDisplay } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useEffect, useState } from "react";
+import { SourcifyMenuItem, SourcifyMenuTitle } from "../SourcifyMenu";
 
 type Theme = "light" | "dark" | "system";
+
+function updateTheme(theme: Theme) {
+  const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const isDarkMode =
+    theme === "dark" || (theme === "system" && darkModeQuery.matches);
+  if (isDarkMode) {
+    document.documentElement.classList.add("dark");
+  } else {
+    document.documentElement.classList.remove("dark");
+  }
+}
 
 const ThemeToggler: React.FC = () => {
   const [theme, setTheme] = useState<Theme>(localStorage.theme ?? "system");
@@ -24,50 +36,44 @@ const ThemeToggler: React.FC = () => {
   }, [theme, setTheme, setUpdated]);
 
   useEffect(() => {
-    const isDarkMode =
-      theme === "dark" || (theme === "system" && darkModeQuery.matches);
-    if (isDarkMode) {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
+    updateTheme(theme);
   }, [theme, updated]);
 
   const handleThemeChange = (newTheme: Theme) => {
+    console.log("Starting");
     if (newTheme === "system") {
       localStorage.removeItem("theme");
     } else {
       localStorage.theme = newTheme;
     }
     setTheme(newTheme);
+    updateTheme(newTheme);
+    console.log("Ending");
   };
 
   return (
-    <div
-      className={`max-w-max mx-2 my-0.5 flex justify-left gap-1 bg-gray-50 rounded-full [&_>button]:transition [&_>button]:duration-100 [&_>button]:ease-in-out text-xs`}
-    >
-      <button
-        className={`px-3 py-1.5 rounded-full border ${theme === "light" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-800 text-gray-500`}
+    <>
+      <SourcifyMenuTitle>Theme</SourcifyMenuTitle>
+      <SourcifyMenuItem
+        checked={theme === "light"}
         onClick={() => handleThemeChange("light")}
-        title="Light theme"
       >
-        <FontAwesomeIcon icon={faSun} size="lg" />
-      </button>
-      <button
-        className={`px-3 py-1.5 rounded-full border ${theme === "dark" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-800 text-gray-500`}
+        <FontAwesomeIcon icon={faSun} className="w-4 mr-0.5" /> Light theme
+      </SourcifyMenuItem>
+      <SourcifyMenuItem
+        checked={theme === "dark"}
         onClick={() => handleThemeChange("dark")}
-        title="Dark theme"
       >
-        <FontAwesomeIcon icon={faMoon} size="lg" />
-      </button>
-      <button
-        className={`px-3 py-1.5 rounded-full border ${theme === "system" ? "border-gray-500" : "border-gray-300"} hover:border-gray-600 active:border-gray-800 text-gray-500`}
+        <FontAwesomeIcon icon={faMoon} className="w-4 mr-0.5" /> Dark theme
+      </SourcifyMenuItem>
+      <SourcifyMenuItem
+        checked={theme === "system"}
         onClick={() => handleThemeChange("system")}
-        title="System preference"
       >
-        <FontAwesomeIcon icon={faDisplay} size="lg" />
-      </button>
-    </div>
+        <FontAwesomeIcon icon={faDisplay} className="w-4 mr-0.5" /> System
+        default theme
+      </SourcifyMenuItem>
+    </>
   );
 };
 

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -1,0 +1,70 @@
+import { faCog, faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+const ThemeToggler: React.FC = () => {
+  const [theme, setTheme] = useState<Theme>(localStorage.theme ?? "system");
+  const [updated, setUpdated] = useState<number | null>(null);
+
+  const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  useEffect(() => {
+    const mediaQueryListener = (event: MediaQueryListEvent) => {
+      if (theme === "system") {
+        setUpdated(Date.now());
+      }
+    };
+    darkModeQuery.addEventListener("change", mediaQueryListener);
+
+    return () => {
+      darkModeQuery.removeEventListener("change", mediaQueryListener);
+    };
+  }, [theme, setTheme, setUpdated]);
+
+  useEffect(() => {
+    const isDarkMode =
+      theme === "dark" || (theme === "system" && darkModeQuery.matches);
+    if (isDarkMode) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [theme, updated]);
+
+  const handleThemeChange = (newTheme: Theme) => {
+    if (newTheme === "system") {
+      localStorage.removeItem("theme");
+    } else {
+      localStorage.theme = newTheme;
+    }
+    setTheme(newTheme);
+  };
+
+  return (
+    <div
+      className={`max-w-max mx-2 my-1 flex justify-left gap-1 bg-gray-100 rounded-full [&_>button]:transition [&_>button]:duration-100 [&_>button]:ease-in-out text-xs`}
+    >
+      <button
+        className={`px-4 py-2 rounded-full border-2 ${theme === "light" ? "border-gray-500" : "border-gray-300"} hover:border-yellow-500 active:border-yellow-600 text-gray-600`}
+        onClick={() => handleThemeChange("light")}
+      >
+        <FontAwesomeIcon icon={faSun} size="lg" />
+      </button>
+      <button
+        className={`px-4 py-2 rounded-full border-2 ${theme === "dark" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-700 text-gray-600`}
+        onClick={() => handleThemeChange("dark")}
+      >
+        <FontAwesomeIcon icon={faMoon} size="lg" />
+      </button>
+      <button
+        className={`px-4 py-2 rounded-full border-2 ${theme === "system" ? "border-gray-500" : "border-gray-300"} hover:border-gray-600 active:border-gray-800 text-gray-600`}
+        onClick={() => handleThemeChange("system")}
+      >
+        <FontAwesomeIcon icon={faCog} size="lg" />
+      </button>
+    </div>
+  );
+};
+
+export default ThemeToggler;

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -71,7 +71,6 @@ const ThemeToggler: React.FC = () => {
         onClick={() => handleThemeChange("system")}
       >
         <FontAwesomeIcon icon={faDisplay} className="w-4 mr-0.5" /> System
-        default
       </SourcifyMenuItem>
     </>
   );

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -58,20 +58,20 @@ const ThemeToggler: React.FC = () => {
         checked={theme === "light"}
         onClick={() => handleThemeChange("light")}
       >
-        <FontAwesomeIcon icon={faSun} className="w-4 mr-0.5" /> Light theme
+        <FontAwesomeIcon icon={faSun} className="w-4 mr-0.5" /> Light
       </SourcifyMenuItem>
       <SourcifyMenuItem
         checked={theme === "dark"}
         onClick={() => handleThemeChange("dark")}
       >
-        <FontAwesomeIcon icon={faMoon} className="w-4 mr-0.5" /> Dark theme
+        <FontAwesomeIcon icon={faMoon} className="w-4 mr-0.5" /> Dark
       </SourcifyMenuItem>
       <SourcifyMenuItem
         checked={theme === "system"}
         onClick={() => handleThemeChange("system")}
       >
         <FontAwesomeIcon icon={faDisplay} className="w-4 mr-0.5" /> System
-        default theme
+        default
       </SourcifyMenuItem>
     </>
   );

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -1,4 +1,4 @@
-import { faCog, faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
+import { faCog, faLightbulb, faMoon } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useEffect, useState } from "react";
 
@@ -48,18 +48,21 @@ const ThemeToggler: React.FC = () => {
       <button
         className={`px-4 py-2 rounded-full border-2 ${theme === "light" ? "border-gray-500" : "border-gray-300"} hover:border-yellow-500 active:border-yellow-600 text-gray-600`}
         onClick={() => handleThemeChange("light")}
+        title="Light theme"
       >
-        <FontAwesomeIcon icon={faSun} size="lg" />
+        <FontAwesomeIcon icon={faLightbulb} size="lg" />
       </button>
       <button
         className={`px-4 py-2 rounded-full border-2 ${theme === "dark" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-700 text-gray-600`}
         onClick={() => handleThemeChange("dark")}
+        title="Dark theme"
       >
         <FontAwesomeIcon icon={faMoon} size="lg" />
       </button>
       <button
         className={`px-4 py-2 rounded-full border-2 ${theme === "system" ? "border-gray-500" : "border-gray-300"} hover:border-gray-600 active:border-gray-800 text-gray-600`}
         onClick={() => handleThemeChange("system")}
+        title="System preference"
       >
         <FontAwesomeIcon icon={faCog} size="lg" />
       </button>

--- a/src/components/ThemeToggler.tsx
+++ b/src/components/ThemeToggler.tsx
@@ -1,4 +1,5 @@
-import { faCog, faLightbulb, faMoon } from "@fortawesome/free-solid-svg-icons";
+import { faMoon, faSun } from "@fortawesome/free-regular-svg-icons";
+import { faDisplay } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useEffect, useState } from "react";
 
@@ -43,28 +44,28 @@ const ThemeToggler: React.FC = () => {
 
   return (
     <div
-      className={`max-w-max mx-2 my-1 flex justify-left gap-1 bg-gray-100 rounded-full [&_>button]:transition [&_>button]:duration-100 [&_>button]:ease-in-out text-xs`}
+      className={`max-w-max mx-2 my-0.5 flex justify-left gap-1 bg-gray-50 rounded-full [&_>button]:transition [&_>button]:duration-100 [&_>button]:ease-in-out text-xs`}
     >
       <button
-        className={`px-4 py-2 rounded-full border-2 ${theme === "light" ? "border-gray-500" : "border-gray-300"} hover:border-yellow-500 active:border-yellow-600 text-gray-600`}
+        className={`px-3 py-1.5 rounded-full border ${theme === "light" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-800 text-gray-500`}
         onClick={() => handleThemeChange("light")}
         title="Light theme"
       >
-        <FontAwesomeIcon icon={faLightbulb} size="lg" />
+        <FontAwesomeIcon icon={faSun} size="lg" />
       </button>
       <button
-        className={`px-4 py-2 rounded-full border-2 ${theme === "dark" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-700 text-gray-600`}
+        className={`px-3 py-1.5 rounded-full border ${theme === "dark" ? "border-gray-500" : "border-gray-300"} hover:border-gray-700 active:border-gray-800 text-gray-500`}
         onClick={() => handleThemeChange("dark")}
         title="Dark theme"
       >
         <FontAwesomeIcon icon={faMoon} size="lg" />
       </button>
       <button
-        className={`px-4 py-2 rounded-full border-2 ${theme === "system" ? "border-gray-500" : "border-gray-300"} hover:border-gray-600 active:border-gray-800 text-gray-600`}
+        className={`px-3 py-1.5 rounded-full border ${theme === "system" ? "border-gray-500" : "border-gray-300"} hover:border-gray-600 active:border-gray-800 text-gray-500`}
         onClick={() => handleThemeChange("system")}
         title="System preference"
       >
-        <FontAwesomeIcon icon={faCog} size="lg" />
+        <FontAwesomeIcon icon={faDisplay} size="lg" />
       </button>
     </div>
   );

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -63,7 +63,10 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
       }`}
     >
       {creation && (
-        <span className="text-amber-300" title="Contract creation">
+        <span
+          className="text-amber-300 dark:text-amber-700"
+          title="Contract creation"
+        >
           <FontAwesomeIcon icon={faStar} size="1x" />
         </span>
       )}
@@ -83,7 +86,10 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
         </span>
       )}
       {miner && (
-        <span className="text-amber-400" title="Miner address">
+        <span
+          className="text-amber-400 dark:text-amber-600"
+          title="Miner address"
+        >
           <FontAwesomeIcon icon={faCoins} size="1x" />
         </span>
       )}

--- a/src/execution/transaction/RewardSplit.tsx
+++ b/src/execution/transaction/RewardSplit.tsx
@@ -56,7 +56,10 @@ const RewardSplit: React.FC<RewardSplitProps> = ({ txData }) => {
         />
         <div className="flex items-baseline space-x-1">
           <span className="flex space-x-1">
-            <span className="text-amber-300" title="Miner fees">
+            <span
+              className="text-amber-300 dark:text-amber-700"
+              title="Miner fees"
+            >
               <FontAwesomeIcon icon={faCoins} size="1x" />
             </span>
             <span>

--- a/src/index.css
+++ b/src/index.css
@@ -28,3 +28,17 @@
     --color-table-row-hover: 2, 132, 199;
   }
 }
+
+@layer components {
+  .dark-mode {
+    @apply dark:invert dark:-hue-rotate-180 dark:brightness-90;
+  }
+
+  .dark-no-invert {
+    @apply dark:invert dark:hue-rotate-180 dark:saturate-[1.25];
+  }
+
+  img {
+    @apply dark-no-invert;
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,13 @@ root.render(
     <HelmetProvider>
       <Helmet>
         <link rel="preload" href={spaceGrotesk} as="font" type="font/woff2" />
+        <script>
+          {`if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+              document.documentElement.classList.add('dark');
+            } else {
+              document.documentElement.classList.remove('dark');
+            }`}
+        </script>
       </Helmet>
       <App />
     </HelmetProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ export default {
     extend: {
       colors: {
         "link-blue": "#3498db",
+        "link-blue-light": "#95c9ec",
         "link-blue-hover": "#0468ab",
         "verified-contract": "#2b50aa",
         "verified-contract-hover": "#26007b",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,7 @@ function withOpacity(variableName) {
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ["./src/**/*.{js,jsx,ts,tsx}", "./index.html"],
+  darkMode: "selector",
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
Dark mode is enabled when the browser's color scheme preference is set to dark.

With color inversion + hue rotation providing most of the dark colors, it should be easy to maintain. One-off changes can be set with the `dark:` class prefix.

![image](https://github.com/otterscan/otterscan/assets/125761775/3c5974a9-0a59-42da-8ea2-cc0b79a7c010)

Closes #280.