### PR TITLE
Add call options accordion to Read Contract functions

### DIFF
--- a/cypress/e2e/devnet/verified-contracts.cy.ts
+++ b/cypress/e2e/devnet/verified-contracts.cy.ts
@@ -18,39 +18,51 @@ describe("Read Contract tests", () => {
           .contains("getVariableLengthStringArray")
           .parent()
           .as("func");
-        cy.get("@func").find("input").type("one");
+        cy.get("@func").find("input.w-full").type("one");
         cy.get("@func").find("button").contains("Add Element").click();
-        cy.get("@func").find("input").eq(1).type("two");
+        cy.get("@func").find("input.w-full").eq(1).type("two");
         cy.get("@func").find("button").contains("Add Element").click();
-        cy.get("@func").find("input").eq(2).type("three");
+        cy.get("@func").find("input.w-full").eq(2).type("three");
 
-        cy.get("@func").find("input").eq(0).should("have.value", "one");
-        cy.get("@func").find("input").eq(1).should("have.value", "two");
-        cy.get("@func").find("input").eq(2).should("have.value", "three");
+        cy.get("@func").find("input.w-full").eq(0).should("have.value", "one");
+        cy.get("@func").find("input.w-full").eq(1).should("have.value", "two");
+        cy.get("@func")
+          .find("input.w-full")
+          .eq(2)
+          .should("have.value", "three");
 
         // Remove the 2nd element
         cy.get("@func")
           .find("[data-test='remove-array-element']")
           .eq(1)
           .click();
-        cy.get("@func").find("input").eq(0).should("have.value", "one");
-        cy.get("@func").find("input").eq(1).should("have.value", "three");
+        cy.get("@func").find("input.w-full").eq(0).should("have.value", "one");
+        cy.get("@func")
+          .find("input.w-full")
+          .eq(1)
+          .should("have.value", "three");
 
         // Add another array element
         cy.get("@func").find("button").contains("Add Element").click();
-        cy.get("@func").find("input").eq(2).type("new");
+        cy.get("@func").find("input.w-full").eq(2).type("new");
 
-        cy.get("@func").find("input").eq(0).should("have.value", "one");
-        cy.get("@func").find("input").eq(1).should("have.value", "three");
-        cy.get("@func").find("input").eq(2).should("have.value", "new");
+        cy.get("@func").find("input.w-full").eq(0).should("have.value", "one");
+        cy.get("@func")
+          .find("input.w-full")
+          .eq(1)
+          .should("have.value", "three");
+        cy.get("@func").find("input.w-full").eq(2).should("have.value", "new");
 
         // Remove the 1st element
         cy.get("@func")
           .find("[data-test='remove-array-element']")
           .eq(0)
           .click();
-        cy.get("@func").find("input").eq(0).should("have.value", "three");
-        cy.get("@func").find("input").eq(1).should("have.value", "new");
+        cy.get("@func")
+          .find("input.w-full")
+          .eq(0)
+          .should("have.value", "three");
+        cy.get("@func").find("input.w-full").eq(1).should("have.value", "new");
 
         // Query
         cy.get("@func").find("button").contains("Query").click();

--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, StoryObj } from "@storybook/react";
+import Accordion from "./Accordion";
+
+const meta = {
+  component: Accordion,
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExampleAccordion: Story = {
+  args: {
+    title: "Example accordion",
+    children: <>Accordion content here</>,
+  },
+};

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -19,6 +19,7 @@ const Accordion: React.FC<AccordionProps> = ({ children, title, neighbor }) => {
     <span>
       <button
         className="ml-2 mt-2 rounded border bg-skin-button-fill px-1 py-1 text-sm text-skin-button hover:bg-skin-button-hover-fill"
+        type="button"
         onClick={handleToggle}
         title={title}
       >

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -7,10 +7,7 @@ interface AccordionProps {
   title?: string;
 }
 
-const Accordion: React.FC<AccordionProps> = ({
-  children,
-  title,
-}) => {
+const Accordion: React.FC<AccordionProps> = ({ children, title }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const handleToggle = () => {

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,4 +1,4 @@
-import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { faMinus, faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { ReactNode, useState } from "react";
 
@@ -18,15 +18,12 @@ const Accordion: React.FC<AccordionProps> = ({ children, title, neighbor }) => {
   return (
     <span>
       <button
-        className="ml-2 mt-2 rounded border bg-skin-button-fill px-1 py-1 text-sm text-skin-button hover:bg-skin-button-hover-fill"
+        className="ml-2 mt-2 rounded border bg-skin-button-fill px-1.5 py-0.5 text-sm text-skin-button hover:bg-skin-button-hover-fill"
         type="button"
         onClick={handleToggle}
         title={title}
       >
-        <FontAwesomeIcon
-          icon={isVisible ? faChevronUp : faChevronDown}
-          size="sm"
-        />
+        <FontAwesomeIcon icon={isVisible ? faMinus : faPlus} size="sm" />
       </button>
       {neighbor}
       <div

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -4,10 +4,11 @@ import React, { ReactNode, useState } from "react";
 
 interface AccordionProps {
   children: ReactNode;
+  neighbor?: ReactNode;
   title?: string;
 }
 
-const Accordion: React.FC<AccordionProps> = ({ children, title }) => {
+const Accordion: React.FC<AccordionProps> = ({ children, title, neighbor }) => {
   const [isVisible, setIsVisible] = useState(false);
 
   const handleToggle = () => {
@@ -17,7 +18,7 @@ const Accordion: React.FC<AccordionProps> = ({ children, title }) => {
   return (
     <span>
       <button
-        className="ml-2 mt-2 rounded border bg-skin-button-fill px-1 py-0.5 text-sm text-skin-button hover:bg-skin-button-hover-fill"
+        className="ml-2 mt-2 rounded border bg-skin-button-fill px-1 py-1 text-sm text-skin-button hover:bg-skin-button-hover-fill"
         onClick={handleToggle}
         title={title}
       >
@@ -26,6 +27,7 @@ const Accordion: React.FC<AccordionProps> = ({ children, title }) => {
           size="sm"
         />
       </button>
+      {neighbor}
       <div
         className={`transition-all duration-300 ease-in-out overflow-hidden ${
           isVisible ? "max-h-80 pb-1" : "max-h-0"

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -4,16 +4,14 @@ import React, { ReactNode, useState } from "react";
 
 interface AccordionProps {
   children: ReactNode;
-  initialVisible?: boolean;
   title?: string;
 }
 
 const Accordion: React.FC<AccordionProps> = ({
   children,
-  initialVisible = false,
   title,
 }) => {
-  const [isVisible, setIsVisible] = useState(initialVisible);
+  const [isVisible, setIsVisible] = useState(false);
 
   const handleToggle = () => {
     setIsVisible(!isVisible);

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -2,13 +2,13 @@ import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { ReactNode, useState } from "react";
 
-interface ShowHideProps {
+interface AccordionProps {
   children: ReactNode;
   initialVisible?: boolean;
   title?: string;
 }
 
-const ShowHide: React.FC<ShowHideProps> = ({
+const Accordion: React.FC<AccordionProps> = ({
   children,
   initialVisible = false,
   title,
@@ -47,4 +47,4 @@ const ShowHide: React.FC<ShowHideProps> = ({
   );
 };
 
-export default ShowHide;
+export default Accordion;

--- a/src/components/ShowHide.tsx
+++ b/src/components/ShowHide.tsx
@@ -1,0 +1,50 @@
+import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React, { ReactNode, useState } from "react";
+
+interface ShowHideProps {
+  children: ReactNode;
+  initialVisible?: boolean;
+  title?: string;
+}
+
+const ShowHide: React.FC<ShowHideProps> = ({
+  children,
+  initialVisible = false,
+  title,
+}) => {
+  const [isVisible, setIsVisible] = useState(initialVisible);
+
+  const handleToggle = () => {
+    setIsVisible(!isVisible);
+  };
+
+  return (
+    <span>
+      <button
+        className="ml-2 mt-2 rounded border bg-skin-button-fill px-1 py-0.5 text-sm text-skin-button hover:bg-skin-button-hover-fill"
+        onClick={handleToggle}
+        title={title}
+      >
+        <FontAwesomeIcon
+          icon={isVisible ? faChevronUp : faChevronDown}
+          size="sm"
+        />
+      </button>
+      <div
+        className={`transition-all duration-300 ease-in-out overflow-hidden ${
+          isVisible ? "max-h-80 pb-1" : "max-h-0"
+        }`}
+        {
+          ...{
+            inert: isVisible ? undefined : "",
+          } /* Workaround until we upgrade to React 19 */
+        }
+      >
+        {children}
+      </div>
+    </span>
+  );
+};
+
+export default ShowHide;

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -292,7 +292,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             )
           }
         >
-          <div className="mt-1">
+          <div className="ml-2 mt-1">
             <div className="text-sm mt-2 text-green-700">Block Number</div>
             <input
               type="text"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -294,7 +294,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             <div className="text-xs">Block Number</div>
             <input
               type="text"
-              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
+              className="mt-1 w-48 rounded border px-2 py-1 text-sm text-gray-600"
               onChange={(e) => setBlockNumber(e.target.value)}
               placeholder="latest"
             />
@@ -310,7 +310,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             </div>
             <input
               type="text"
-              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
+              className="mt-1 w-72 rounded border px-2 py-1 text-sm text-gray-600"
               onChange={(e) => setValue(e.target.value)}
               placeholder="0"
             />

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -293,8 +293,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
           <div className="ml-6">
             <div className="text-xs">Block Number</div>
             <input
-              type="number"
-              min="0"
+              type="text"
               className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
               onChange={(e) => setBlockNumber(e.target.value)}
               placeholder="latest"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -10,7 +10,7 @@ import {
   type ParamType,
 } from "ethers";
 import { FC, FormEvent, memo, useContext, useRef, useState } from "react";
-import ShowHide from "../../../components/ShowHide";
+import Accordion from "../../../components/Accordion";
 import { DevMethod } from "../../../sourcify/useSourcify";
 import { useChainInfo } from "../../../useChainInfo";
 import { RuntimeContext } from "../../../useRuntime";
@@ -241,7 +241,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
   return (
     <li key={func.format()} className="pb-4" data-test="read-function">
       <span className="text-md font-medium">{func.name}</span>
-      <ShowHide title="Call options">
+      <Accordion title="Call options">
         <form onSubmit={onFormSubmit}>
           <div className="ml-6">
             <div className="text-xs">Block Number</div>
@@ -271,7 +271,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             <button type="submit" className="hidden"></button>
           </div>
         </form>
-      </ShowHide>
+      </Accordion>
       <form onSubmit={onFormSubmit} className="mt-2 pl-4">
         <ul className="ml-2 list-inside">
           {func.inputs &&

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -13,6 +13,7 @@ import { FC, FormEvent, memo, useContext, useRef, useState } from "react";
 import Accordion from "../../../components/Accordion";
 import { DevMethod } from "../../../sourcify/useSourcify";
 import { useChainInfo } from "../../../useChainInfo";
+import { useLatestBlockNumber } from "../../../useLatestBlock";
 import { RuntimeContext } from "../../../useRuntime";
 import ParamDeclaration from "../../components/ParamDeclaration";
 import OutputDecoder from "../../transaction/decoder/OutputDecoder";
@@ -188,6 +189,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
     new Array(func.inputs.length).fill(null),
   );
   const { provider } = useContext(RuntimeContext);
+  const latestBlockNumber = useLatestBlockNumber(provider);
   const { nativeCurrency } = useChainInfo();
 
   async function submitCall() {
@@ -294,10 +296,22 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             <div className="text-xs">Block Number</div>
             <input
               type="text"
+              value={blockNumber}
               className="mt-1 w-48 rounded border px-2 py-1 text-sm text-gray-600"
               onChange={(e) => setBlockNumber(e.target.value)}
               placeholder="latest"
             />
+            <button
+              type="button"
+              className="ml-2 mt-2 rounded border bg-skin-button-fill px-3 py-1 text-left text-sm text-skin-button hover:bg-skin-button-hover-fill"
+              onClick={() => {
+                if (latestBlockNumber !== undefined) {
+                  setBlockNumber(latestBlockNumber.toString());
+                }
+              }}
+            >
+              Latest
+            </button>
             <div className="text-xs">Sender</div>
             <input
               type="text"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -290,7 +290,7 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             )
           }
         >
-          <div className="ml-6">
+          <div className="ml-4 mt-1">
             <div className="text-xs">Block Number</div>
             <input
               type="text"

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -292,8 +292,8 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             )
           }
         >
-          <div className="ml-4 mt-1">
-            <div className="text-xs">Block Number</div>
+          <div className="mt-1">
+            <div className="text-sm mt-2 text-green-700">Block Number</div>
             <input
               type="text"
               value={blockNumber}
@@ -312,14 +312,14 @@ const ReadFunction: FC<ReadFunctionProps> = ({
             >
               Latest
             </button>
-            <div className="text-xs">Sender</div>
+            <div className="text-sm mt-2 text-green-700">Sender</div>
             <input
               type="text"
               className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
               onChange={(e) => setSender(e.target.value)}
               placeholder="0x0000000000000000000000000000000000000000"
             />
-            <div className="text-xs">
+            <div className="text-sm mt-2 text-green-700">
               Value {nativeCurrency && `(${nativeCurrency.symbol})`}
             </div>
             <input

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -227,6 +227,17 @@ const ReadFunction: FC<ReadFunctionProps> = ({
       });
       setError(null);
     } catch (e: any) {
+      if (blockTag !== "latest") {
+        try {
+          provider.send("ots_hasCode", [address, blockTag]).then((hasCode) => {
+            if (!hasCode) {
+              setError(e.toString() + " (Contract not deployed at this time.)");
+            }
+          });
+        } catch (e) {
+          console.error("Failed to call ots_hasCode:", e);
+        }
+      }
       setResult(null);
       setError(e.toString());
     }

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -252,37 +252,6 @@ const ReadFunction: FC<ReadFunctionProps> = ({
   return (
     <li key={func.format()} className="pb-4" data-test="read-function">
       <span className="text-md font-medium">{func.name}</span>
-      <Accordion title="Call options">
-        <form onSubmit={onFormSubmit}>
-          <div className="ml-6">
-            <div className="text-xs">Block Number</div>
-            <input
-              type="number"
-              min="0"
-              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
-              onChange={(e) => setBlockNumber(e.target.value)}
-              placeholder="latest"
-            />
-            <div className="text-xs">Sender</div>
-            <input
-              type="text"
-              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
-              onChange={(e) => setSender(e.target.value)}
-              placeholder="0x0000000000000000000000000000000000000000"
-            />
-            <div className="text-xs">
-              Value {nativeCurrency && `(${nativeCurrency.symbol})`}
-            </div>
-            <input
-              type="text"
-              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
-              onChange={(e) => setValue(e.target.value)}
-              placeholder="0"
-            />
-            <button type="submit" className="hidden"></button>
-          </div>
-        </form>
-      </Accordion>
       <form onSubmit={onFormSubmit} className="mt-2 pl-4">
         <ul className="ml-2 list-inside">
           {func.inputs &&
@@ -308,11 +277,46 @@ const ReadFunction: FC<ReadFunctionProps> = ({
         >
           Query
         </button>{" "}
-        {result === undefined && (
-          <span className="self-center">
-            <FontAwesomeIcon className="animate-spin" icon={faCircleNotch} />
-          </span>
-        )}
+        <Accordion
+          title="Call options"
+          neighbor={
+            result === undefined && (
+              <span className="ml-2 self-center">
+                <FontAwesomeIcon
+                  className="animate-spin"
+                  icon={faCircleNotch}
+                />
+              </span>
+            )
+          }
+        >
+          <div className="ml-6">
+            <div className="text-xs">Block Number</div>
+            <input
+              type="number"
+              min="0"
+              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
+              onChange={(e) => setBlockNumber(e.target.value)}
+              placeholder="latest"
+            />
+            <div className="text-xs">Sender</div>
+            <input
+              type="text"
+              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
+              onChange={(e) => setSender(e.target.value)}
+              placeholder="0x0000000000000000000000000000000000000000"
+            />
+            <div className="text-xs">
+              Value {nativeCurrency && `(${nativeCurrency.symbol})`}
+            </div>
+            <input
+              type="text"
+              className="mt-1 w-96 rounded border px-2 py-1 text-sm text-gray-600"
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="0"
+            />
+          </div>
+        </Accordion>
       </form>
       <div className="mt-2 pl-6">
         {result && (


### PR DESCRIPTION
Closes #2243 

Adds an accordion controlled by a button with extra call options: block number, sender, and call value.

When closed:
![image](https://github.com/otterscan/otterscan/assets/125761775/9cff2970-8316-4417-bed9-05864ffca095)

When open:
![image](https://github.com/otterscan/otterscan/assets/125761775/9f6b2af6-dcc3-4459-9161-ab2608879527)

A note is appended to the error message if the the block number was changed and contract address has no code.