### PR TITLE
Add ids and scrolling to Read Contract functions

### DIFF
--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -96,6 +96,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
               <ContractABI
                 abi={match.metadata.output.abi}
                 unknownSelectors={match.unknownSelectors}
+                address={checksummedAddress}
               />
             )}
             {match.type !== MatchType.WHATSABI_GUESS && (

--- a/src/execution/address/contract/ContractABI.tsx
+++ b/src/execution/address/contract/ContractABI.tsx
@@ -6,7 +6,11 @@ import { ABIAwareComponentProps } from "../../types";
 import DecodedABI from "./DecodedABI";
 import RawABI from "./RawABI";
 
-const ContractABI: FC<ABIAwareComponentProps> = ({ abi, unknownSelectors }) => (
+const ContractABI: FC<ABIAwareComponentProps> = ({
+  abi,
+  unknownSelectors,
+  address,
+}) => (
   <div className="mb-3">
     <TabGroup>
       <TabList className="mb-1 flex items-baseline space-x-1">
@@ -19,7 +23,11 @@ const ContractABI: FC<ABIAwareComponentProps> = ({ abi, unknownSelectors }) => (
       </TabList>
       <TabPanels>
         <TabPanel>
-          <DecodedABI abi={abi} unknownSelectors={unknownSelectors} />
+          <DecodedABI
+            abi={abi}
+            unknownSelectors={unknownSelectors}
+            address={address}
+          />
         </TabPanel>
         <TabPanel>
           <RawABI abi={abi} />

--- a/src/execution/address/contract/DecodedABI.tsx
+++ b/src/execution/address/contract/DecodedABI.tsx
@@ -1,8 +1,9 @@
-import { Interface } from "ethers";
+import { Fragment, FunctionFragment, Interface } from "ethers";
 import { FC, memo } from "react";
 import { ABIAwareComponentProps } from "../../types";
 import DecodedFragment from "./DecodedFragment";
 import RawDecodedFragment from "./RawDecodedFragment";
+import { isReadFunction } from "./ReadContract";
 
 const DecodedABI: FC<ABIAwareComponentProps> = ({
   abi,
@@ -12,8 +13,18 @@ const DecodedABI: FC<ABIAwareComponentProps> = ({
   const intf = new Interface(abi);
   return (
     <div className="overflow-x-auto border">
-      {intf.fragments.map((f, i) => (
-        <DecodedFragment key={i} intf={intf} fragment={f} address={address} />
+      {intf.fragments.map((fragment, i) => (
+        <DecodedFragment
+          key={i}
+          intf={intf}
+          fragment={fragment}
+          address={
+            Fragment.isFunction(fragment) &&
+            isReadFunction(fragment as FunctionFragment)
+              ? address
+              : undefined
+          }
+        />
       ))}
       {unknownSelectors && unknownSelectors.length > 0 && (
         <div className="ml-2 mt-3 text-sm">Unknown functions:</div>

--- a/src/execution/address/contract/DecodedABI.tsx
+++ b/src/execution/address/contract/DecodedABI.tsx
@@ -4,12 +4,16 @@ import { ABIAwareComponentProps } from "../../types";
 import DecodedFragment from "./DecodedFragment";
 import RawDecodedFragment from "./RawDecodedFragment";
 
-const DecodedABI: FC<ABIAwareComponentProps> = ({ abi, unknownSelectors }) => {
+const DecodedABI: FC<ABIAwareComponentProps> = ({
+  abi,
+  unknownSelectors,
+  address,
+}) => {
   const intf = new Interface(abi);
   return (
     <div className="overflow-x-auto border">
       {intf.fragments.map((f, i) => (
-        <DecodedFragment key={i} intf={intf} fragment={f} />
+        <DecodedFragment key={i} intf={intf} fragment={f} address={address} />
       ))}
       {unknownSelectors && unknownSelectors.length > 0 && (
         <div className="ml-2 mt-3 text-sm">Unknown functions:</div>

--- a/src/execution/address/contract/DecodedFragment.tsx
+++ b/src/execution/address/contract/DecodedFragment.tsx
@@ -12,9 +12,14 @@ import RawDecodedFragment from "./RawDecodedFragment";
 type DecodedFragmentProps = {
   intf: Interface;
   fragment: Fragment;
+  address?: string;
 };
 
-const DecodedFragment: FC<DecodedFragmentProps> = ({ intf, fragment }) => {
+const DecodedFragment: FC<DecodedFragmentProps> = ({
+  intf,
+  fragment,
+  address,
+}) => {
   let fragmentType: "constructor" | "event" | "function" | "error" | undefined;
   let sig: string | undefined;
   let letter: string | undefined;
@@ -53,6 +58,7 @@ const DecodedFragment: FC<DecodedFragmentProps> = ({ intf, fragment }) => {
       letter={letter}
       letterBg={letterBg}
       hashBg={hashBg}
+      address={address}
     />
   );
 };

--- a/src/execution/address/contract/RawDecodedFragment.tsx
+++ b/src/execution/address/contract/RawDecodedFragment.tsx
@@ -1,6 +1,7 @@
 import { faCaretRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, JSX, memo } from "react";
+import { NavLink } from "react-router-dom";
 
 type RawDecodedFragmentProps = {
   fragmentType?: "constructor" | "event" | "function" | "error";
@@ -9,6 +10,7 @@ type RawDecodedFragmentProps = {
   letter?: string;
   letterBg?: string;
   hashBg?: string;
+  address?: string;
 };
 
 const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
@@ -18,6 +20,7 @@ const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
   letter,
   letterBg,
   hashBg,
+  address,
 }) => {
   return (
     <div className="flex items-baseline space-x-2 px-2 py-1 hover:bg-gray-100">
@@ -37,18 +40,25 @@ const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
         </span>
       )}
       {sig && (
-        <span
-          className={`rounded-xl border px-2 pt-1 font-code text-xs text-gray-600 ${hashBg}`}
-          title={
-            fragmentType === "function"
-              ? "Method Selector"
-              : fragmentType === "event"
-                ? "Topic Hash"
-                : ""
-          }
-        >
-          {sig}
-        </span>
+        <>
+          <span
+            className={`rounded-xl border px-2 pt-1 font-code text-xs text-gray-600 ${hashBg}`}
+            title={
+              fragmentType === "function"
+                ? "Method Selector"
+                : fragmentType === "event"
+                  ? "Topic Hash"
+                  : ""
+            }
+          >
+            {sig}
+          </span>
+          {address && fragmentType === "function" && (
+            <NavLink to={`/address/${address}/readContract#${sig}`}>
+              read &raquo;
+            </NavLink>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/execution/address/contract/RawDecodedFragment.tsx
+++ b/src/execution/address/contract/RawDecodedFragment.tsx
@@ -54,9 +54,11 @@ const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
             {sig}
           </span>
           {address && fragmentType === "function" && (
-            <NavLink to={`/address/${address}/readContract#${sig}`}>
-              read &raquo;
-            </NavLink>
+            <span className="whitespace-nowrap">
+              <NavLink to={`/address/${address}/readContract#${sig}`}>
+                read &raquo;
+              </NavLink>
+            </span>
           )}
         </>
       )}

--- a/src/execution/address/contract/RawDecodedFragment.tsx
+++ b/src/execution/address/contract/RawDecodedFragment.tsx
@@ -1,7 +1,7 @@
 import { faCaretRight } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FC, JSX, memo } from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink } from "react-router";
 
 type RawDecodedFragmentProps = {
   fragmentType?: "constructor" | "event" | "function" | "error";

--- a/src/execution/address/contract/RawDecodedFragment.tsx
+++ b/src/execution/address/contract/RawDecodedFragment.tsx
@@ -36,7 +36,16 @@ const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
       )}
       {fragmentStr !== undefined && (
         <span className="whitespace-nowrap font-code text-sm">
-          {fragmentStr}
+          {address && fragmentType === "function" && sig ? (
+            <NavLink
+              to={`/address/${address}/readContract#${sig}`}
+              className="hover:underline text-blue-900"
+            >
+              {fragmentStr}
+            </NavLink>
+          ) : (
+            fragmentStr
+          )}
         </span>
       )}
       {sig && (
@@ -53,13 +62,6 @@ const RawDecodedFragment: FC<RawDecodedFragmentProps> = ({
           >
             {sig}
           </span>
-          {address && fragmentType === "function" && (
-            <span className="whitespace-nowrap">
-              <NavLink to={`/address/${address}/readContract#${sig}`}>
-                read &raquo;
-              </NavLink>
-            </span>
-          )}
         </>
       )}
     </div>

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -1,5 +1,6 @@
 import { FunctionFragment } from "ethers";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router";
 import ContentFrame from "../../../components/ContentFrame";
 import LabeledSwitch from "../../../components/LabeledSwitch";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
@@ -34,6 +35,21 @@ const ReadContract: React.FC<ContractsProps> = ({
     (fn) => fn.outputs && fn.outputs.length > 0 && !isReadFunction(fn),
   );
   const showDecodedOutputs = match?.type !== MatchType.WHATSABI_GUESS;
+
+  const location = useLocation();
+  useEffect(() => {
+    setTimeout(() => {
+      if (location.hash) {
+        // Scroll to fragment, e.g. "#0xabcdef01"
+        let foundElement = document.getElementById(location.hash.slice(1));
+        if (foundElement) {
+          foundElement.scrollIntoView({
+            behavior: "smooth",
+          });
+        }
+      }
+    }, 200);
+  }, [match]);
 
   return (
     <StandardSelectionBoundary>

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -14,7 +14,10 @@ type ContractsProps = {
   match: Match | null | undefined;
 };
 
-function isReadFunction(abiFn: { type: string; stateMutability: string }) {
+export function isReadFunction(abiFn: {
+  type: string;
+  stateMutability: string;
+}) {
   return (
     abiFn.type === "function" &&
     (abiFn.stateMutability === "pure" || abiFn.stateMutability === "view")

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -221,7 +221,12 @@ const ReadFunction: FC<ReadFunctionProps> = ({
   }
 
   return (
-    <li key={func.format()} className="pb-4" data-test="read-function">
+    <li
+      key={func.format()}
+      className="pb-4"
+      data-test="read-function"
+      id={func.selector}
+    >
       <span className="text-md font-medium">{func.name}</span>
       <form onSubmit={onFormSubmit} className="mt-2 pl-4">
         <ul className="ml-2 list-inside">

--- a/src/execution/types.ts
+++ b/src/execution/types.ts
@@ -14,4 +14,5 @@ export type AddressAwareComponentProps = {
 export type ABIAwareComponentProps = {
   abi: any[];
   unknownSelectors?: string[];
+  address?: string;
 };


### PR DESCRIPTION
Closes #2256
Closes #2257 

Note that there are no links on the React Contract page itself, but the functions can be linked to. @wmitsuda Do you want the numbers in the ordered list to be links?