### PR TITLE
Wrap block/position and from/nonce details

### DIFF
--- a/src/components/BlockConfirmations.tsx
+++ b/src/components/BlockConfirmations.tsx
@@ -6,7 +6,7 @@ type BlockConfirmationsProps = {
 };
 
 const BlockConfirmations: FC<BlockConfirmationsProps> = ({ confirmations }) => (
-  <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-500">
+  <span className="rounded bg-gray-100 px-2 py-1 text-xs text-gray-500 whitespace-nowrap">
     {commify(confirmations)} Block{" "}
     {confirmations === 1 ? "Confirmation" : "Confirmations"}
   </span>

--- a/src/components/BlockLink.tsx
+++ b/src/components/BlockLink.tsx
@@ -20,7 +20,7 @@ const BlockLink: FC<BlockLinkProps> = ({ blockTag }) => {
   return (
     <NavLink
       className={`flex-inline items-baseline space-x-1 break-all text-link-blue hover:text-link-blue-hover ${
-        isNum ? "font-blocknum" : "font-hash"
+        isNum ? "font-blocknum whitespace-nowrap" : "font-hash"
       }`}
       to={blockURL(blockTag)}
     >

--- a/src/components/NavBlock.tsx
+++ b/src/components/NavBlock.tsx
@@ -19,11 +19,13 @@ const NavBlock: FC<NavBlockProps> = ({
   urlBuilder,
   showFirstLink = false,
 }) => (
-  <div className="flex space-x-1 self-center pl-2">
+  <div className="flex flex-no-wrap space-x-1 self-center pl-2">
     {showFirstLink && (
       <NavButton href={urlBuilder(0)} disabled={entityNum === 0}>
-        <FontAwesomeIcon icon={faChevronLeft} />
-        <FontAwesomeIcon icon={faChevronLeft} />
+        <div className="whitespace-nowrap">
+          <FontAwesomeIcon icon={faChevronLeft} />
+          <FontAwesomeIcon icon={faChevronLeft} />
+        </div>
       </NavButton>
     )}
     <NavButton href={urlBuilder(entityNum - 1)} disabled={entityNum === 0}>
@@ -39,8 +41,10 @@ const NavBlock: FC<NavBlockProps> = ({
       href={urlBuilder(latestEntityNum!)}
       disabled={latestEntityNum === undefined || entityNum >= latestEntityNum}
     >
-      <FontAwesomeIcon icon={faChevronRight} />
-      <FontAwesomeIcon icon={faChevronRight} />
+      <div className="whitespace-nowrap">
+        <FontAwesomeIcon icon={faChevronRight} />
+        <FontAwesomeIcon icon={faChevronRight} />
+      </div>
     </NavButton>
   </div>
 );

--- a/src/components/RelativePosition.tsx
+++ b/src/components/RelativePosition.tsx
@@ -6,7 +6,7 @@ type RelativePositionProps = {
 };
 
 const RelativePosition: FC<RelativePositionProps> = ({ pos, total }) => (
-  <span className="text-xs">
+  <span className="text-xs whitespace-nowrap">
     {pos}
     <span className="text-sm text-gray-600"> / {total}</span>
   </span>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -218,15 +218,15 @@ const Details: FC<DetailsProps> = ({ txData }) => {
       {txData.confirmedData && (
         <>
           <InfoRow title="Block / Position">
-            <div className="flex items-baseline divide-x-2 divide-dotted divide-gray-300">
-              <div className="mr-3 flex items-baseline space-x-1">
+            <div className="flex flex-wrap items-baseline divide-x-2 divide-dotted divide-gray-300">
+              <div className="flex items-baseline space-x-1">
                 <BlockLink blockTag={txData.confirmedData.blockNumber} />
                 <BlockConfirmations
                   confirmations={txData.confirmedData.confirmations}
                 />
               </div>
               {block && (
-                <div className="flex items-baseline space-x-2 pl-3">
+                <div className="ml-3 flex items-baseline space-x-2 pl-3">
                   <RelativePosition
                     pos={txData.confirmedData.transactionIndex}
                     total={block.transactionCount - 1}
@@ -257,7 +257,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
         </>
       )}
       <InfoRow title="From / Nonce">
-        <div className="flex divide-x-2 divide-dotted divide-gray-300">
+        <div className="flex flex-wrap divide-x-2 divide-dotted divide-gray-300">
           <TransactionAddressWithCopy address={txData.from} />
           <div className="ml-3 flex items-baseline pl-3">
             <Nonce value={txData.nonce} />

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -218,7 +218,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
       {txData.confirmedData && (
         <>
           <InfoRow title="Block / Position">
-            <div className="flex flex-wrap items-baseline divide-x-2 divide-dotted divide-gray-300">
+            <div className="flex flex-wrap gap-y-2 items-baseline divide-x-2 divide-dotted divide-gray-300">
               <div className="flex items-baseline space-x-1">
                 <BlockLink blockTag={txData.confirmedData.blockNumber} />
                 <BlockConfirmations
@@ -257,7 +257,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
         </>
       )}
       <InfoRow title="From / Nonce">
-        <div className="flex flex-wrap divide-x-2 divide-dotted divide-gray-300">
+        <div className="flex flex-wrap gap-y-2 divide-x-2 divide-dotted divide-gray-300">
           <TransactionAddressWithCopy address={txData.from} />
           <div className="ml-3 flex items-baseline pl-3">
             <Nonce value={txData.nonce} />


### PR DESCRIPTION
Closes #2380.

Allows the Block/Position and From/Nonce transaction detail rows to wrap.

Enough room:
![image](https://github.com/user-attachments/assets/ab1c9ef0-ee61-40a2-bb61-3e9c4f75cc31)

Compressed:
![image](https://github.com/user-attachments/assets/ae8d8bd0-9086-411e-b6e4-8d1201f4fd49)
