### PR TITLE
Recognize common block explorer URLs in search bar

### DIFF
--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -234,7 +234,42 @@ const doSearch = async (q: string, navigate: NavigateFunction) => {
   const sepIndex = q.lastIndexOf(":");
   if (sepIndex !== -1) {
     maybeAddress = q.substring(0, sepIndex);
-    maybeIndex = q.substring(sepIndex + 1);
+    const afterAddress = q.substring(sepIndex + 1);
+    maybeIndex = !isNaN(parseInt(afterAddress))
+      ? parseInt(afterAddress).toString()
+      : "";
+  }
+
+  // Parse URLs for other block explorers
+  try {
+    const url = new URL(q);
+    const pathname = url.pathname.replace(/\/$/, "");
+
+    const addressMatch = pathname.match(/^\/(?:address|token)\/(.*)$/);
+    const txMatch = pathname.match(/^\/tx\/(.*)$/);
+    const blockMatch = pathname.match(/^\/block\/(\d+)$/);
+    const epochMatch = pathname.match(/^\/epoch\/(.*)$/);
+    const slotMatch = pathname.match(/^\/slot\/(.*)$/);
+    const validatorMatch = pathname.match(/^\/validator\/(.*)$/);
+    if (addressMatch) {
+      maybeAddress = addressMatch[1];
+      // The URL might use a different port number
+      maybeIndex = "";
+    } else if (txMatch) {
+      q = txMatch[1];
+    } else if (blockMatch) {
+      q = blockMatch[1];
+    } else if (epochMatch) {
+      q = "epoch:" + epochMatch[1];
+    } else if (slotMatch) {
+      q = "slot:" + slotMatch[1];
+    } else if (validatorMatch) {
+      q = "validator:" + validatorMatch[1];
+    }
+  } catch (error) {
+    if (!(error instanceof TypeError)) {
+      throw error;
+    }
   }
 
   // Plain address?


### PR DESCRIPTION
Closes #2244.

Strategy: if a searched item is a URL, parse the URL and try matching it to a known path format.

There are some caveats: if `/address/<unknown path>` is entered, Otterscan will try navigating to that. This works just fine for ENS names and links from other Otterscan instances, but not if the path includes a subpath like `/address/0x.../someOtherPage`. I think the tradeoff is okay for now.

Try, for example,
```
https://eth.blockscout.com/address/0x000000000022D473030F116dDEE9F6B43aC78BA3?tab=token_transfers
https://beaconcha.in/validator/999999
https://beaconcha.in/epoch/252630
https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7
https://ethplorer.io/tx/0xdf92a3a82fc9337db1cbca318aeccb62443849888bf27f5f0bab6bd950f12760#996
```