### PR TITLE
Erigon 3 removed total difficult field

### DIFF
--- a/src/execution/BlockDetails.tsx
+++ b/src/execution/BlockDetails.tsx
@@ -167,7 +167,9 @@ const BlockDetails: FC<BlockDetailsProps> = ({ blockNumberOrHash }) => {
             {commify(block.difficulty.toString())}
           </InfoRow>
           <InfoRow title="Total Difficulty">
-            {commify(block.totalDifficulty.toString())}
+            {block.totalDifficulty !== undefined
+              ? commify(block.totalDifficulty.toString())
+              : "N/A"}
           </InfoRow>
           <InfoRow title="Hash">
             <HexValue value={block.hash ?? "<unknown>"} />

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -41,7 +41,7 @@ export interface ExtendedBlock extends BlockParams {
   size: number;
   sha3Uncles: string;
   stateRoot: string;
-  totalDifficulty: bigint;
+  totalDifficulty?: bigint;
   transactionCount: number;
   // Optimism-specific
   gasUsedDepositTx?: bigint;
@@ -78,7 +78,9 @@ export const readBlock = async (
     size: formatter.number(_rawBlock.block.size),
     sha3Uncles: _rawBlock.block.sha3Uncles,
     stateRoot: _rawBlock.block.stateRoot,
-    totalDifficulty: formatter.bigInt(_rawBlock.block.totalDifficulty),
+    totalDifficulty:
+      _rawBlock.block.totalDifficulty &&
+      formatter.bigInt(_rawBlock.block.totalDifficulty),
     transactionCount: formatter.number(_rawBlock.block.transactionCount),
     // Optimism-specific; gas used by the deposit transaction
     gasUsedDepositTx: formatter.bigInt(_rawBlock.gasUsedDepositTx ?? 0n),


### PR DESCRIPTION
Current builds of E3 removed the "total difficult" field, so there may be E2 or old E3 nodes with that info, others without it.

Current Otterscan builds have the block page broken with recent E3 nodes.