### PR TITLE
Align items in decoded params table with baseline

### DIFF
--- a/src/execution/transaction/decoder/DecodedParamRow.tsx
+++ b/src/execution/transaction/decoder/DecodedParamRow.tsx
@@ -36,7 +36,7 @@ const DecodedParamRow: FC<DecodedParamRowProps> = ({
 
   return (
     <>
-      <tr className="grid grid-cols-12 gap-x-2 py-2 hover:bg-gray-100">
+      <tr className="grid grid-cols-12 gap-x-2 py-2 hover:bg-gray-100 items-baseline">
         <td className="col-span-3 pl-1">
           <div className="flex items-baseline space-x-2">
             <span>


### PR DESCRIPTION
Fixes #269 

Before:
![image](https://github.com/otterscan/otterscan/assets/125761775/7e28ef87-5b46-46d9-9c62-fbb396860c15)
After:
![image](https://github.com/otterscan/otterscan/assets/125761775/c728854c-63f3-4a7c-89df-dc5fb5d46991)

Another example:
![image](https://github.com/otterscan/otterscan/assets/125761775/ab66cec7-63a1-464a-8e15-925ca3c44078)
becomes
![image](https://github.com/otterscan/otterscan/assets/125761775/eff1822f-04c4-4d9e-a12c-55903d9d64f4)
