### PR TITLE
Add slot and validator columns to Blocks Rewarded table

### DIFF
--- a/src/execution/address/BlockRewardedItem.tsx
+++ b/src/execution/address/BlockRewardedItem.tsx
@@ -1,9 +1,15 @@
-import { FC, memo } from "react";
+import { FC, memo, useContext } from "react";
 import BlockLink from "../../components/BlockLink";
 import NativeTokenAmount from "../../components/NativeTokenAmount";
 import TimestampAge from "../../components/TimestampAge";
+import SlotLink from "../../consensus/components/SlotLink";
+import ValidatorLink from "../../consensus/components/ValidatorLink";
 import { BlockNumberContext } from "../../useBlockTagContext";
+import { useSlotHeader } from "../../useConsensus";
+import { useBlockData } from "../../useErigonHooks";
+import { RuntimeContext } from "../../useRuntime";
 import { AddressAwareComponentProps } from "../types";
+import PendingItem from "./PendingItem";
 
 export type BlockRewardedItemProps = AddressAwareComponentProps & {
   blockNumber: number;
@@ -17,6 +23,16 @@ const BlockRewardedItem: FC<BlockRewardedItemProps> = ({
   timestamp,
   totalFees,
 }) => {
+  const { config, provider } = useContext(RuntimeContext);
+  const { data: nextBlock, isLoading: isLoadingBlockData } = useBlockData(
+    provider,
+    (blockNumber + 1).toString(),
+  );
+  const { slot, isLoading: isLoadingSlotData } = useSlotHeader(
+    nextBlock?.parentBeaconBlockRoot ?? null,
+  );
+
+  const proposerIndex = slot?.data?.header?.message?.["proposer_index"];
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>
@@ -29,6 +45,38 @@ const BlockRewardedItem: FC<BlockRewardedItemProps> = ({
         <td>
           <NativeTokenAmount value={totalFees} />
         </td>
+        {config?.beaconAPI !== undefined && (
+          <>
+            <td>
+              {isLoadingBlockData || isLoadingSlotData ? (
+                <div className="w-80">
+                  <PendingItem />
+                </div>
+              ) : slot && slot?.data?.header?.message?.slot ? (
+                <div>
+                  <SlotLink slot={Number(slot?.data?.header?.message?.slot)} />
+                </div>
+              ) : (
+                <span className="text-gray-400">Not available</span>
+              )}
+            </td>
+            <td>
+              {isLoadingBlockData || isLoadingSlotData ? (
+                <div className="w-80">
+                  <PendingItem />
+                </div>
+              ) : (
+                <div>
+                  {proposerIndex !== undefined ? (
+                    <ValidatorLink validatorIndex={proposerIndex} />
+                  ) : (
+                    <span className="text-gray-400">Not available</span>
+                  )}
+                </div>
+              )}
+            </td>
+          </>
+        )}
       </tr>
     </BlockNumberContext.Provider>
   );

--- a/src/execution/address/BlocksRewarded.tsx
+++ b/src/execution/address/BlocksRewarded.tsx
@@ -13,16 +13,8 @@ import { AddressAwareComponentProps } from "../types";
 import BlockRewardedItem, { BlockRewardedItemProps } from "./BlockRewardedItem";
 import GenericTransactionSearchResult from "./GenericTransactionSearchResult";
 
-const searchHeader = (
-  <StandardTHead>
-    <th className="w-28">Block</th>
-    <th className="w-36">Age</th>
-    <th className="w-36">Block fees</th>
-  </StandardTHead>
-);
-
 const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
-  const { provider } = useContext(RuntimeContext);
+  const { config, provider } = useContext(RuntimeContext);
 
   const pageNumber = usePageNumber();
   const total = useGenericTransactionCount(provider, "BlocksRewarded", address);
@@ -49,6 +41,20 @@ const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
     [results],
   );
 
+  const searchHeader = (
+    <StandardTHead>
+      <th className="w-28">Block</th>
+      <th className="w-32">Age</th>
+      <th className="w-36">Block fees</th>
+      {config?.beaconAPI && (
+        <>
+          <th className="w-28">Slot</th>
+          <th className="w-28">Validator</th>
+        </>
+      )}
+    </StandardTHead>
+  );
+
   usePageTitle(`Blocks Rewarded | ${address}`);
 
   return (
@@ -59,7 +65,7 @@ const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
       Item={(i) => <BlockRewardedItem {...i} />}
       header={searchHeader}
       typeName="block"
-      columns={3}
+      columns={config?.beaconAPI === undefined ? 3 : 5}
     />
   );
 };

--- a/src/useConsensus.ts
+++ b/src/useConsensus.ts
@@ -156,6 +156,21 @@ export const useSlot = (slot: number | string) => {
   };
 };
 
+export const useSlotHeader = (slot: number | string | null) => {
+  const url = useBeaconHeaderURL(slot === null ? "" : slot.toString());
+  const { data, error, isLoading, isValidating } = useSWR(
+    slot === null ? null : url,
+    jsonFetcherWithErrorHandling,
+  );
+
+  return {
+    slot: data,
+    error,
+    isLoading,
+    isValidating,
+  };
+};
+
 export const useBlockRoot = (slotNumber: number) => {
   const url = useBlockRootURL(slotNumber);
   const { data, error, isLoading, isValidating } = useSWRImmutable(

--- a/src/useConsensus.ts
+++ b/src/useConsensus.ts
@@ -158,7 +158,7 @@ export const useSlot = (slot: number | string) => {
 
 export const useSlotHeader = (slot: number | string | null) => {
   const url = useBeaconHeaderURL(slot === null ? "" : slot.toString());
-  const { data, error, isLoading, isValidating } = useSWR(
+  const { data, error, isLoading, isValidating } = useSWRImmutable(
     slot === null ? null : url,
     jsonFetcherWithErrorHandling,
   );


### PR DESCRIPTION
Closes #1356 

The beacon block is found from the parent beacon block root in the execution block header.

Example:
![image](https://github.com/otterscan/otterscan/assets/125761775/488e5d3a-a673-4a8b-8da4-6f208c14a02f)

When old slot data (or parent beacon block root) is not available:
![image](https://github.com/otterscan/otterscan/assets/125761775/d8375ce3-3fe4-44a2-a139-260c4154231e)

If the beacon API is not set in the config, these new beacon chain columns will not be shown.