### PR TITLE
Increase log scroll timeout to 500ms

### DIFF
--- a/src/execution/transaction/Logs.tsx
+++ b/src/execution/transaction/Logs.tsx
@@ -21,7 +21,7 @@ const Logs: FC<LogsProps> = ({ logs }) => {
           });
         }
       }
-    }, 200);
+    }, 500);
   }, [logs]);
   return (
     <ContentFrame tabs>


### PR DESCRIPTION
Closes #2376.

I am able to reproduce the issue 35% of the time (20 attempts) with the following network connection (using browser debug tools):

Download = 450 kbps
Upload = 150 kbps
Latency = 150 ms

The issue stems from the fact that the page (and each component) is not aware of when all the logs are completely loaded and their height fully extended, so we have to guess when the logs are likely to be loaded and then scroll. Further, we don't want to scroll the page too late after it finishes loading. I'd rather not complicate the code too much, so I just extended the timeout from 200ms to 500ms. I did not get any log scroll misses in another 20 attempts with this 500ms timeout.

We could consider making it an "instant scroll" rather than an animated scroll, though that wouldn't change whether the logs are still loading.