### PR TITLE
Remove checks assuming provider object is now guaranteed to be present

### DIFF
--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -8,16 +8,12 @@ const Footer: React.FC = () => {
     <>
       <div
         className={`w-full border-t border-t-gray-100 px-2 py-1 text-xs ${
-          provider?._network.chainId === 1n
+          provider._network.chainId === 1n
             ? "bg-link-blue dark:bg-link-blue-light text-gray-200 dark:text-gray-800"
             : "bg-orange-400 text-white dark:text-gray-900"
         } text-center`}
       >
-        {provider ? (
-          <>Using Erigon node at {config.erigonURL}</>
-        ) : (
-          <>Waiting for the provider...</>
-        )}
+        Using Erigon node at {config.erigonURL}
       </div>
     </>
   );

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -42,7 +42,7 @@ const Header: FC = () => {
           </div>
         </div>
         <div className="flex items-baseline gap-x-3">
-          {(provider?._network.chainId === 1n ||
+          {(provider._network.chainId === 1n ||
             config.priceOracleInfo?.nativeTokenPrice?.ethUSDOracleAddress) && (
             <div className="hidden lg:inline">
               <PriceBox />
@@ -59,7 +59,7 @@ const Header: FC = () => {
               type="text"
               size={60}
               placeholder={`Type "/" to search by address / txn hash / block number${
-                provider?._network.getPlugin(
+                provider._network.getPlugin(
                   "org.ethers.plugins.network.Ens",
                 ) !== null
                   ? " / ENS name"

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -49,7 +49,7 @@ const Home: FC = () => {
               size={50}
               data-test="home-search-input"
               placeholder={`Search by address / txn hash / block number${
-                provider?._network.getPlugin(
+                provider._network.getPlugin(
                   "org.ethers.plugins.network.Ens",
                 ) !== null
                   ? " / ENS name"

--- a/src/PriceBox.tsx
+++ b/src/PriceBox.tsx
@@ -57,7 +57,7 @@ const PriceBox: React.FC = () => {
 
   const [prevDayBlock, setPrevDayBlock] = useState<number | null>(null);
   useEffect(() => {
-    if (provider === undefined || latestBlock === undefined) {
+    if (latestBlock === undefined) {
       return;
     }
     (async function () {

--- a/src/WarningHeader.tsx
+++ b/src/WarningHeader.tsx
@@ -5,7 +5,7 @@ import { RuntimeContext } from "./useRuntime";
 const WarningHeader: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
   const { name } = useChainInfo();
-  const chainId = provider?._network.chainId;
+  const chainId = provider._network.chainId;
   if (chainId === 1n) {
     return <></>;
   }

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -106,11 +106,11 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
   const hasCode = useHasCode(provider, checksummedAddress);
   const match = useSourcifyMetadata(
     hasCode ? checksummedAddress : undefined,
-    provider?._network.chainId,
+    provider._network.chainId,
   );
   const whatsabiMatch = useWhatsabiMetadata(
     match === null && hasCode ? checksummedAddress : undefined,
-    provider?._network.chainId,
+    provider._network.chainId,
     provider,
     config.assetsURLPrefix,
   );
@@ -121,7 +121,7 @@ const AddressMainPage: React.FC<AddressMainPageProps> = () => {
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
           supportsENS={
-            provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
+            provider._network.getPlugin("org.ethers.plugins.network.Ens") !==
             null
           }
         />

--- a/src/execution/AddressTransactionByNonce.tsx
+++ b/src/execution/AddressTransactionByNonce.tsx
@@ -52,7 +52,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
   // Calculate txCount ONLY when asked for latest nonce
   const [txCount, setTxCount] = useState<bigint | undefined>();
   useEffect(() => {
-    if (!provider || !checksummedAddress || rawNonce !== "latest") {
+    if (!checksummedAddress || rawNonce !== "latest") {
       setTxCount(undefined);
       return;
     }
@@ -106,7 +106,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
         <AddressOrENSNameNotFound
           addressOrENSName={addressOrName}
           supportsENS={
-            provider?._network.getPlugin("org.ethers.plugins.network.Ens") !==
+            provider._network.getPlugin("org.ethers.plugins.network.Ens") !==
             null
           }
         />

--- a/src/execution/BroadcastTransactionPage.tsx
+++ b/src/execution/BroadcastTransactionPage.tsx
@@ -16,23 +16,21 @@ const BroadcastTransactionPage: React.FC = () => {
   }>({ success: null, result: "" });
 
   async function submitTx() {
-    if (provider) {
-      const trimmedRawTx = rawTx.trim();
-      if (trimmedRawTx.length > 2) {
-        try {
-          const txHash = await provider.send("eth_sendRawTransaction", [
-            trimmedRawTx,
-          ]);
-          setResultState({ success: true, result: txHash });
-        } catch (e: any) {
-          setResultState({ success: false, result: e.toString() });
-        }
-      } else {
-        setResultState({
-          success: false,
-          result: "Please enter a raw signed transaction.",
-        });
+    const trimmedRawTx = rawTx.trim();
+    if (trimmedRawTx.length > 2) {
+      try {
+        const txHash = await provider.send("eth_sendRawTransaction", [
+          trimmedRawTx,
+        ]);
+        setResultState({ success: true, result: txHash });
+      } catch (e: any) {
+        setResultState({ success: false, result: e.toString() });
       }
+    } else {
+      setResultState({
+        success: false,
+        result: "Please enter a raw signed transaction.",
+      });
     }
   }
 

--- a/src/execution/address/AddressTokens.tsx
+++ b/src/execution/address/AddressTokens.tsx
@@ -20,7 +20,7 @@ const AddressTokens: FC<AddressAwareComponentProps> = ({ address }) => {
   usePageTitle(`Token Balances | ${address}`);
 
   const [enabled, setEnabled] = useState<boolean>(true);
-  const tokenSet = useTokenSet(provider?._network.chainId);
+  const tokenSet = useTokenSet(provider._network.chainId);
   const filteredList = useMemo(() => {
     if (erc20List === undefined) {
       return undefined;

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -72,7 +72,7 @@ const AddressTransactionResults: FC<AddressAwareComponentProps> = ({
   );
 
   useEffect(() => {
-    if (!provider || !address) {
+    if (!address) {
       return;
     }
 

--- a/src/execution/address/contract/ReadContract.tsx
+++ b/src/execution/address/contract/ReadContract.tsx
@@ -1,10 +1,9 @@
 import { FunctionFragment } from "ethers";
-import React, { useContext, useState } from "react";
+import React, { useState } from "react";
 import ContentFrame from "../../../components/ContentFrame";
 import LabeledSwitch from "../../../components/LabeledSwitch";
 import StandardSelectionBoundary from "../../../selection/StandardSelectionBoundary";
 import { Match, MatchType } from "../../../sourcify/useSourcify";
-import { RuntimeContext } from "../../../useRuntime";
 import { usePageTitle } from "../../../useTitle";
 import WhatsabiWarning from "../WhatsabiWarning";
 import ReadFunction from "./ReadFunction";
@@ -25,7 +24,6 @@ const ReadContract: React.FC<ContractsProps> = ({
   checksummedAddress,
   match,
 }) => {
-  const { provider } = useContext(RuntimeContext);
   const [showNonViewReturns, setShowNonViewReturns] = useState<boolean>(false);
   usePageTitle(`Read Contract | ${checksummedAddress}`);
 

--- a/src/execution/address/contract/ReadFunction.tsx
+++ b/src/execution/address/contract/ReadFunction.tsx
@@ -185,37 +185,32 @@ const ReadFunction: FC<ReadFunctionProps> = ({
 
   async function submitCall() {
     let int = new Interface([func]);
-    if (provider) {
-      try {
-        setResult(undefined);
-        // The parser can be recompiled with `npm run build-parsers`
-        const inputTree: ParamValue[] = childRefs.current.map((childRef) =>
-          childRef.computeParamValue(),
-        );
-        let encodedData = int.encodeFunctionData(
-          func.name,
-          await Promise.all(
-            inputTree.map((input: ParamValue, i: number) =>
-              parseStructuredArgument(input, func.inputs[i], i, provider),
-            ),
+    try {
+      setResult(undefined);
+      // The parser can be recompiled with `npm run build-parsers`
+      const inputTree: ParamValue[] = childRefs.current.map((childRef) =>
+        childRef.computeParamValue(),
+      );
+      let encodedData = int.encodeFunctionData(
+        func.name,
+        await Promise.all(
+          inputTree.map((input: ParamValue, i: number) =>
+            parseStructuredArgument(input, func.inputs[i], i, provider),
           ),
-        );
-        let resultData = await provider.call({
-          to: address,
-          data: encodedData,
-        });
-        setResult({
-          result: int.decodeFunctionResult(func.name, resultData),
-          data: resultData,
-        });
-        setError(null);
-      } catch (e: any) {
-        setResult(null);
-        setError(e.toString());
-      }
-    } else {
+        ),
+      );
+      let resultData = await provider.call({
+        to: address,
+        data: encodedData,
+      });
+      setResult({
+        result: int.decodeFunctionResult(func.name, resultData),
+        data: resultData,
+      });
+      setError(null);
+    } catch (e: any) {
       setResult(null);
-      setError("Provider not found");
+      setError(e.toString());
     }
   }
 

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -47,7 +47,7 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
   plain,
 }) => {
   const { config, provider } = useContext(RuntimeContext);
-  const match = useSourcifyMetadata(address, provider?._network.chainId);
+  const match = useSourcifyMetadata(address, provider._network.chainId);
 
   const mint = addressCtx === AddressContext.FROM && address === ZERO_ADDRESS;
   const burn = addressCtx === AddressContext.TO && address === ZERO_ADDRESS;
@@ -146,14 +146,9 @@ const ResolvedAddress: FC<ResolvedAddressProps> = ({
   const { provider } = useContext(RuntimeContext);
   const resolvedAddress = useResolvedAddress(provider, address);
   const linkable = address !== selectedAddress;
-  const match = useSourcifyMetadata(address, provider?._network.chainId);
+  const match = useSourcifyMetadata(address, provider._network.chainId);
 
-  if (
-    provider &&
-    !resolvedAddress &&
-    match &&
-    match.metadata.settings?.compilationTarget
-  ) {
+  if (!resolvedAddress && match && match.metadata.settings?.compilationTarget) {
     const compilationTarget = match.metadata.settings?.compilationTarget;
     if (Object.values(compilationTarget).length > 0) {
       return VerifiedContractRenderer(
@@ -166,7 +161,7 @@ const ResolvedAddress: FC<ResolvedAddressProps> = ({
     }
   }
 
-  if (!provider || !resolvedAddress) {
+  if (!resolvedAddress) {
     return (
       <PlainAddress
         address={address}

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -87,7 +87,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
 
   const tokenTransfers = useTokenTransfers(txData);
 
-  const match = useSourcifyMetadata(txData?.to, provider?._network.chainId);
+  const match = useSourcifyMetadata(txData?.to, provider._network.chainId);
   const metadata = match?.metadata;
 
   const txDesc = useSourcifyTransactionDescription(metadata, txData);
@@ -117,7 +117,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
     : undefined;
   const [expanded, setExpanded] = useState<boolean>(false);
   const [showFunctionHelp, setShowFunctionHelp] = useState<boolean>(false);
-  const isOptimistic = isOptimisticChain(provider?._network.chainId);
+  const isOptimistic = isOptimisticChain(provider._network.chainId);
 
   const { totalFees } = calculateFee(txData, block);
 

--- a/src/execution/transaction/LogEntry.tsx
+++ b/src/execution/transaction/LogEntry.tsx
@@ -18,7 +18,7 @@ type LogEntryProps = {
 
 const LogEntry: FC<LogEntryProps> = ({ log }) => {
   const { provider } = useContext(RuntimeContext);
-  const match = useSourcifyMetadata(log.address, provider?._network.chainId);
+  const match = useSourcifyMetadata(log.address, provider._network.chainId);
 
   const logDesc = useMemo(() => {
     if (!match) {

--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -45,7 +45,7 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
     t.value,
   );
 
-  const match = useSourcifyMetadata(t.to, provider?._network.chainId);
+  const match = useSourcifyMetadata(t.to, provider._network.chainId);
   const metadata = match?.metadata;
   const sourcifyTxDesc = useSourcifyTransactionDescription(metadata, {
     data: t.input,

--- a/src/ots2/usePrototypeHooks.ts
+++ b/src/ots2/usePrototypeHooks.ts
@@ -43,7 +43,7 @@ export type ContractSearchType =
   | "ERC1167";
 
 export const useGenericContractSearch = <T extends ContractMatch>(
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   t: ContractSearchType,
   pageNumber: number,
   pageSize: number,
@@ -80,7 +80,7 @@ export const useGenericContractSearch = <T extends ContractMatch>(
 };
 
 export const useGenericContractsCount = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   t: ContractSearchType,
 ): number | undefined => {
   const rpcMethod = `ots2_get${t}Count`;

--- a/src/ots2/usePrototypeTransferHooks.ts
+++ b/src/ots2/usePrototypeTransferHooks.ts
@@ -63,7 +63,7 @@ type SearchResultsType<T extends TransactionSearchType> =
       : TransactionMatchWithData;
 
 export const useGenericTransactionCount = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   typeName: TransactionSearchType,
   address: ChecksummedAddress,
 ): number | undefined => {
@@ -109,7 +109,7 @@ function decodeResults<T extends TransactionSearchType>(
 }
 
 const resultFetcher = <T extends TransactionSearchType, U>(
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   typeName: T,
 ): Fetcher<
   TransactionListResults<SearchResultsType<T>, U> | undefined,
@@ -119,7 +119,7 @@ const resultFetcher = <T extends TransactionSearchType, U>(
 
   return async (key) => {
     const res = await fetcher(key);
-    if (res === undefined || provider === undefined) {
+    if (res === undefined) {
       return undefined;
     }
 
@@ -142,7 +142,7 @@ export const useGenericTransactionList = <
   T extends TransactionSearchType,
   U = BlockSummary,
 >(
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   typeName: T,
   address: ChecksummedAddress,
   pageNumber: number,
@@ -164,7 +164,7 @@ export const useGenericTransactionList = <
 };
 
 export const useERC1167Impl = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
 ): ChecksummedAddress | undefined | null => {
   const fetcher = providerFetcher(provider);
@@ -179,7 +179,7 @@ export const useERC1167Impl = (
 };
 
 export const useERC20Holdings = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress,
 ): ChecksummedAddress[] | undefined => {
   const fetcher = providerFetcher(provider);
@@ -202,16 +202,12 @@ const ERC20_PROTOTYPE = new Contract(ZeroAddress, erc20);
 
 const erc20BalanceFetcher =
   (
-    provider: JsonRpcApiProvider | undefined,
+    provider: JsonRpcApiProvider,
   ): Fetcher<
     bigint | null,
     ["erc20balance", ChecksummedAddress, ChecksummedAddress]
   > =>
   async ([_, address, tokenAddress]) => {
-    if (provider === undefined) {
-      return null;
-    }
-
     // TODO: Remove "as Contract" workaround for https://github.com/ethers-io/ethers.js/issues/4183
     const contract = ERC20_PROTOTYPE.connect(provider).attach(
       tokenAddress,
@@ -220,7 +216,7 @@ const erc20BalanceFetcher =
   };
 
 export const useTokenBalance = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
   tokenAddress: ChecksummedAddress | undefined,
 ): bigint | null | undefined => {
@@ -249,7 +245,7 @@ export type AddressAttributes = {
 };
 
 export const useAddressAttributes = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
 ): AddressAttributes | undefined => {
   const fetcher = providerFetcher(provider);
@@ -275,7 +271,7 @@ export type ProxyAttributes = {
 };
 
 export const useProxyAttributes = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
 ): ProxyAttributes => {
   const attr = useAddressAttributes(provider, address);
@@ -289,7 +285,7 @@ export const useProxyAttributes = (
   const proxyHasCode = useHasCode(provider, checksummedProxyAddress);
   const proxyMatch = useSourcifyMetadata(
     proxyHasCode ? checksummedProxyAddress : undefined,
-    provider?._network.chainId,
+    provider._network.chainId,
   );
 
   return {

--- a/src/special/london/Blocks.tsx
+++ b/src/special/london/Blocks.tsx
@@ -59,10 +59,6 @@ const Blocks: React.FC<BlocksProps> = ({ latestBlock }) => {
 
   const addBlock = useCallback(
     async (blockNumber: number) => {
-      if (!provider) {
-        return;
-      }
-
       const extBlock = await readBlock(provider, blockNumber.toString());
       setBlocks((_blocks) => {
         for (let i = 0; i < _blocks.length; i++) {

--- a/src/special/london/LiveBlocks.tsx
+++ b/src/special/london/LiveBlocks.tsx
@@ -6,7 +6,7 @@ import Blocks from "./Blocks";
 const LiveBlocks: React.FC = () => {
   const { provider } = useContext(RuntimeContext);
   const block = useLatestBlockHeader(provider);
-  if (!provider || !block) {
+  if (!block) {
     return <div className="grow"></div>;
   }
 

--- a/src/use4Bytes.ts
+++ b/src/use4Bytes.ts
@@ -99,10 +99,7 @@ export const use4Bytes = (
   }
 
   const { config, provider } = useContext(RuntimeContext);
-  const sourcifyMatch = useSourcifyMetadata(
-    address,
-    provider?._network.chainId,
-  );
+  const sourcifyMatch = useSourcifyMetadata(address, provider._network.chainId);
   let sourcifyFourBytes: FourBytesEntry | null = null;
   if (sourcifyMatch && rawFourBytes) {
     try {

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -740,7 +740,7 @@ type ContractCreator = {
 };
 
 export const useContractCreator = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
 ): ContractCreator | null | undefined => {
   const { data, error } = useSWR<
@@ -748,7 +748,7 @@ export const useContractCreator = (
     any,
     ContractCreatorKey | null
   >(
-    provider && address
+    address
       ? {
           type: "cc",
           network: provider._network.chainId,
@@ -782,13 +782,13 @@ const getContractCreatorFetcher =
   };
 
 export const useAddressBalance = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress | undefined,
 ): bigint | null | undefined => {
   const [balance, setBalance] = useState<bigint | undefined>();
 
   useEffect(() => {
-    if (!provider || !address) {
+    if (!address) {
       return undefined;
     }
 
@@ -912,13 +912,9 @@ const l1BlockContractAddress = "0x4200000000000000000000000000000000000015";
 const L1BLOCK_PROTOTYPE = new Contract(l1BlockContractAddress, L1Block);
 const l1EpochFetcher =
   (
-    provider: JsonRpcApiProvider | undefined,
+    provider: JsonRpcApiProvider,
   ): Fetcher<bigint | null, ["l1epoch", BlockTag]> =>
   async ([_, blockTag]) => {
-    if (provider === undefined) {
-      return null;
-    }
-
     // TODO: workaround for https://github.com/ethers-io/ethers.js/issues/4183
     const l1BlockContract: Contract = L1BLOCK_PROTOTYPE.connect(
       provider,
@@ -931,12 +927,11 @@ const l1EpochFetcher =
   };
 
 export const useL1Epoch = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   blockTag: BlockTag | null,
 ): bigint | null | undefined => {
   const fetcher = l1EpochFetcher(provider);
-  const key =
-    provider !== undefined && isOptimisticChain(provider._network.chainId)
+  const key = isOptimisticChain(provider._network.chainId)
       ? ["l1epoch", blockTag]
       : null;
   const { data, error } = useSWRImmutable(key, fetcher);

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -932,8 +932,8 @@ export const useL1Epoch = (
 ): bigint | null | undefined => {
   const fetcher = l1EpochFetcher(provider);
   const key = isOptimisticChain(provider._network.chainId)
-      ? ["l1epoch", blockTag]
-      : null;
+    ? ["l1epoch", blockTag]
+    : null;
   const { data, error } = useSWRImmutable(key, fetcher);
   return error ? undefined : data;
 };

--- a/src/useLatestBlock.ts
+++ b/src/useLatestBlock.ts
@@ -7,14 +7,10 @@ import { formatter } from "./utils/formatter";
  * that'll update and trigger a component render as a side effect
  * every time it is notified of a new block by the web3 provider.
  */
-export const useLatestBlockHeader = (provider?: JsonRpcApiProvider) => {
+export const useLatestBlockHeader = (provider: JsonRpcApiProvider) => {
   const [latestBlock, setLatestBlock] = useState<Block>();
 
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
-
     const getAndSetBlockHeader = async (blockNumber: number) => {
       const _raw = await provider.send("erigon_getHeaderByNumber", [
         blockNumber,
@@ -48,14 +44,10 @@ export const useLatestBlockHeader = (provider?: JsonRpcApiProvider) => {
  *
  * This hook is cheaper than useLatestBlockHeader.
  */
-export const useLatestBlockNumber = (provider?: JsonRpcApiProvider) => {
+export const useLatestBlockNumber = (provider: JsonRpcApiProvider) => {
   const [latestBlock, setLatestBlock] = useState<number>();
 
   useEffect(() => {
-    if (!provider) {
-      return;
-    }
-
     // Immediately read and set the latest block number
     const readLatestBlock = async () => {
       const blockNum = await provider.getBlockNumber();

--- a/src/useResolvedAddresses.ts
+++ b/src/useResolvedAddresses.ts
@@ -40,9 +40,6 @@ export const useAddressOrENS = (
       return;
     }
 
-    if (!provider) {
-      return;
-    }
     if (
       (
         provider._network.getPlugin(
@@ -74,16 +71,13 @@ export const useAddressOrENS = (
 };
 
 export const useResolvedAddress = (
-  provider: JsonRpcApiProvider | undefined,
+  provider: JsonRpcApiProvider,
   address: ChecksummedAddress,
 ): SelectedResolvedName<any> | undefined => {
   const fetcher: Fetcher<
     SelectedResolvedName<any> | undefined,
     string
   > = async (key) => {
-    if (!provider) {
-      return undefined;
-    }
     const resolver = getResolver(provider._network.chainId);
     return resolver.resolveAddress(provider, key);
   };


### PR DESCRIPTION
Now that we guarantee that the provider object is created at initialization, we can remove lots of checks downstream and simplify the code.