### PR TITLE
Optional runtime fields refactoring - part 1

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -14,7 +14,7 @@ const Footer: React.FC = () => {
         } text-center`}
       >
         {provider ? (
-          <>Using Erigon node at {config?.erigonURL}</>
+          <>Using Erigon node at {config.erigonURL}</>
         ) : (
           <>Waiting for the provider...</>
         )}

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -32,10 +32,8 @@ const Header: FC = () => {
                 title="An otter scanning"
               />
               <span>
-                {config?.branding?.siteName || "Otterscan"}
-                {config?.experimental && (
-                  <span className="text-red-400">2</span>
-                )}
+                {config.branding?.siteName || "Otterscan"}
+                {config.experimental && <span className="text-red-400">2</span>}
               </span>
             </div>
           </Link>
@@ -45,7 +43,7 @@ const Header: FC = () => {
         </div>
         <div className="flex items-baseline gap-x-3">
           {(provider?._network.chainId === 1n ||
-            config?.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleAddress) && (
+            config.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleAddress) && (
             <div className="hidden lg:inline">
               <PriceBox />
             </div>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -75,8 +75,8 @@ const Home: FC = () => {
             Search
           </button>
         </form>
-        {!(config?.branding?.hideAnnouncements ?? false) &&
-          config?.experimental && (
+        {!(config.branding?.hideAnnouncements ?? false) &&
+          config.experimental && (
             <NavLink
               className="text-md font-bold text-green-600 hover:text-green-800"
               to="contracts/all"

--- a/src/Logo.tsx
+++ b/src/Logo.tsx
@@ -17,8 +17,8 @@ const Logo: FC = () => {
         title="An otter scanning"
       />
       <span data-test="logotext">
-        {config?.branding?.siteName || "Otterscan"}
-        {config?.experimental && <span className="text-red-400">2</span>}
+        {config.branding?.siteName || "Otterscan"}
+        {config.experimental && <span className="text-red-400">2</span>}
       </span>
     </div>
   );

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -81,7 +81,7 @@ const PriceBox: React.FC = () => {
     }
 
     const priceDecimals =
-      config?.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleDecimals ??
+      config.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleDecimals ??
       ETH_FEED_DEFAULT_DECIMALS;
     const currentPrice = FixedNumber.fromValue(
       latestPriceData.answer,

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -34,7 +34,7 @@ import { AddressAwareComponentProps } from "./types";
 
 const ProxyTabs: React.FC<AddressAwareComponentProps> = ({ address }) => {
   const { addressOrName } = useParams();
-  const { config, provider } = useContext(RuntimeContext);
+  const { provider } = useContext(RuntimeContext);
   const proxyAttrs = useProxyAttributes(provider, address);
   return (
     <>
@@ -56,7 +56,7 @@ const ProxyTabs: React.FC<AddressAwareComponentProps> = ({ address }) => {
 };
 
 const ProxyContracts: React.FC<AddressAwareComponentProps> = ({ address }) => {
-  const { config, provider } = useContext(RuntimeContext);
+  const { provider } = useContext(RuntimeContext);
   const proxyAttrs = useProxyAttributes(provider, address);
   return (
     <Contracts
@@ -69,7 +69,7 @@ const ProxyContracts: React.FC<AddressAwareComponentProps> = ({ address }) => {
 const ProxyReadContract: React.FC<AddressAwareComponentProps> = ({
   address,
 }) => {
-  const { config, provider } = useContext(RuntimeContext);
+  const { provider } = useContext(RuntimeContext);
   const proxyAttrs = useProxyAttributes(provider, address);
   return (
     <ReadContract checksummedAddress={address} match={proxyAttrs.proxyMatch} />
@@ -112,7 +112,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
     match === null && hasCode ? checksummedAddress : undefined,
     provider?._network.chainId,
     provider,
-    config?.assetsURLPrefix,
+    config.assetsURLPrefix,
   );
 
   return (

--- a/src/execution/BlockDetails.tsx
+++ b/src/execution/BlockDetails.tsx
@@ -56,7 +56,7 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
 
   const l1Epoch = useL1Epoch(provider, block ? block.number : null);
   const l1ExplorerUrl: string | undefined =
-    config?.opChainSettings?.l1ExplorerURL;
+    config.opChainSettings?.l1ExplorerURL;
 
   return (
     <>

--- a/src/execution/address/AddressSubtitle.tsx
+++ b/src/execution/address/AddressSubtitle.tsx
@@ -62,14 +62,14 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
         <Copy value={address} rounded />
         {/* Only display faucets for testnets who actually have any */}
         {faucets && faucets.length > 0 && <Faucet address={address} rounded />}
-        {config?.experimental && <AddressAttributes address={address} full />}
+        {config.experimental && <AddressAttributes address={address} full />}
         {resolvedName && resolvedNameTrusted && !editingAddressTag && (
           <div className="rounded-lg bg-gray-200 px-2 py-1 text-sm text-gray-500 text-nowrap">
             <FontAwesomeIcon icon={faTag} size="1x" />
             <span className="pl-1 text-nowrap">{resolvedName}</span>
           </div>
         )}
-        {config?.WIP_customAddressLabels && (
+        {config.WIP_customAddressLabels && (
           <div className="flex flex-no-wrap space-x-1">
             {editingAddressTag && (
               <EditableAddressTag

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -188,7 +188,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
               </div>
             </InfoRow>
           )}
-          {config && config.experimental && <ProxyInfo address={address} />}
+          {config.experimental && <ProxyInfo address={address} />}
         </BlockNumberContext.Provider>
         <NavBar address={address} page={page} controller={controller} />
         <StandardScrollableTable isAuto={true}>

--- a/src/execution/address/BlockRewardedItem.tsx
+++ b/src/execution/address/BlockRewardedItem.tsx
@@ -45,7 +45,7 @@ const BlockRewardedItem: FC<BlockRewardedItemProps> = ({
         <td>
           <NativeTokenAmount value={totalFees} />
         </td>
-        {config?.beaconAPI !== undefined && (
+        {config.beaconAPI !== undefined && (
           <>
             <td>
               {isLoadingBlockData || isLoadingSlotData ? (

--- a/src/execution/address/BlocksRewarded.tsx
+++ b/src/execution/address/BlocksRewarded.tsx
@@ -46,7 +46,7 @@ const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
       <th className="w-28">Block</th>
       <th className="w-32">Age</th>
       <th className="w-36">Block fees</th>
-      {config?.beaconAPI && (
+      {config.beaconAPI && (
         <>
           <th className="w-28">Slot</th>
           <th className="w-28">Validator</th>
@@ -65,7 +65,7 @@ const BlocksRewarded: FC<AddressAwareComponentProps> = ({ address }) => {
       Item={(i) => <BlockRewardedItem {...i} />}
       header={searchHeader}
       typeName="block"
-      columns={config?.beaconAPI === undefined ? 3 : 5}
+      columns={config.beaconAPI === undefined ? 3 : 5}
     />
   );
 };

--- a/src/execution/address/WithdrawalItem.tsx
+++ b/src/execution/address/WithdrawalItem.tsx
@@ -27,7 +27,7 @@ const WithdrawalItem: FC<WithdrawalItemProps> = ({
   amount,
 }) => {
   const { config } = useContext(RuntimeContext);
-  const hasConsensusClient = config?.beaconAPI !== undefined;
+  const hasConsensusClient = config.beaconAPI !== undefined;
   return (
     <BlockNumberContext.Provider value={blockNumber}>
       <tr>

--- a/src/execution/address/renderer/TokenLogo.tsx
+++ b/src/execution/address/renderer/TokenLogo.tsx
@@ -16,9 +16,7 @@ const TokenLogo: FC<TokenLogoProps> = ({ chainId, address, name }) => {
   const { config } = useContext(RuntimeContext);
 
   const srcList: string[] = [];
-  if (config) {
-    srcList.push(tokenLogoURL(config.assetsURLPrefix ?? "", chainId, address));
-  }
+  srcList.push(tokenLogoURL(config.assetsURLPrefix ?? "", chainId, address));
   const { src, isLoading } = useImage({ srcList, useSuspense: false });
 
   return (

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -128,7 +128,7 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
           )}
         </>
       )}
-      {config?.experimental && <AddressAttributes address={address} />}
+      {config.experimental && <AddressAttributes address={address} />}
     </div>
   );
 };

--- a/src/execution/components/TransactionAddress.stories.tsx
+++ b/src/execution/components/TransactionAddress.stories.tsx
@@ -1,30 +1,12 @@
 import { Meta, StoryObj } from "@storybook/react";
-import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import { SelectionContext } from "../../selection/useSelection";
-import { SourcifySource } from "../../sourcify/useSourcify";
+import { runtimeDecorator } from "../../storybook/util";
 import { AddressContext } from "../../types";
-import { AppConfigContext } from "../../useAppConfig";
-import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "./TransactionAddress";
 
 const meta = {
   component: TransactionAddress,
-  decorators: [
-    (Story) => (
-      <RuntimeContext.Provider value={{}}>
-        <AppConfigContext.Provider
-          value={{
-            sourcifySource: SourcifySource.CENTRAL_SERVER,
-            setSourcifySource: () => {},
-          }}
-        >
-          <StandardSelectionBoundary>
-            <Story />
-          </StandardSelectionBoundary>
-        </AppConfigContext.Provider>
-      </RuntimeContext.Provider>
-    ),
-  ],
+  decorators: [runtimeDecorator],
 } satisfies Meta<typeof TransactionAddress>;
 
 export default meta;

--- a/src/execution/transaction/decoder/AddressDecoder.stories.tsx
+++ b/src/execution/transaction/decoder/AddressDecoder.stories.tsx
@@ -1,28 +1,10 @@
 import { Meta, StoryObj } from "@storybook/react";
-import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
-import { SourcifySource } from "../../../sourcify/useSourcify";
-import { AppConfigContext } from "../../../useAppConfig";
-import { RuntimeContext } from "../../../useRuntime";
+import { runtimeDecorator } from "../../../storybook/util";
 import AddressDecoder from "./AddressDecoder";
 
 const meta = {
   component: AddressDecoder,
-  decorators: [
-    (Story) => (
-      <RuntimeContext.Provider value={{}}>
-        <AppConfigContext.Provider
-          value={{
-            sourcifySource: SourcifySource.CENTRAL_SERVER,
-            setSourcifySource: () => {},
-          }}
-        >
-          <StandardSelectionBoundary>
-            <Story />
-          </StandardSelectionBoundary>
-        </AppConfigContext.Provider>
-      </RuntimeContext.Provider>
-    ),
-  ],
+  decorators: [runtimeDecorator],
 } satisfies Meta<typeof AddressDecoder>;
 
 export default meta;

--- a/src/execution/transaction/decoder/DecodedParamRow.stories.tsx
+++ b/src/execution/transaction/decoder/DecodedParamRow.stories.tsx
@@ -1,29 +1,11 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { ParamType } from "ethers";
-import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
-import { SourcifySource } from "../../../sourcify/useSourcify";
-import { AppConfigContext } from "../../../useAppConfig";
-import { RuntimeContext } from "../../../useRuntime";
+import { runtimeDecorator } from "../../../storybook/util";
 import DecodedParamRow from "./DecodedParamRow";
 
 const meta = {
   component: DecodedParamRow,
-  decorators: [
-    (Story) => (
-      <RuntimeContext.Provider value={{}}>
-        <AppConfigContext.Provider
-          value={{
-            sourcifySource: SourcifySource.CENTRAL_SERVER,
-            setSourcifySource: () => {},
-          }}
-        >
-          <StandardSelectionBoundary>
-            <Story />
-          </StandardSelectionBoundary>
-        </AppConfigContext.Provider>
-      </RuntimeContext.Provider>
-    ),
-  ],
+  decorators: [runtimeDecorator],
 } satisfies Meta<typeof DecodedParamRow>;
 
 export default meta;

--- a/src/execution/transaction/decoder/DecodedParamsTable.stories.tsx
+++ b/src/execution/transaction/decoder/DecodedParamsTable.stories.tsx
@@ -1,9 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { Result } from "ethers";
-import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
-import { SourcifySource } from "../../../sourcify/useSourcify";
-import { AppConfigContext } from "../../../useAppConfig";
-import { RuntimeContext } from "../../../useRuntime";
+import { runtimeDecorator } from "../../../storybook/util";
 import {
   AddressWithHelp,
   ArrayOfTupleWithHelp,
@@ -17,22 +14,7 @@ import DecodedParamsTable from "./DecodedParamsTable";
 
 const meta = {
   component: DecodedParamsTable,
-  decorators: [
-    (Story) => (
-      <RuntimeContext.Provider value={{}}>
-        <AppConfigContext.Provider
-          value={{
-            sourcifySource: SourcifySource.CENTRAL_SERVER,
-            setSourcifySource: () => {},
-          }}
-        >
-          <StandardSelectionBoundary>
-            <Story />
-          </StandardSelectionBoundary>
-        </AppConfigContext.Provider>
-      </RuntimeContext.Provider>
-    ),
-  ],
+  decorators: [runtimeDecorator],
 } satisfies Meta<typeof DecodedParamsTable>;
 
 export default meta;

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -115,9 +115,6 @@ function resolveSourcifySource(
 
 function useSourcifySources(): SourcifySourceMap {
   const { config } = useContext(RuntimeContext);
-  if (!config) {
-    return {};
-  }
   return config.sourcifySources ?? defaultSourcifySources;
 }
 

--- a/src/storybook/util.tsx
+++ b/src/storybook/util.tsx
@@ -17,7 +17,7 @@ const mockProvider: JsonRpcProvider = new JsonRpcProvider(
   },
 );
 
-export const runtimeDecorator: Decorator<any> = (Story) => (
+export const runtimeDecorator: Decorator<unknown> = (Story) => (
   <RuntimeContext.Provider
     value={{ config: mockConfig, provider: mockProvider }}
   >

--- a/src/storybook/util.tsx
+++ b/src/storybook/util.tsx
@@ -1,0 +1,35 @@
+import { Decorator } from "@storybook/react/*";
+import { JsonRpcProvider } from "ethers";
+import StandardSelectionBoundary from "../selection/StandardSelectionBoundary";
+import { SourcifySource } from "../sourcify/useSourcify";
+import { AppConfigContext } from "../useAppConfig";
+import { OtterscanConfig } from "../useConfig";
+import { RuntimeContext } from "../useRuntime";
+
+const mockConfig: OtterscanConfig = {};
+
+// Mock ETH node at localhost@4242; with mock chain ID 424242
+const mockProvider: JsonRpcProvider = new JsonRpcProvider(
+  "http://127.0.0.1:4242",
+  424242,
+  {
+    staticNetwork: true,
+  },
+);
+
+export const runtimeDecorator: Decorator<any> = (Story) => (
+  <RuntimeContext.Provider
+    value={{ config: mockConfig, provider: mockProvider }}
+  >
+    <AppConfigContext.Provider
+      value={{
+        sourcifySource: SourcifySource.CENTRAL_SERVER,
+        setSourcifySource: () => {},
+      }}
+    >
+      <StandardSelectionBoundary>
+        <Story />
+      </StandardSelectionBoundary>
+    </AppConfigContext.Provider>
+  </RuntimeContext.Provider>
+);

--- a/src/use4Bytes.ts
+++ b/src/use4Bytes.ts
@@ -120,7 +120,7 @@ export const use4Bytes = (
     } catch (e: any) {}
   }
 
-  const assetsURLPrefix = config?.assetsURLPrefix;
+  const assetsURLPrefix = config.assetsURLPrefix;
   const fourBytesKey = assetsURLPrefix !== undefined ? rawFourBytes : null;
 
   const fetcher = fourBytesFetcher(assetsURLPrefix!);

--- a/src/useChainInfo.ts
+++ b/src/useChainInfo.ts
@@ -9,14 +9,14 @@ export const populateChainInfo = async (
   const runtime = await rtPromise;
 
   // Hardcoded chainInfo; DON'T fetch it
-  const hardcodedChainInfo = runtime.config?.chainInfo !== undefined;
+  const hardcodedChainInfo = runtime.config.chainInfo !== undefined;
   if (hardcodedChainInfo) {
     return rtPromise;
   }
 
   // TODO: check the assertions
-  const assetsURLPrefix = runtime.config!.assetsURLPrefix!;
-  const network = await runtime.provider!.getNetwork();
+  const assetsURLPrefix = runtime.config.assetsURLPrefix!;
+  const network = await runtime.provider.getNetwork();
   const chainId = network.chainId;
 
   const url = chainInfoURL(assetsURLPrefix, chainId);

--- a/src/useChainInfo.ts
+++ b/src/useChainInfo.ts
@@ -23,15 +23,15 @@ export const populateChainInfo = async (
   try {
     const res = await fetch(url);
     if (!res.ok) {
-      runtime.config!.chainInfo = defaultChainInfo;
+      runtime.config.chainInfo = defaultChainInfo;
       return Promise.resolve(runtime);
     }
 
     const info: ChainInfo = await res.json();
-    runtime.config!.chainInfo = info;
+    runtime.config.chainInfo = info;
     return Promise.resolve(runtime);
   } catch (err) {
-    runtime.config!.chainInfo = defaultChainInfo;
+    runtime.config.chainInfo = defaultChainInfo;
     return Promise.resolve(runtime);
   }
 };

--- a/src/useConsensus.ts
+++ b/src/useConsensus.ts
@@ -20,7 +20,7 @@ function toNumberWithDefault(item: any, defaultVal: number): number {
 
 const useGenesisURL = () => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/beacon/genesis`;
@@ -59,7 +59,7 @@ export const useGenesisTime = (): number | undefined => {
 
 const useBeaconSpecURL = () => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/config/spec`;
@@ -96,7 +96,7 @@ export const useSlotToEpoch = <T extends number | undefined>(
 
 const useBeaconHeaderURL = (tag: string) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/beacon/headers/${tag}`;
@@ -104,7 +104,7 @@ const useBeaconHeaderURL = (tag: string) => {
 
 const useBeaconBlockURL = (slot: number | string) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v2/beacon/blocks/${slot}`;
@@ -112,7 +112,7 @@ const useBeaconBlockURL = (slot: number | string) => {
 
 const useBlockRootURL = (slotNumber: number) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/beacon/blocks/${slotNumber}/root`;
@@ -120,7 +120,7 @@ const useBlockRootURL = (slotNumber: number) => {
 
 const useValidatorURL = (validatorIndex: number | string) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/beacon/states/head/validators/${validatorIndex}`;
@@ -128,7 +128,7 @@ const useValidatorURL = (validatorIndex: number | string) => {
 
 const useEpochProposersURL = (epochNumber: number) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/validator/duties/proposer/${epochNumber}`;
@@ -140,7 +140,7 @@ const useCommitteeURL = (
   committeeIndex: number,
 ) => {
   const { config } = useContext(RuntimeContext);
-  if (config?.beaconAPI === undefined) {
+  if (config.beaconAPI === undefined) {
     return null;
   }
   return `${config.beaconAPI}/eth/v1/beacon/states/head/committees?epoch=${epochNumber}&slot=${slotNumber}&index=${committeeIndex}`;

--- a/src/usePriceOracle.ts
+++ b/src/usePriceOracle.ts
@@ -245,7 +245,7 @@ export const useTokenUSDOracle = (
   const { config } = useContext(RuntimeContext);
   const fetcher = feedRegistryFetcher(
     provider,
-    config?.priceOracleInfo,
+    config.priceOracleInfo,
     {
       price: ethPrice,
       decimals: ethPriceDecimals,
@@ -303,7 +303,7 @@ export const useETHUSDOracle = (
 ): { price: bigint | undefined; decimals: bigint } => {
   const { config } = useContext(RuntimeContext);
   const priceOracleInfo =
-    config?.priceOracleInfo ??
+    config.priceOracleInfo ??
     (provider
       ? defaultPriceOracleInfo.get(provider._network.chainId)
       : undefined);
@@ -326,7 +326,7 @@ export const useFiatValue = (
   ethAmount: bigint,
   blockTag: BlockTag | undefined,
 ) => {
-  const { config, provider } = useContext(RuntimeContext);
+  const { provider } = useContext(RuntimeContext);
   const { price: ethPrice, decimals: ethPriceDecimals } = useETHUSDOracle(
     provider,
     blockTag,
@@ -366,7 +366,7 @@ export const useETHUSDRawOracle = (
   blockTag: BlockTag | undefined,
 ): any | undefined => {
   const { config } = useContext(RuntimeContext);
-  const fetcher = ethUSDFetcher(provider, config?.priceOracleInfo);
+  const fetcher = ethUSDFetcher(provider, config.priceOracleInfo);
   const { data, error } = useSWRImmutable(ethUSDFetcherKey(blockTag), fetcher);
   if (error) {
     return undefined;

--- a/src/useProvider.ts
+++ b/src/useProvider.ts
@@ -13,7 +13,7 @@ export const DEFAULT_ERIGON_URL = "http://127.0.0.1:8545";
 export const createAndProbeProvider = async (
   erigonURL?: string,
   experimentalFixedChainId?: number,
-): Promise<JsonRpcApiProvider | undefined> => {
+): Promise<JsonRpcApiProvider> => {
   if (erigonURL !== undefined) {
     if (erigonURL === "") {
       console.info(`Using default erigon URL: ${DEFAULT_ERIGON_URL}`);

--- a/src/useRuntime.ts
+++ b/src/useRuntime.ts
@@ -9,15 +9,23 @@ import { createAndProbeProvider } from "./useProvider";
  */
 export type OtterscanRuntime = {
   /**
-   * Config object; may be null if it is still fetching.
+   * Config object; it is guaranteed a config has already been loaded
+   * by the time the runtime object is constructed.
    */
-  config?: OtterscanConfig;
+  config: OtterscanConfig;
 
   /**
-   * ETH provider; may be undefined if not ready because of config fetching,
-   * probing occurring, etc.
+   * ETH provider; notice that it doesn't mean that there can't be network
+   * errors, remote node shutting down, etc., situations which can make
+   * this object unusable in the future and the caller should do proper
+   * error handling.
+   *
+   * The presence of this field merely means that at the time this object
+   * was instantiated, an ETH provider was built on top of the given
+   * configuration, and some basic testing/probing might have been made
+   * in order to fail fast obvious configuration errors.
    */
-  provider?: JsonRpcApiProvider;
+  provider: JsonRpcApiProvider;
 };
 
 /**
@@ -46,8 +54,8 @@ export const createRuntime = async (
   }
 
   const provider = await createAndProbeProvider(
-    effectiveConfig?.erigonURL,
-    effectiveConfig?.experimentalFixedChainId,
+    effectiveConfig.erigonURL,
+    effectiveConfig.experimentalFixedChainId,
   );
   return {
     config: effectiveConfig,

--- a/src/useTitle.ts
+++ b/src/useTitle.ts
@@ -11,9 +11,9 @@ export const usePageTitle = (title: string | undefined) => {
   if (title === undefined) {
     return;
   }
-  const siteName = config?.branding?.siteName || "Otterscan";
-  const networkTitle = config?.branding?.networkTitle
-    ? `| ${config?.branding?.networkTitle} `
+  const siteName = config.branding?.siteName || "Otterscan";
+  const networkTitle = config.branding?.networkTitle
+    ? `| ${config.branding?.networkTitle} `
     : "";
   document.title = `${title} ${networkTitle}| ${siteName}`;
 };

--- a/src/useTopic0.ts
+++ b/src/useTopic0.ts
@@ -46,7 +46,7 @@ export const useTopic0 = (
   }
 
   const runtime = useContext(RuntimeContext);
-  const assetsURLPrefix = runtime.config?.assetsURLPrefix;
+  const assetsURLPrefix = runtime.config.assetsURLPrefix;
 
   const topic0 = rawTopic0.slice(2);
   const signatureURL = () =>


### PR DESCRIPTION
Removing only the runtime.config? assertion.

will do runtime.provider? separately because it is a lot of code, and also I saw some provider._network calls that may be error prone and needs fix too.