### PR TITLE
Add whatsabi ABI filling prototype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@headlessui/react": "^2.0.4",
         "@otterscan/react-qr-reader": "^5.2.0",
+        "@shazow/whatsabi": "^0.12.0",
         "@storybook/test": "^8.1.10",
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^15.0.5",
@@ -4916,6 +4917,17 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@shazow/whatsabi": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@shazow/whatsabi/-/whatsabi-0.12.0.tgz",
+      "integrity": "sha512-wA6gaRW7G9eKG0YtZKEk+slxXOzsmTfWBsgMCscf8XiHe+7XrVP4HbSHkXqW8O2cU4RTBJKnsD/aIcieu5jR8Q==",
+      "dependencies": {
+        "ethers": "^6.13.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1"
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "1.7.0",
@@ -23828,6 +23840,14 @@
       "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
       "dev": true,
       "optional": true
+    },
+    "@shazow/whatsabi": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@shazow/whatsabi/-/whatsabi-0.12.0.tgz",
+      "integrity": "sha512-wA6gaRW7G9eKG0YtZKEk+slxXOzsmTfWBsgMCscf8XiHe+7XrVP4HbSHkXqW8O2cU4RTBJKnsD/aIcieu5jR8Q==",
+      "requires": {
+        "ethers": "^6.13.0"
+      }
     },
     "@shikijs/core": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@headlessui/react": "^2.0.4",
     "@otterscan/react-qr-reader": "^5.2.0",
+    "@shazow/whatsabi": "^0.12.0",
     "@storybook/test": "^8.1.10",
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^15.0.5",

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -15,7 +15,10 @@ import NavTab from "../components/NavTab";
 import StandardFrame from "../components/StandardFrame";
 import { useProxyAttributes } from "../ots2/usePrototypeTransferHooks";
 import SourcifyLogo from "../sourcify/SourcifyLogo";
-import { useSourcifyMetadata } from "../sourcify/useSourcify";
+import {
+  useSourcifyMetadata,
+  useWhatsabiMetadata,
+} from "../sourcify/useSourcify";
 import { ChecksummedAddress } from "../types";
 import { useHasCode } from "../useErigonHooks";
 import { useAddressOrENS } from "../useResolvedAddresses";
@@ -107,6 +110,12 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
     hasCode ? checksummedAddress : undefined,
     provider?._network.chainId,
   );
+  const whatsabiMatch = useWhatsabiMetadata(
+    match === null && hasCode ? checksummedAddress : undefined,
+    provider?._network.chainId,
+    provider,
+    config?.assetsURLPrefix,
+  );
 
   return (
     <StandardFrame>
@@ -175,7 +184,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
                     </span>
                   </NavTab>
                 )}
-                {hasCode && match && (
+                {hasCode && (match || whatsabiMatch) && (
                   <NavTab href={`/address/${addressOrName}/readContract`}>
                     <span className={`flex items-baseline space-x-2`}>
                       <span>Read Contract</span>
@@ -237,7 +246,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
                     element={
                       <Contracts
                         checksummedAddress={checksummedAddress}
-                        match={match}
+                        match={match ?? whatsabiMatch}
                       />
                     }
                   />
@@ -246,7 +255,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
                     element={
                       <ReadContract
                         checksummedAddress={checksummedAddress}
-                        match={match}
+                        match={match ?? whatsabiMatch}
                       />
                     }
                   />

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -15,10 +15,8 @@ import NavTab from "../components/NavTab";
 import StandardFrame from "../components/StandardFrame";
 import { useProxyAttributes } from "../ots2/usePrototypeTransferHooks";
 import SourcifyLogo from "../sourcify/SourcifyLogo";
-import {
-  useSourcifyMetadata,
-  useWhatsabiMetadata,
-} from "../sourcify/useSourcify";
+import { useSourcifyMetadata } from "../sourcify/useSourcify";
+import { useWhatsabiMetadata } from "../sourcify/useWhatsabi";
 import { ChecksummedAddress } from "../types";
 import { useHasCode } from "../useErigonHooks";
 import { useAddressOrENS } from "../useResolvedAddresses";

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -53,7 +53,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
             <FontAwesomeIcon icon={faWarning} className="mr-2" />
             <span className="text-md">
               Contract not found in Sourcify respository. Below is an estimate
-              of the ABI from its bytecode:
+              of the ABI from its bytecode.
             </span>
           </div>
         </>

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -53,7 +53,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
             <FontAwesomeIcon icon={faWarning} className="mr-2" />
             <span className="text-md">
               Contract not found in Sourcify respository. Below is an estimate
-              of the ABI from its bytecode using known function selectors:
+              of the ABI from its bytecode:
             </span>
           </div>
         </>
@@ -102,7 +102,10 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
         {match !== undefined && match !== null && (
           <>
             {match.metadata.output.abi && (
-              <ContractABI abi={match.metadata.output.abi} />
+              <ContractABI
+                abi={match.metadata.output.abi}
+                unknownSelectors={match.unknownSelectors}
+              />
             )}
             {match.type !== MatchType.WHATSABI_GUESS && (
               <div>

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -1,4 +1,4 @@
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import React, { lazy, useContext, useEffect, useState } from "react";
@@ -44,7 +44,21 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
 
   return (
     <ContentFrame tabs>
-      {match && (
+      {match && match.type === MatchType.WHATSABI_GUESS && (
+        <>
+          <div
+            className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-3 py-2.5 mb-4 rounded mt-2"
+            role="alert"
+          >
+            <FontAwesomeIcon icon={faWarning} className="mr-2" />
+            <span className="text-md">
+              Contract not found in Sourcify respository. Below is an estimate
+              of the ABI from its bytecode using known function selectors:
+            </span>
+          </div>
+        </>
+      )}
+      {match && match.type !== MatchType.WHATSABI_GUESS && (
         <>
           {match.metadata.settings?.compilationTarget && (
             <InfoRow title="Name">
@@ -90,64 +104,66 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
             {match.metadata.output.abi && (
               <ContractABI abi={match.metadata.output.abi} />
             )}
-            <div>
-              <Menu>
-                <div className="flex items-baseline justify-between space-x-2">
-                  <MenuButton className="flex space-x-2 rounded-t border-l border-r border-t px-2 py-1 text-sm">
-                    <span>{selected}</span>
-                    <span className="self-center">
-                      <FontAwesomeIcon icon={faChevronDown} size="xs" />
-                    </span>
-                  </MenuButton>
-                  {provider && (
-                    <div className="text-sm">
-                      <ExternalLink
-                        href={openInRemixURL(
-                          checksummedAddress,
-                          provider._network.chainId,
-                        )}
-                      >
-                        Open in Remix
-                      </ExternalLink>
-                    </div>
-                  )}
-                </div>
-                <div className="relative">
-                  <MenuItems className="absolute z-10 flex flex-col rounded-b border bg-white p-1">
-                    {Object.entries(match.metadata.sources).map(([k]) => (
-                      <MenuItem key={k}>
-                        <button
-                          className={`flex px-2 py-1 text-sm ${
-                            selected === k
-                              ? "bg-gray-200 font-bold text-gray-500"
-                              : "text-gray-400 transition-colors duration-75 hover:text-gray-500"
-                          }`}
-                          onClick={() => setSelected(k)}
+            {match.type !== MatchType.WHATSABI_GUESS && (
+              <div>
+                <Menu>
+                  <div className="flex items-baseline justify-between space-x-2">
+                    <MenuButton className="flex space-x-2 rounded-t border-l border-r border-t px-2 py-1 text-sm">
+                      <span>{selected}</span>
+                      <span className="self-center">
+                        <FontAwesomeIcon icon={faChevronDown} size="xs" />
+                      </span>
+                    </MenuButton>
+                    {provider && (
+                      <div className="text-sm">
+                        <ExternalLink
+                          href={openInRemixURL(
+                            checksummedAddress,
+                            provider._network.chainId,
+                          )}
                         >
-                          {k}
-                        </button>
-                      </MenuItem>
-                    ))}
-                  </MenuItems>
-                </div>
-              </Menu>
-              {selected && (
-                <>
-                  {match.metadata.sources[selected].content ? (
-                    <HighlightedSolidity
-                      source={match.metadata.sources[selected].content}
-                    />
-                  ) : (
-                    <ContractFromRepo
-                      checksummedAddress={checksummedAddress}
-                      networkId={provider!._network.chainId}
-                      filename={selected}
-                      type={match.type}
-                    />
-                  )}
-                </>
-              )}
-            </div>
+                          Open in Remix
+                        </ExternalLink>
+                      </div>
+                    )}
+                  </div>
+                  <div className="relative">
+                    <MenuItems className="absolute z-10 flex flex-col rounded-b border bg-white p-1">
+                      {Object.entries(match.metadata.sources).map(([k]) => (
+                        <MenuItem key={k}>
+                          <button
+                            className={`flex px-2 py-1 text-sm ${
+                              selected === k
+                                ? "bg-gray-200 font-bold text-gray-500"
+                                : "text-gray-400 transition-colors duration-75 hover:text-gray-500"
+                            }`}
+                            onClick={() => setSelected(k)}
+                          >
+                            {k}
+                          </button>
+                        </MenuItem>
+                      ))}
+                    </MenuItems>
+                  </div>
+                </Menu>
+                {selected && (
+                  <>
+                    {match.metadata.sources[selected].content ? (
+                      <HighlightedSolidity
+                        source={match.metadata.sources[selected].content}
+                      />
+                    ) : (
+                      <ContractFromRepo
+                        checksummedAddress={checksummedAddress}
+                        networkId={provider!._network.chainId}
+                        filename={selected}
+                        type={match.type}
+                      />
+                    )}
+                  </>
+                )}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -1,4 +1,4 @@
-import { faChevronDown, faWarning } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import React, { lazy, useContext, useEffect, useState } from "react";
@@ -13,6 +13,7 @@ import { RuntimeContext } from "../../useRuntime";
 import { usePageTitle } from "../../useTitle";
 import { commify } from "../../utils/utils";
 import ContractFromRepo from "./ContractFromRepo";
+import WhatsabiWarning from "./WhatsabiWarning";
 import ContractABI from "./contract/ContractABI";
 
 const HighlightedSolidity = lazy(
@@ -44,20 +45,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
 
   return (
     <ContentFrame tabs>
-      {match && match.type === MatchType.WHATSABI_GUESS && (
-        <>
-          <div
-            className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-3 py-2.5 mb-4 rounded mt-2"
-            role="alert"
-          >
-            <FontAwesomeIcon icon={faWarning} className="mr-2" />
-            <span className="text-md">
-              Contract not found in Sourcify respository. Below is an estimate
-              of the ABI from its bytecode.
-            </span>
-          </div>
-        </>
-      )}
+      {match && match.type === MatchType.WHATSABI_GUESS && <WhatsabiWarning />}
       {match && match.type !== MatchType.WHATSABI_GUESS && (
         <>
           {match.metadata.settings?.compilationTarget && (

--- a/src/execution/address/WhatsabiWarning.tsx
+++ b/src/execution/address/WhatsabiWarning.tsx
@@ -1,0 +1,18 @@
+import { faWarning } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+
+const WhatsabiWarning: React.FC = () => (
+  <div
+    className="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-3 py-2.5 mb-4 rounded mt-2"
+    role="alert"
+  >
+    <FontAwesomeIcon icon={faWarning} className="mr-2" />
+    <span className="text-md">
+      Contract not found in Sourcify respository. Below is an estimate of the
+      ABI from its bytecode.
+    </span>
+  </div>
+);
+
+export default WhatsabiWarning;

--- a/src/execution/address/contract/ContractABI.tsx
+++ b/src/execution/address/contract/ContractABI.tsx
@@ -6,7 +6,7 @@ import { ABIAwareComponentProps } from "../../types";
 import DecodedABI from "./DecodedABI";
 import RawABI from "./RawABI";
 
-const ContractABI: FC<ABIAwareComponentProps> = ({ abi }) => (
+const ContractABI: FC<ABIAwareComponentProps> = ({ abi, unknownSelectors }) => (
   <div className="mb-3">
     <TabGroup>
       <TabList className="mb-1 flex items-baseline space-x-1">
@@ -19,7 +19,7 @@ const ContractABI: FC<ABIAwareComponentProps> = ({ abi }) => (
       </TabList>
       <TabPanels>
         <TabPanel>
-          <DecodedABI abi={abi} />
+          <DecodedABI abi={abi} unknownSelectors={unknownSelectors} />
         </TabPanel>
         <TabPanel>
           <RawABI abi={abi} />

--- a/src/execution/address/contract/DecodedABI.tsx
+++ b/src/execution/address/contract/DecodedABI.tsx
@@ -2,14 +2,28 @@ import { Interface } from "ethers";
 import { FC, memo } from "react";
 import { ABIAwareComponentProps } from "../../types";
 import DecodedFragment from "./DecodedFragment";
+import RawDecodedFragment from "./RawDecodedFragment";
 
-const DecodedABI: FC<ABIAwareComponentProps> = ({ abi }) => {
+const DecodedABI: FC<ABIAwareComponentProps> = ({ abi, unknownSelectors }) => {
   const intf = new Interface(abi);
   return (
     <div className="overflow-x-auto border">
       {intf.fragments.map((f, i) => (
         <DecodedFragment key={i} intf={intf} fragment={f} />
       ))}
+      {unknownSelectors && unknownSelectors.length > 0 && (
+        <div className="ml-2 mt-3 text-sm">Unknown functions:</div>
+      )}
+      {unknownSelectors &&
+        unknownSelectors.map((selector) => (
+          <RawDecodedFragment
+            fragmentType="function"
+            sig={selector}
+            letter="F"
+            letterBg="bg-violet-500"
+            hashBg="bg-violet-50"
+          />
+        ))}
     </div>
   );
 };

--- a/src/execution/address/contract/DecodedFragment.tsx
+++ b/src/execution/address/contract/DecodedFragment.tsx
@@ -1,5 +1,3 @@
-import { faCaretRight } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   ConstructorFragment,
   ErrorFragment,
@@ -9,6 +7,7 @@ import {
   Interface,
 } from "ethers";
 import { FC, memo } from "react";
+import RawDecodedFragment from "./RawDecodedFragment";
 
 type DecodedFragmentProps = {
   intf: Interface;
@@ -47,35 +46,14 @@ const DecodedFragment: FC<DecodedFragmentProps> = ({ intf, fragment }) => {
   }
 
   return (
-    <div className="flex items-baseline space-x-2 px-2 py-1 hover:bg-gray-100">
-      <span className="text-gray-500">
-        <FontAwesomeIcon icon={faCaretRight} size="1x" />
-      </span>
-      {letter && (
-        <span
-          className={`flex h-5 w-5 shrink-0 items-center justify-center self-center rounded-full border border-gray-300 font-code text-xs font-bold text-white ${letterBg}`}
-        >
-          {letter}
-        </span>
-      )}
-      <span className="whitespace-nowrap font-code text-sm">
-        {fragment.format("full")}
-      </span>
-      {sig && (
-        <span
-          className={`rounded-xl border px-2 pt-1 font-code text-xs text-gray-600 ${hashBg}`}
-          title={
-            fragmentType === "function"
-              ? "Method Selector"
-              : fragmentType === "event"
-                ? "Topic Hash"
-                : ""
-          }
-        >
-          {sig}
-        </span>
-      )}
-    </div>
+    <RawDecodedFragment
+      fragmentType={fragmentType}
+      fragmentStr={fragment.format("full")}
+      sig={sig}
+      letter={letter}
+      letterBg={letterBg}
+      hashBg={hashBg}
+    />
   );
 };
 

--- a/src/execution/address/contract/RawDecodedFragment.tsx
+++ b/src/execution/address/contract/RawDecodedFragment.tsx
@@ -1,0 +1,57 @@
+import { faCaretRight } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC, JSX, memo } from "react";
+
+type RawDecodedFragmentProps = {
+  fragmentType?: "constructor" | "event" | "function" | "error";
+  fragmentStr?: JSX.Element | string;
+  sig?: string;
+  letter?: string;
+  letterBg?: string;
+  hashBg?: string;
+};
+
+const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
+  fragmentType,
+  fragmentStr,
+  sig,
+  letter,
+  letterBg,
+  hashBg,
+}) => {
+  return (
+    <div className="flex items-baseline space-x-2 px-2 py-1 hover:bg-gray-100">
+      <span className="text-gray-500">
+        <FontAwesomeIcon icon={faCaretRight} size="1x" />
+      </span>
+      {letter && (
+        <span
+          className={`flex h-5 w-5 shrink-0 items-center justify-center self-center rounded-full border border-gray-300 font-code text-xs font-bold text-white ${letterBg}`}
+        >
+          {letter}
+        </span>
+      )}
+      {fragmentStr !== undefined && (
+        <span className="whitespace-nowrap font-code text-sm">
+          {fragmentStr}
+        </span>
+      )}
+      {sig && (
+        <span
+          className={`rounded-xl border px-2 pt-1 font-code text-xs text-gray-600 ${hashBg}`}
+          title={
+            fragmentType === "function"
+              ? "Method Selector"
+              : fragmentType === "event"
+                ? "Topic Hash"
+                : ""
+          }
+        >
+          {sig}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default memo(RawDecodedFragment);

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -3,9 +3,10 @@ import React, { useContext, useState } from "react";
 import ContentFrame from "../../../components/ContentFrame";
 import LabeledSwitch from "../../../components/LabeledSwitch";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
-import { Match } from "../../../sourcify/useSourcify";
+import { Match, MatchType } from "../../../sourcify/useSourcify";
 import { RuntimeContext } from "../../../useRuntime";
 import { usePageTitle } from "../../../useTitle";
+import WhatsabiWarning from "../WhatsabiWarning";
 import ReadFunction from "./ReadFunction";
 
 type ContractsProps = {
@@ -38,6 +39,9 @@ const ReadContract: React.FC<ContractsProps> = ({
   return (
     <StandardSelectionBoundary>
       <ContentFrame tabs>
+        {match && match.type === MatchType.WHATSABI_GUESS && (
+          <WhatsabiWarning />
+        )}
         <div className="py-5">
           {match === undefined && (
             <span>Getting data from Sourcify repository...</span>

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -35,6 +35,7 @@ const ReadContract: React.FC<ContractsProps> = ({
   const nonViewReturns = match?.metadata.output.abi.filter(
     (fn) => fn.outputs && fn.outputs.length > 0 && !isReadFunction(fn),
   );
+  const showDecodedOutputs = match?.type !== MatchType.WHATSABI_GUESS;
 
   return (
     <StandardSelectionBoundary>
@@ -69,6 +70,7 @@ const ReadContract: React.FC<ContractsProps> = ({
                           FunctionFragment.from(fn).format("sighash")
                         ]
                       }
+                      showDecodedOutputs={showDecodedOutputs}
                       key={i}
                     />
                   ))}
@@ -92,6 +94,7 @@ const ReadContract: React.FC<ContractsProps> = ({
                                   FunctionFragment.from(fn).format("sighash")
                                 ]
                               }
+                              showDecodedOutputs={showDecodedOutputs}
                               key={i}
                             />
                           ))}

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -19,12 +19,6 @@ import FunctionParamInput, {
 } from "./FunctionParamInput";
 import { parse } from "./contractInputDataParser";
 
-interface ReadFunctionProps {
-  address: string;
-  func: FunctionFragment;
-  devMethod?: DevMethod;
-}
-
 /**
  * Prepares an unprocessed argument string by coercing it into the proper
  * format in some cases as a convenience feature
@@ -167,7 +161,19 @@ async function parseStructuredArgument(
   throw new Error("Unhandled parse sequence: " + argType.format("full"));
 }
 
-const ReadFunction: FC<ReadFunctionProps> = ({ address, func, devMethod }) => {
+interface ReadFunctionProps {
+  address: string;
+  func: FunctionFragment;
+  devMethod?: DevMethod;
+  showDecodedOutputs?: boolean;
+}
+
+const ReadFunction: FC<ReadFunctionProps> = ({
+  address,
+  func,
+  devMethod,
+  showDecodedOutputs = true,
+}) => {
   let [result, setResult] = useState<
     { result: Result; data: string } | null | undefined
   >(null);
@@ -257,7 +263,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({ address, func, devMethod }) => {
         {result && (
           <OutputDecoder
             args={result.result}
-            paramTypes={func.outputs || []}
+            paramTypes={showDecodedOutputs ? func.outputs ?? [] : null}
             data={result.data}
             devMethod={devMethod}
           />

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -13,4 +13,5 @@ export type AddressAwareComponentProps = {
  */
 export type ABIAwareComponentProps = {
   abi: any[];
+  unknownSelectors?: string[];
 };

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -193,9 +193,9 @@ function whatsabiFetcher(
       const unknownSelectors = selectors.filter(
         (selector, i) => decodedFunctions[i] === null,
       );
-      const functions: string[] = decodedFunctions.filter(
-        (sig) => sig !== null,
-      ) as string[];
+      const functions: string[] = decodedFunctions
+        .filter((sig) => sig !== null)
+        .sort() as string[];
       const int = Interface.from([...functions]);
       const abi = JSON.parse(int.formatJson());
       const metadata = {

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -1,10 +1,8 @@
-import { whatsabi } from "@shazow/whatsabi";
-import { ErrorDescription, Interface, JsonRpcApiProvider } from "ethers";
+import { ErrorDescription, Interface } from "ethers";
 import { useContext, useMemo } from "react";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { ChecksummedAddress, TransactionDescriptionData } from "../types";
-import { fourBytesURL } from "../url";
 import { useAppConfigContext } from "../useAppConfig";
 import { RuntimeContext } from "../useRuntime";
 
@@ -162,64 +160,6 @@ export type Match = {
   unknownSelectors?: string[];
 };
 
-function whatsabiFetcher(
-  provider: JsonRpcApiProvider | undefined,
-  assetsURLPrefix: string | undefined,
-): Fetcher<Match | null | undefined, ["whatsabi", ChecksummedAddress, bigint]> {
-  return async ([_, address, chainId]) => {
-    if (provider && assetsURLPrefix !== undefined) {
-      const code = await provider.getCode(address);
-      const selectors = whatsabi.selectorsFromBytecode(code);
-      const decodedFunctions: (string | null)[] = await Promise.all(
-        selectors.map(async (selector) => {
-          try {
-            const result = await fetch(
-              fourBytesURL(assetsURLPrefix, selector.slice(2)),
-            );
-            if (!result.ok) {
-              throw new Error(
-                `4bytes fetch returned ${result.status} response`,
-              );
-            }
-            const text = await result.text();
-            const sig = text.split(";")[0];
-            if (sig.length > 0) {
-              return `function ${sig} external view`;
-            }
-          } catch (e) {}
-          return null;
-        }),
-      );
-      const unknownSelectors = selectors.filter(
-        (selector, i) => decodedFunctions[i] === null,
-      );
-      const functions: string[] = decodedFunctions
-        .filter((sig) => sig !== null)
-        .sort() as string[];
-      const int = Interface.from([...functions]);
-      const abi = JSON.parse(int.formatJson());
-      const metadata = {
-        version: "Unknown",
-        language: "Unknown",
-        compiler: { version: "Unknown" },
-        sources: {},
-        // settings: {remappings: [], compilationTarget: {}, libraries: {}},
-        output: {
-          abi,
-        },
-      };
-
-      return {
-        type: MatchType.WHATSABI_GUESS,
-        metadata: metadata,
-        unknownSelectors,
-      };
-    }
-
-    return null;
-  };
-}
-
 function sourcifyFetcher(
   sourcifySources: SourcifySourceMap,
 ): Fetcher<
@@ -287,24 +227,6 @@ export const useSourcifyMetadata = (
   const fetcher = sourcifyFetcher(sourcifySources);
   const { data, error } = useSWRImmutable<Match | null | undefined>(
     metadataURL,
-    fetcher,
-  );
-  if (error) {
-    return null;
-  }
-  return data;
-};
-
-export const useWhatsabiMetadata = (
-  address: ChecksummedAddress | undefined,
-  chainId: bigint | undefined,
-  provider: JsonRpcApiProvider | undefined,
-  assetsURLPrefix: string | undefined,
-): Match | null | undefined => {
-  const fetcher = whatsabiFetcher(provider, assetsURLPrefix);
-  const key = ["whatsabi", address, chainId];
-  const { data, error } = useSWRImmutable<Match | null | undefined>(
-    key,
     fetcher,
   );
   if (error) {

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -173,7 +173,9 @@ function whatsabiFetcher(
       const decodedFunctions: (string | null)[] = await Promise.all(
         selectors.map(async (selector) => {
           try {
-            const result = await fetch(fourBytesURL(assetsURLPrefix, selector));
+            const result = await fetch(
+              fourBytesURL(assetsURLPrefix, selector.slice(2)),
+            );
             if (!result.ok) {
               throw new Error(
                 `4bytes fetch returned ${result.status} response`,

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -1,8 +1,10 @@
-import { ErrorDescription, Interface } from "ethers";
+import { whatsabi } from "@shazow/whatsabi";
+import { ErrorDescription, Interface, JsonRpcApiProvider } from "ethers";
 import { useContext, useMemo } from "react";
 import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { ChecksummedAddress, TransactionDescriptionData } from "../types";
+import { fourBytesURL } from "../url";
 import { useAppConfigContext } from "../useAppConfig";
 import { RuntimeContext } from "../useRuntime";
 
@@ -63,7 +65,7 @@ export type Metadata = {
       license?: string;
     };
   };
-  settings: {
+  settings?: {
     remappings: string[];
     optimizer?: {
       enabled: boolean;
@@ -151,6 +153,7 @@ export const sourcifySourceFile = (
 export enum MatchType {
   FULL_MATCH,
   PARTIAL_MATCH,
+  WHATSABI_GUESS,
 }
 
 export type Match = {
@@ -158,56 +161,105 @@ export type Match = {
   metadata: Metadata;
 };
 
-const sourcifyFetcher: Fetcher<
-  Match | null | undefined,
-  ["sourcify", ChecksummedAddress, bigint, SourcifySource, SourcifySourceMap]
-> = async ([_, address, chainId, sourcifySource, sourcifySources]) => {
-  // Try full match
-  try {
-    const url = sourcifyMetadata(
-      address,
-      chainId,
-      sourcifySource,
-      MatchType.FULL_MATCH,
-      sourcifySources,
-    );
-    const res = await fetch(url);
-    if (res.ok) {
+function whatsabiFetcher(
+  provider: JsonRpcApiProvider | undefined,
+  assetsURLPrefix: string | undefined,
+): Fetcher<Match | null | undefined, ["whatsabi", ChecksummedAddress, bigint]> {
+  return async ([_, address, chainId]) => {
+    if (provider && assetsURLPrefix !== undefined) {
+      const code = await provider.getCode(address);
+      const selectors = whatsabi.selectorsFromBytecode(code);
+      const decodedFunctions: (string | null)[] = await Promise.all(
+        selectors.map(async (selector) => {
+          try {
+            const result = await fetch(fourBytesURL(assetsURLPrefix, selector));
+            const text = await result.text();
+            const sig = text.split(";")[0];
+            if (sig.length > 0) {
+              return `function ${sig} external view`;
+            }
+          } catch (e) {}
+          return null;
+        }),
+      );
+      const functions: string[] = decodedFunctions.filter(
+        (sig) => sig !== null,
+      ) as string[];
+      const int = Interface.from([...functions]);
+      const abi = JSON.parse(int.formatJson());
+      const metadata = {
+        version: "Unknown",
+        language: "Unknown",
+        compiler: { version: "Unknown" },
+        sources: {},
+        // settings: {remappings: [], compilationTarget: {}, libraries: {}},
+        output: {
+          abi,
+        },
+      };
       return {
-        type: MatchType.FULL_MATCH,
-        metadata: await res.json(),
+        type: MatchType.WHATSABI_GUESS,
+        metadata: metadata,
       };
     }
-  } catch (err) {
-    console.info(
-      `error while getting Sourcify full_match metadata: chainId=${chainId} address=${address} err=${err}; falling back to partial_match`,
-    );
-  }
 
-  // Fallback to try partial match
-  try {
-    const url = sourcifyMetadata(
-      address,
-      chainId,
-      sourcifySource,
-      MatchType.PARTIAL_MATCH,
-      sourcifySources,
-    );
-    const res = await fetch(url);
-    if (res.ok) {
-      return {
-        type: MatchType.PARTIAL_MATCH,
-        metadata: await res.json(),
-      };
+    return null;
+  };
+}
+
+function sourcifyFetcher(
+  sourcifySources: SourcifySourceMap,
+): Fetcher<
+  Match | null | undefined,
+  ["sourcify", ChecksummedAddress, bigint, SourcifySource]
+> {
+  return async ([_, address, chainId, sourcifySource]) => {
+    // Try full match
+    try {
+      const url = sourcifyMetadata(
+        address,
+        chainId,
+        sourcifySource,
+        MatchType.FULL_MATCH,
+        sourcifySources,
+      );
+      const res = await fetch(url);
+      if (res.ok) {
+        return {
+          type: MatchType.FULL_MATCH,
+          metadata: await res.json(),
+        };
+      }
+    } catch (err) {
+      console.info(
+        `error while getting Sourcify full_match metadata: chainId=${chainId} address=${address} err=${err}; falling back to partial_match`,
+      );
+    }
+
+    // Fallback to try partial match
+    try {
+      const url = sourcifyMetadata(
+        address,
+        chainId,
+        sourcifySource,
+        MatchType.PARTIAL_MATCH,
+        sourcifySources,
+      );
+      const res = await fetch(url);
+      if (res.ok) {
+        return {
+          type: MatchType.PARTIAL_MATCH,
+          metadata: await res.json(),
+        };
+      }
+    } catch (err) {
+      console.warn(
+        `error while getting Sourcify partial_match metadata: chainId=${chainId} address=${address} err=${err}`,
+      );
     }
     return null;
-  } catch (err) {
-    console.warn(
-      `error while getting Sourcify partial_match metadata: chainId=${chainId} address=${address} err=${err}`,
-    );
-    return null;
-  }
-};
+  };
+}
 
 export const useSourcifyMetadata = (
   address: ChecksummedAddress | undefined,
@@ -219,10 +271,28 @@ export const useSourcifyMetadata = (
     address === undefined || chainId === undefined
       ? null
       : ["sourcify", address, chainId, sourcifySource];
+  const fetcher = sourcifyFetcher(sourcifySources);
   const { data, error } = useSWRImmutable<Match | null | undefined>(
     metadataURL,
-    (key: ["sourcify", string, bigint, SourcifySource]) =>
-      sourcifyFetcher([...key, sourcifySources]),
+    fetcher,
+  );
+  if (error) {
+    return null;
+  }
+  return data;
+};
+
+export const useWhatsabiMetadata = (
+  address: ChecksummedAddress | undefined,
+  chainId: bigint | undefined,
+  provider: JsonRpcApiProvider | undefined,
+  assetsURLPrefix: string | undefined,
+): Match | null | undefined => {
+  const fetcher = whatsabiFetcher(provider, assetsURLPrefix);
+  const key = ["whatsabi", address, chainId];
+  const { data, error } = useSWRImmutable<Match | null | undefined>(
+    key,
+    fetcher,
   );
   if (error) {
     return null;

--- a/src/sourcify/useWhatsabi.ts
+++ b/src/sourcify/useWhatsabi.ts
@@ -1,0 +1,83 @@
+import { whatsabi } from "@shazow/whatsabi";
+import { Interface, JsonRpcApiProvider } from "ethers";
+import { Fetcher } from "swr";
+import useSWRImmutable from "swr/immutable";
+import { ChecksummedAddress } from "../types";
+import { fourBytesURL } from "../url";
+import { Match, MatchType } from "./useSourcify";
+
+export const useWhatsabiMetadata = (
+  address: ChecksummedAddress | undefined,
+  chainId: bigint | undefined,
+  provider: JsonRpcApiProvider | undefined,
+  assetsURLPrefix: string | undefined,
+): Match | null | undefined => {
+  const fetcher = whatsabiFetcher(provider, assetsURLPrefix);
+  const key = ["whatsabi", address, chainId];
+  const { data, error } = useSWRImmutable<Match | null | undefined>(
+    key,
+    fetcher,
+  );
+  if (error) {
+    return null;
+  }
+  return data;
+};
+
+function whatsabiFetcher(
+  provider: JsonRpcApiProvider | undefined,
+  assetsURLPrefix: string | undefined,
+): Fetcher<Match | null | undefined, ["whatsabi", ChecksummedAddress, bigint]> {
+  return async ([_, address, chainId]) => {
+    if (provider && assetsURLPrefix !== undefined) {
+      const code = await provider.getCode(address);
+      const selectors = whatsabi.selectorsFromBytecode(code);
+      const decodedFunctions: (string | null)[] = await Promise.all(
+        selectors.map(async (selector) => {
+          try {
+            const result = await fetch(
+              fourBytesURL(assetsURLPrefix, selector.slice(2)),
+            );
+            if (!result.ok) {
+              throw new Error(
+                `4bytes fetch returned ${result.status} response`,
+              );
+            }
+            const text = await result.text();
+            const sig = text.split(";")[0];
+            if (sig.length > 0) {
+              return `function ${sig} external view`;
+            }
+          } catch (e) {}
+          return null;
+        }),
+      );
+      const unknownSelectors = selectors.filter(
+        (selector, i) => decodedFunctions[i] === null,
+      );
+      const functions: string[] = decodedFunctions
+        .filter((sig) => sig !== null)
+        .sort() as string[];
+      const int = Interface.from([...functions]);
+      const abi = JSON.parse(int.formatJson());
+      const metadata = {
+        version: "Unknown",
+        language: "Unknown",
+        compiler: { version: "Unknown" },
+        sources: {},
+        // settings: {remappings: [], compilationTarget: {}, libraries: {}},
+        output: {
+          abi,
+        },
+      };
+
+      return {
+        type: MatchType.WHATSABI_GUESS,
+        metadata: metadata,
+        unknownSelectors,
+      };
+    }
+
+    return null;
+  };
+}


### PR DESCRIPTION
Here's a preview:
![image](https://github.com/otterscan/otterscan/assets/125761775/01fc5cb2-c926-4366-8817-4638a682114a)

You can use the Read Contract tab, but the return values aren't decoded due to the function selector not using it and therefore 4bytes not having it either: 
![image](https://github.com/otterscan/otterscan/assets/125761775/3674ae34-d9cc-4483-b633-b3f965537f55)

Function selectors not found in 4bytes aren't displayed currently. With some more lifting we could include them.

- [x] Do a more comprehensive review of the whatsabi repo.

Closes #2018