### PR TITLE
Sourcify RepositoryV2 support

### DIFF
--- a/cypress/support/devnet-config.json
+++ b/cypress/support/devnet-config.json
@@ -2,8 +2,10 @@
   "erigonURL": "http://localhost:8545",
   "beaconAPI": "http://localhost:5052",
   "assetsURLPrefix": "http://localhost:5175",
-  "sourcifySources": {
-    "central_server": "http://localhost:7077",
-    "ipfs": "http://localhost:7077"
+  "sourcify": {
+    "sources": {
+      "central_server": "http://localhost:7077",
+      "ipfs": "http://localhost:7077"
+    }
   }
 }

--- a/src/execution/address/ContractFromRepo.tsx
+++ b/src/execution/address/ContractFromRepo.tsx
@@ -12,6 +12,7 @@ type ContractFromRepoProps = {
   checksummedAddress: string;
   networkId: bigint;
   filename: string;
+  fileHash: string;
   type: MatchType;
 };
 
@@ -19,6 +20,7 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
   checksummedAddress,
   networkId,
   filename,
+  fileHash,
   type,
 }) => {
   const { sourcifySource } = useAppConfigContext();
@@ -26,6 +28,7 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
     checksummedAddress,
     networkId,
     filename,
+    fileHash,
     sourcifySource,
     type,
   );

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -151,6 +151,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
                         checksummedAddress={checksummedAddress}
                         networkId={provider!._network.chainId}
                         filename={selected}
+                        fileHash={match.metadata.sources[selected].keccak256}
                         type={match.type}
                       />
                     )}

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -159,11 +159,24 @@ export type OtterscanConfig = {
     hideAnnouncements?: boolean;
   };
 
-  /**
-   * Optional custom Sourcify sources object with the keys "ipfs" and
-   * "central_server" whose values are their respective root URLs.
-   */
-  sourcifySources?: { [key: string]: string };
+  sourcify?: {
+    /**
+     * Optional custom Sourcify sources object with the keys "ipfs" and
+     * "central_server" whose values are their respective root URLs.
+     */
+    sources?: { [key: string]: string };
+
+    /**
+     * See https://github.com/ethereum/sourcify/tree/staging/services/server#choosing-the-storage-backend
+     *
+     * "RepositoryV1" for the original backend format whose source filenames
+     * are derived from the contract metadata.
+     * "RepositoryV2" to use the Sourcify backend format which uses keccak256
+     * hashes for source file names since source file names can be arbitrary
+     * strings.
+     */
+    backendFormat?: string;
+  };
 
   /**
    * Optional custom price oracle information for estimating the current price


### PR DESCRIPTION
This is a breaking change that puts all Sourcify-related options under the "sourcify" key in the config and adds support for Sourcify's RepositoryV2 backend format by setting the `backendFormat` key. We can add support for other backends (e.g., the Sourcify v2 API) to the `backendFormat` key.

Related: #2472 