### PR TITLE
Show revert locations in contract source code

### DIFF
--- a/src/execution/address/ContractFromRepo.tsx
+++ b/src/execution/address/ContractFromRepo.tsx
@@ -1,6 +1,7 @@
 import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
+import { DecorationOptions } from "shiki";
 import { MatchType, useContract } from "../../sourcify/useSourcify";
 import { useAppConfigContext } from "../../useAppConfig";
 import HighlightedSource from "./contract/HighlightedSource";
@@ -12,6 +13,7 @@ type ContractFromRepoProps = {
   fileHash: string;
   type: MatchType;
   langName: string;
+  decorations?: DecorationOptions["decorations"];
 };
 
 const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
@@ -21,6 +23,7 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
   fileHash,
   type,
   langName,
+  decorations,
 }) => {
   const { sourcifySource } = useAppConfigContext();
   const content = useContract(
@@ -46,7 +49,11 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
         </div>
       )}
       {content !== undefined && (
-        <HighlightedSource source={content} langName={langName} />
+        <HighlightedSource
+          source={content}
+          langName={langName}
+          decorations={decorations}
+        />
       )}
     </>
   );

--- a/src/execution/address/contract/HighlightedSource.tsx
+++ b/src/execution/address/contract/HighlightedSource.tsx
@@ -107,6 +107,14 @@ const HighlightedSource: React.FC<HighlightedSourceProps> = ({
     loadAndHighlight();
   }, [source, highlighter, langName, decorations]);
 
+  useEffect(() => {
+    // Scroll to a highlighted source region if one exists
+    const highlightedNode = document.querySelector(".bg-source-line-highlight");
+    if (highlightedNode) {
+      highlightedNode.scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  }, [code]);
+
   return (
     <div
       className="h-full w-full border font-code text-sm p-3 [&_code]:[counter-reset:step] [&_code]:[counter-increment:step_0] [&_span.line]:before:content-[counter(step)] [&_span.line]:before:[counter-increment:step] [&_span.line]:before:w-4 [&_span.line]:before:mr-6 [&_span.line]:before:inline-block [&_span.line]:before:text-right [&_span.line]:before:text-source-line-numbers"

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -68,7 +68,7 @@ type DetailsProps = {
 };
 
 const Details: FC<DetailsProps> = ({ txData }) => {
-  const { provider } = useContext(RuntimeContext);
+  const { config, provider } = useContext(RuntimeContext);
   const block = useBlockDataFromTransaction(provider, txData);
 
   const hasEIP1559 =
@@ -228,12 +228,14 @@ const Details: FC<DetailsProps> = ({ txData }) => {
                 </TabPanels>
               </TabGroup>
             )}
-            <div className="flex">
-              <div className="rounded-lg bg-red-50 p-2">
-                Revert trace:
-                <RevertTrace txHash={txData.transactionHash} />
+            {config?.revertTraces?.enabled !== false && (
+              <div className="flex">
+                <div className="rounded-lg bg-red-50 p-2">
+                  Revert trace:
+                  <RevertTrace txHash={txData.transactionHash} />
+                </div>
               </div>
-            </div>
+            )}
           </>
         )}
       </InfoRow>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -4,6 +4,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
+import { useQuery } from "@tanstack/react-query";
 import { formatUnits } from "ethers";
 import { FC, memo, useContext, useState } from "react";
 import BlockConfirmations from "../../components/BlockConfirmations";
@@ -44,6 +45,7 @@ import {
 } from "../../use4Bytes";
 import { useChainInfo } from "../../useChainInfo";
 import {
+  getTraceTransactionQuery,
   useBlockDataFromTransaction,
   useSendsToMiner,
   useTokenTransfers,
@@ -59,6 +61,7 @@ import RewardSplit from "./RewardSplit";
 import TokenTransferItem from "./TokenTransferItem";
 import DecodedParamsTable from "./decoder/DecodedParamsTable";
 import InputDecoder from "./decoder/InputDecoder";
+import RevertTrace from "./trace/RevertTrace";
 
 type DetailsProps = {
   txData: TransactionData;
@@ -116,11 +119,16 @@ const Details: FC<DetailsProps> = ({ txData }) => {
   const devError = errorDescription
     ? devDoc?.errors?.[errorDescription.signature]?.[0]
     : undefined;
+
   const [expanded, setExpanded] = useState<boolean>(false);
   const [showFunctionHelp, setShowFunctionHelp] = useState<boolean>(false);
   const isOptimistic = isOptimisticChain(provider._network.chainId);
 
   const { totalFees } = calculateFee(txData, block);
+
+  const { data: otsTrace } = useQuery(
+    getTraceTransactionQuery(provider, txData.transactionHash),
+  );
 
   return (
     <ContentFrame tabs>
@@ -220,6 +228,12 @@ const Details: FC<DetailsProps> = ({ txData }) => {
                 </TabPanels>
               </TabGroup>
             )}
+            <div className="flex">
+              <div className="rounded-lg bg-red-50 p-2">
+                Revert trace:
+                <RevertTrace txHash={txData.transactionHash} />
+              </div>
+            </div>
           </>
         )}
       </InfoRow>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -61,7 +61,7 @@ import RewardSplit from "./RewardSplit";
 import TokenTransferItem from "./TokenTransferItem";
 import DecodedParamsTable from "./decoder/DecodedParamsTable";
 import InputDecoder from "./decoder/InputDecoder";
-import RevertTrace from "./trace/RevertTrace";
+import RevertTraceToggle from "./trace/RevertTraceToggle";
 
 type DetailsProps = {
   txData: TransactionData;
@@ -156,86 +156,84 @@ const Details: FC<DetailsProps> = ({ txData }) => {
           </span>
         ) : (
           <>
-            <div className="flex items-baseline space-x-1">
-              <div className="flex items-baseline space-x-1 rounded-lg bg-red-50 px-3 py-1 text-xs text-red-500">
-                <FontAwesomeIcon
-                  className="self-center"
-                  icon={faTimesCircle}
-                  size="1x"
-                />
-                <span>
-                  {errorType === "string" && errorMsg && (
-                    <>
-                      Fail with revert message: '
-                      <span className="font-bold underline">{errorMsg}</span>'
-                    </>
-                  )}
-                  {errorType === "custom" && (
-                    <>
-                      Fail with custom error
-                      {errorDescription && (
-                        <>
-                          {" '"}
-                          <span className="font-code font-bold underline">
-                            {errorDescription.name}
-                          </span>
-                          {"'"}
-                        </>
-                      )}
-                    </>
-                  )}
-                  {errorType === "panic" && (
-                    <>
-                      <SolidityLogo /> Panic {errorMsg}{" "}
-                      <ExternalLink href="https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require">
-                        (docs)
-                      </ExternalLink>
-                    </>
-                  )}
-                </span>
-              </div>
-              {errorType === "custom" && (
-                <ExpanderSwitch expanded={expanded} setExpanded={setExpanded} />
-              )}
-            </div>
-            {expanded && (
-              <TabGroup>
-                <TabList className="mb-1 mt-2 flex space-x-1">
-                  <ModeTab disabled={!errorDescription}>Decoded</ModeTab>
-                  <ModeTab>Raw</ModeTab>
-                </TabList>
-                <TabPanels>
-                  <TabPanel>
-                    {errorDescription === undefined ? (
-                      <>Waiting for data...</>
-                    ) : errorDescription === null ? (
-                      <>Can't decode data</>
-                    ) : errorDescription.args.length === 0 ? (
-                      <>No parameters</>
-                    ) : (
-                      <DecodedParamsTable
-                        args={errorDescription.args}
-                        paramTypes={errorDescription.fragment.inputs}
-                        hasParamNames
-                        userMethod={userError}
-                        devMethod={devError}
-                      />
+            <div className="flex flex-col space-y-1">
+              <div className="flex items-baseline space-x-1">
+                <div className="flex items-baseline space-x-1 rounded-lg bg-red-50 px-3 py-1 text-xs text-red-500">
+                  <FontAwesomeIcon
+                    className="self-center"
+                    icon={faTimesCircle}
+                    size="1x"
+                  />
+                  <span>
+                    {errorType === "string" && errorMsg && (
+                      <>
+                        Fail with revert message: '
+                        <span className="font-bold underline">{errorMsg}</span>'
+                      </>
                     )}
-                  </TabPanel>
-                  <TabPanel>
-                    <StandardTextarea value={outputData} />
-                  </TabPanel>
-                </TabPanels>
-              </TabGroup>
-            )}
-            {config?.revertTraces?.enabled !== false && (
-              <div className="flex">
-                <div className="rounded-lg bg-red-50 p-2">
-                  Revert trace:
-                  <RevertTrace txHash={txData.transactionHash} />
+                    {errorType === "custom" && (
+                      <>
+                        Fail with custom error
+                        {errorDescription && (
+                          <>
+                            {" '"}
+                            <span className="font-code font-bold underline">
+                              {errorDescription.name}
+                            </span>
+                            {"'"}
+                          </>
+                        )}
+                      </>
+                    )}
+                    {errorType === "panic" && (
+                      <>
+                        <SolidityLogo /> Panic {errorMsg}{" "}
+                        <ExternalLink href="https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require">
+                          (docs)
+                        </ExternalLink>
+                      </>
+                    )}
+                  </span>
                 </div>
+                {errorType === "custom" && (
+                  <ExpanderSwitch
+                    expanded={expanded}
+                    setExpanded={setExpanded}
+                  />
+                )}
               </div>
-            )}
+              {expanded && (
+                <TabGroup>
+                  <TabList className="mb-1 mt-2 flex space-x-1">
+                    <ModeTab disabled={!errorDescription}>Decoded</ModeTab>
+                    <ModeTab>Raw</ModeTab>
+                  </TabList>
+                  <TabPanels>
+                    <TabPanel>
+                      {errorDescription === undefined ? (
+                        <>Waiting for data...</>
+                      ) : errorDescription === null ? (
+                        <>Can't decode data</>
+                      ) : errorDescription.args.length === 0 ? (
+                        <>No parameters</>
+                      ) : (
+                        <DecodedParamsTable
+                          args={errorDescription.args}
+                          paramTypes={errorDescription.fragment.inputs}
+                          hasParamNames
+                          userMethod={userError}
+                          devMethod={devError}
+                        />
+                      )}
+                    </TabPanel>
+                    <TabPanel>
+                      <StandardTextarea value={outputData} />
+                    </TabPanel>
+                  </TabPanels>
+                </TabGroup>
+              )}
+              <RevertTraceToggle txData={txData} />
+            </div>
           </>
         )}
       </InfoRow>

--- a/src/execution/transaction/Trace.tsx
+++ b/src/execution/transaction/Trace.tsx
@@ -1,7 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
 import React, { useContext } from "react";
 import ContentFrame from "../../components/ContentFrame";
 import { TransactionData } from "../../types";
-import { useTraceTransaction } from "../../useErigonHooks";
+import { getTraceTransactionQuery } from "../../useErigonHooks";
 import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
 import TraceItem from "./TraceItem";
@@ -12,7 +13,9 @@ type TraceProps = {
 
 const Trace: React.FC<TraceProps> = ({ txData }) => {
   const { provider } = useContext(RuntimeContext);
-  const traces = useTraceTransaction(provider, txData.transactionHash);
+  const { data: traces } = useQuery(
+    getTraceTransactionQuery(provider, txData.transactionHash),
+  );
 
   return (
     <ContentFrame tabs>

--- a/src/execution/transaction/trace/LinkToSourceRegion.tsx
+++ b/src/execution/transaction/trace/LinkToSourceRegion.tsx
@@ -1,11 +1,35 @@
-import { FC, PropsWithChildren, useEffect, useState } from "react";
+import { FC, PropsWithChildren, useContext, useEffect, useState } from "react";
 import { NavLink } from "react-router";
+import { queryClient } from "../../../queryClient";
+import SourcifyLogo from "../../../sourcify/SourcifyLogo";
+import {
+  getContractQuery,
+  useSourcifyMetadata,
+  useSourcifySources,
+} from "../../../sourcify/useSourcify";
+import { useAppConfigContext } from "../../../useAppConfig";
+import { RuntimeContext } from "../../../useRuntime";
+import { getLineNumber } from "./traceInterpreter";
+
+/**
+ * Extracts a filename from a given file path
+ */
+function getFilenameFromPath(filePath: string): string {
+  const lastSeparatorIndex = filePath.lastIndexOf("/");
+  const filename =
+    lastSeparatorIndex === -1
+      ? filePath
+      : filePath.slice(lastSeparatorIndex + 1);
+  return filename;
+}
 
 type LinkToSourceRegionProps = {
   targetAddr: string;
   targetStart?: number;
   targetEnd?: number;
   targetSource?: string;
+  targetSourceHash?: string;
+  contractName?: string;
 } & PropsWithChildren;
 
 const LinkToSourceRegion: FC<LinkToSourceRegionProps> = ({
@@ -13,9 +37,16 @@ const LinkToSourceRegion: FC<LinkToSourceRegionProps> = ({
   targetStart,
   targetEnd,
   targetSource,
+  targetSourceHash,
+  contractName,
   children,
 }) => {
   const [safeUrl, setSafeUrl] = useState<string>();
+  const [lineNumber, setLineNumber] = useState<number | null>(null);
+  const { sourcifySource } = useAppConfigContext();
+  const sourcifySources = useSourcifySources();
+  const { provider } = useContext(RuntimeContext);
+  const match = useSourcifyMetadata(targetAddr, provider._network.chainId);
 
   useEffect(() => {
     const searchParams = new URLSearchParams();
@@ -32,13 +63,67 @@ const LinkToSourceRegion: FC<LinkToSourceRegionProps> = ({
     setSafeUrl(url);
   }, [targetAddr, targetStart, targetEnd, targetSource]);
 
+  useEffect(() => {
+    if (
+      targetAddr &&
+      targetStart &&
+      targetEnd &&
+      targetSource &&
+      targetSourceHash &&
+      match
+    ) {
+      // Find the line number of the starting location
+      (async function fetchContract() {
+        const contractData = await queryClient.fetchQuery(
+          getContractQuery(
+            sourcifySources,
+            sourcifySource,
+            targetAddr,
+            provider._network.chainId,
+            targetSource,
+            targetSourceHash,
+            match.type,
+          ),
+        );
+
+        if (contractData !== null) {
+          const newLineNumber = getLineNumber(contractData, targetStart);
+          if (newLineNumber !== null) {
+            setLineNumber(newLineNumber);
+          }
+        }
+      })();
+    }
+  }, [
+    targetAddr,
+    targetStart,
+    targetEnd,
+    targetSource,
+    targetSourceHash,
+    match,
+  ]);
+
   if (!safeUrl) {
     return null;
   }
 
   return (
     <NavLink className="text-link-blue hover:text-link-blue-hover" to={safeUrl}>
-      {children}
+      {contractName ? (
+        <div
+          className={`flex space-x-1 ${targetStart !== undefined && targetEnd !== undefined ? "text-green-600 hover:text-green-800" : "text-verified-contract hover:text-verified-contract-hover"}`}
+        >
+          <SourcifyLogo />
+          <span>
+            {contractName}
+            {lineNumber !== null && targetSource
+              ? " - " + getFilenameFromPath(targetSource) + ":" + lineNumber
+              : null}
+          </span>
+        </div>
+      ) : (
+        targetAddr
+      )}
     </NavLink>
   );
 };

--- a/src/execution/transaction/trace/LinkToSourceRegion.tsx
+++ b/src/execution/transaction/trace/LinkToSourceRegion.tsx
@@ -1,0 +1,46 @@
+import { FC, PropsWithChildren, useEffect, useState } from "react";
+import { NavLink } from "react-router";
+
+type LinkToSourceRegionProps = {
+  targetAddr: string;
+  targetStart?: number;
+  targetEnd?: number;
+  targetSource?: string;
+} & PropsWithChildren;
+
+const LinkToSourceRegion: FC<LinkToSourceRegionProps> = ({
+  targetAddr,
+  targetStart,
+  targetEnd,
+  targetSource,
+  children,
+}) => {
+  const [safeUrl, setSafeUrl] = useState<string>();
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams();
+
+    if (targetStart !== undefined && targetEnd !== undefined) {
+      searchParams.append("hr", `${targetStart}-${targetEnd}`);
+    }
+
+    if (targetSource !== undefined) {
+      searchParams.append("source", targetSource);
+    }
+
+    const url = `/address/${encodeURIComponent(targetAddr)}/contract?${searchParams.toString()}`;
+    setSafeUrl(url);
+  }, [targetAddr, targetStart, targetEnd, targetSource]);
+
+  if (!safeUrl) {
+    return null;
+  }
+
+  return (
+    <NavLink className="text-link-blue hover:text-link-blue-hover" to={safeUrl}>
+      {children}
+    </NavLink>
+  );
+};
+
+export default LinkToSourceRegion;

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query";
-import { toBeArray } from "ethers";
 import React, { useContext, useEffect, useState } from "react";
 import { queryClient } from "../../../queryClient";
 import {
@@ -17,6 +16,7 @@ import {
   getVmTraceQuery,
 } from "../../../useErigonHooks";
 import { RuntimeContext } from "../../../useRuntime";
+import { hexToArray } from "../../../utils/utils";
 import LinkToSourceRegion from "./LinkToSourceRegion";
 import {
   findLastUniqueLocation,
@@ -117,7 +117,7 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
 
             const lastUniqueIndex = findLastUniqueLocation(
               targetOffsets,
-              toBeArray(
+              hexToArray(
                 targetCode.startsWith("0x") ? targetCode : "0x" + targetCode,
               ),
             );

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -79,6 +79,7 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
               sourcifySource,
               targetAddr,
               provider._network.chainId,
+              true,
             ),
           );
 
@@ -99,8 +100,9 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
             targetMatch.metadata.settings !== undefined &&
             targetOffsets !== undefined &&
             targetCode !== undefined &&
-            // TODO: SourcifyV2 only
-            (targetMatch.metadata as any).output.contracts !== undefined
+            targetMatch.runtimeBytecode?.sourceMap !== undefined &&
+            // TODO: Remove once SourcifyV2 support for the sources key is implemented
+            targetMatch.stdJsonOutput?.sources !== undefined
           ) {
             // TODO: metadata only (as before)
             const fileName = Object.keys(
@@ -108,12 +110,9 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
             )[0];
             const sourceName =
               targetMatch.metadata.settings.compilationTarget[fileName];
-            // TODO: This is not part of the metadata object! SourcifyV2 only.
-            const sourceMap = (targetMatch.metadata as any).output.contracts[
-              fileName
-            ][sourceName].evm.deployedBytecode.sourceMap;
+            const sourceMap = targetMatch.runtimeBytecode.sourceMap;
             const soliditySources = Object.values(
-              (targetMatch.metadata as any).output.sources,
+              targetMatch.stdJsonOutput.sources,
             ).map((source: any) => source.id);
             const instructionIndexMap = bytecodeToInstructionIndex(targetCode);
 
@@ -134,11 +133,10 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
                 targetStart = byteOffset;
                 targetEnd = byteOffset + length;
                 targetSource = Object.keys(
-                  (targetMatch.metadata as any).output.sources,
+                  targetMatch.stdJsonOutput.sources,
                 ).find(
                   (key) =>
-                    (targetMatch.metadata as any).output.sources[key].id ===
-                    sourceIndex,
+                    targetMatch.stdJsonOutput.sources[key].id === sourceIndex,
                 );
                 if (
                   targetSource !== undefined &&

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -186,16 +186,31 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
           },
           index,
         ) => (
-          <div className="flex" key={index}>
-            <LinkToSourceRegion
-              targetAddr={address}
-              targetStart={targetStart}
-              targetEnd={targetEnd}
-              targetSource={targetSource}
-              targetSourceHash={targetSourceHash}
-              contractName={contractName}
-            ></LinkToSourceRegion>
-          </div>
+          <>
+            <div className="flex" key={index}>
+              <LinkToSourceRegion
+                targetAddr={address}
+                targetStart={targetStart}
+                targetEnd={targetEnd}
+                targetSource={targetSource}
+                targetSourceHash={targetSourceHash}
+                contractName={contractName}
+              ></LinkToSourceRegion>
+            </div>
+            {index < revertLocationsFinal.length - 1 && (
+              <div className="w-full flex justify-center">
+                {/* Chevron */}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="-4 -1.5 8 2.5"
+                  fill="#88b"
+                  className="w-[20px] h-2"
+                >
+                  <path d="M0 -1L4 1V0.5L0 -1.5L-4 0.5V1Z"></path>
+                </svg>
+              </div>
+            )}
+          </>
         ),
       )
     ) : (

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -1,0 +1,191 @@
+import { useQuery } from "@tanstack/react-query";
+import { toBeArray } from "ethers";
+import React, { useContext, useEffect, useState } from "react";
+import { queryClient } from "../../../queryClient";
+import {
+  bytecodeToInstructionIndex,
+  getSourceRange,
+} from "../../../sourcify/sourceMapping";
+import SourcifyLogo from "../../../sourcify/SourcifyLogo";
+import {
+  getSourcifyMetadataQuery,
+  useSourcifySources,
+} from "../../../sourcify/useSourcify";
+import { useAppConfigContext } from "../../../useAppConfig";
+import {
+  getTraceTransactionQuery,
+  getVmTraceQuery,
+} from "../../../useErigonHooks";
+import { RuntimeContext } from "../../../useRuntime";
+import LinkToSourceRegion from "./LinkToSourceRegion";
+import {
+  findLastUniqueLocation,
+  findRevertChain,
+  findTraceExitLocations,
+  mergeEntries,
+} from "./traceInterpreter";
+
+interface RevertTraceProps {
+  txHash: string;
+}
+
+const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
+  const { provider } = useContext(RuntimeContext);
+  const { sourcifySource } = useAppConfigContext();
+  const sourcifySources = useSourcifySources();
+  const { data: otsTrace } = useQuery(
+    getTraceTransactionQuery(provider, txHash),
+  );
+  const { data: vmTrace } = useQuery(getVmTraceQuery(provider, txHash));
+  const traceRes =
+    otsTrace &&
+    vmTrace &&
+    mergeEntries(otsTrace, [findTraceExitLocations(vmTrace)]);
+  const revertChain = findRevertChain(traceRes ?? null);
+
+  const [revertLocations, setRevertLocations] = useState<
+    | {
+        address: string;
+        targetStart?: number;
+        targetEnd?: number;
+        targetSource?: string;
+        contractName?: string;
+      }[]
+    | null
+  >(
+    revertChain
+      ? revertChain.map((traceGroup) => ({ address: traceGroup.to }))
+      : null,
+  );
+
+  useEffect(() => {
+    (async () => {
+      const newRevertLocations = await Promise.all(
+        revertChain.map(async (revertingCall) => {
+          const targetAddr = revertingCall.to;
+          const targetOffsets = revertingCall.pc;
+          const targetCode = revertingCall.code;
+
+          let targetStart: number | undefined = undefined;
+          let targetEnd: number | undefined = undefined;
+          let targetSource: string | undefined = undefined;
+          let contractName: string | undefined = undefined;
+
+          const targetMatch = await queryClient.fetchQuery(
+            getSourcifyMetadataQuery(
+              sourcifySources,
+              sourcifySource,
+              targetAddr,
+              provider._network.chainId,
+            ),
+          );
+
+          if (
+            targetMatch &&
+            targetMatch.metadata?.settings?.compilationTarget
+          ) {
+            const fileName = Object.keys(
+              targetMatch.metadata.settings.compilationTarget,
+            )[0];
+            const sourceName =
+              targetMatch.metadata.settings.compilationTarget[fileName];
+            contractName = sourceName;
+          }
+
+          if (
+            targetMatch &&
+            targetMatch.metadata.settings !== undefined &&
+            targetOffsets !== undefined &&
+            targetCode !== undefined &&
+            // TODO: SourcifyV2 only
+            (targetMatch.metadata as any).output.contracts !== undefined
+          ) {
+            // TODO: metadata only (as before)
+            const fileName = Object.keys(
+              targetMatch.metadata.settings.compilationTarget,
+            )[0];
+            const sourceName =
+              targetMatch.metadata.settings.compilationTarget[fileName];
+            // TODO: This is not part of the metadata object! SourcifyV2 only.
+            const sourceMap = (targetMatch.metadata as any).output.contracts[
+              fileName
+            ][sourceName].evm.deployedBytecode.sourceMap;
+            const soliditySources = Object.values(
+              (targetMatch.metadata as any).output.sources,
+            ).map((source: any) => source.id);
+            const instructionIndexMap = bytecodeToInstructionIndex(targetCode);
+
+            const lastUniqueIndex = findLastUniqueLocation(
+              targetOffsets,
+              toBeArray(
+                targetCode.startsWith("0x") ? targetCode : "0x" + targetCode,
+              ),
+            );
+            for (let i = lastUniqueIndex; i >= 0; i--) {
+              const instructionNumber = instructionIndexMap[targetOffsets[i]];
+              const sourceRange = getSourceRange(sourceMap, instructionNumber);
+              if (sourceRange === null) {
+                continue;
+              }
+              const { byteOffset, length, sourceIndex } = sourceRange;
+              if (soliditySources.includes(sourceIndex)) {
+                targetStart = byteOffset;
+                targetEnd = byteOffset + length;
+                targetSource = Object.keys(
+                  (targetMatch.metadata as any).output.sources,
+                ).find(
+                  (key) =>
+                    (targetMatch.metadata as any).output.sources[key].id ===
+                    sourceIndex,
+                );
+                break;
+              }
+            }
+          }
+          return {
+            targetStart,
+            targetEnd,
+            targetSource,
+            contractName,
+            address: targetAddr,
+          };
+        }),
+      );
+      setRevertLocations(newRevertLocations);
+    })();
+  }, [txHash, revertChain.length]);
+
+  return (
+    revertLocations &&
+    revertLocations.some((location) => location.targetStart !== undefined) &&
+    revertLocations.map(
+      (
+        { targetStart, targetEnd, targetSource, contractName, address },
+        index,
+      ) => (
+        <div className="flex" key={index}>
+          <LinkToSourceRegion
+            targetAddr={address}
+            targetStart={targetStart}
+            targetEnd={targetEnd}
+            targetSource={targetSource}
+          >
+            {contractName ? (
+              <div
+                className={`flex space-x-1 ${targetStart !== undefined && targetEnd !== undefined ? "text-green-600 hover:text-green-800" : "text-verified-contract hover:text-verified-contract-hover"}`}
+              >
+                <SourcifyLogo />
+                <span>{contractName}</span>
+              </div>
+            ) : (
+              address
+            )}
+          </LinkToSourceRegion>
+          {index < revertLocations.length - 1 ? <>/</> : null}
+        </div>
+      ),
+    )
+  );
+};
+
+export default RevertTrace;

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -155,10 +155,24 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
     })();
   }, [txHash, revertChain.length]);
 
-  return revertLocations !== null ? (
-    revertLocations.length > 0 ? (
-      // revertLocations.some((location) => location.targetStart !== undefined) ?
-      revertLocations.map(
+  let revertLocationsFinal:
+    | {
+        address: string;
+        targetStart?: number;
+        targetEnd?: number;
+        targetSource?: string;
+        contractName?: string;
+      }[]
+    | null =
+    revertLocations !== null &&
+    revertLocations.length === 0 &&
+    revertChain.length > 0
+      ? revertChain.map((traceGroup) => ({ address: traceGroup.to }))
+      : revertLocations;
+
+  return traceRes && revertLocationsFinal !== null ? (
+    revertLocationsFinal.length > 0 ? (
+      revertLocationsFinal.map(
         (
           { targetStart, targetEnd, targetSource, contractName, address },
           index,
@@ -181,7 +195,7 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
                 address
               )}
             </LinkToSourceRegion>
-            {index < revertLocations.length - 1 ? <>/</> : null}
+            {index < revertLocationsFinal.length - 1 ? <>/</> : null}
           </div>
         ),
       )

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -136,7 +136,8 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
                   targetMatch.stdJsonOutput.sources,
                 ).find(
                   (key) =>
-                    targetMatch.stdJsonOutput.sources[key].id === sourceIndex,
+                    targetMatch.stdJsonOutput?.sources?.[key]?.id ===
+                    sourceIndex,
                 );
                 if (
                   targetSource !== undefined &&

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -155,36 +155,41 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
     })();
   }, [txHash, revertChain.length]);
 
-  return (
-    revertLocations &&
-    revertLocations.some((location) => location.targetStart !== undefined) &&
-    revertLocations.map(
-      (
-        { targetStart, targetEnd, targetSource, contractName, address },
-        index,
-      ) => (
-        <div className="flex" key={index}>
-          <LinkToSourceRegion
-            targetAddr={address}
-            targetStart={targetStart}
-            targetEnd={targetEnd}
-            targetSource={targetSource}
-          >
-            {contractName ? (
-              <div
-                className={`flex space-x-1 ${targetStart !== undefined && targetEnd !== undefined ? "text-green-600 hover:text-green-800" : "text-verified-contract hover:text-verified-contract-hover"}`}
-              >
-                <SourcifyLogo />
-                <span>{contractName}</span>
-              </div>
-            ) : (
-              address
-            )}
-          </LinkToSourceRegion>
-          {index < revertLocations.length - 1 ? <>/</> : null}
-        </div>
-      ),
+  return revertLocations !== null ? (
+    revertLocations.length > 0 ? (
+      // revertLocations.some((location) => location.targetStart !== undefined) ?
+      revertLocations.map(
+        (
+          { targetStart, targetEnd, targetSource, contractName, address },
+          index,
+        ) => (
+          <div className="flex" key={index}>
+            <LinkToSourceRegion
+              targetAddr={address}
+              targetStart={targetStart}
+              targetEnd={targetEnd}
+              targetSource={targetSource}
+            >
+              {contractName ? (
+                <div
+                  className={`flex space-x-1 ${targetStart !== undefined && targetEnd !== undefined ? "text-green-600 hover:text-green-800" : "text-verified-contract hover:text-verified-contract-hover"}`}
+                >
+                  <SourcifyLogo />
+                  <span>{contractName}</span>
+                </div>
+              ) : (
+                address
+              )}
+            </LinkToSourceRegion>
+            {index < revertLocations.length - 1 ? <>/</> : null}
+          </div>
+        ),
+      )
+    ) : (
+      <p>No revert locations found.</p>
     )
+  ) : (
+    <p>Loading...</p>
   );
 };
 

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -114,6 +114,7 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
             const soliditySources = Object.values(
               targetMatch.stdJsonOutput.sources,
             ).map((source: any) => source.id);
+
             const instructionIndexMap = bytecodeToInstructionIndex(targetCode);
 
             const lastUniqueIndex = findLastUniqueLocation(

--- a/src/execution/transaction/trace/RevertTrace.tsx
+++ b/src/execution/transaction/trace/RevertTrace.tsx
@@ -163,7 +163,7 @@ const RevertTrace: React.FC<RevertTraceProps> = ({ txHash }) => {
       );
       setRevertLocations(newRevertLocations);
     })();
-  }, [txHash, revertChain.length]);
+  }, [txHash, revertChain.length, sourcifySource]);
 
   let revertLocationsFinal: RevertLocation[] | null =
     revertLocations !== null &&

--- a/src/execution/transaction/trace/RevertTraceToggle.tsx
+++ b/src/execution/transaction/trace/RevertTraceToggle.tsx
@@ -18,7 +18,7 @@ const RevertTraceToggle: React.FC<RevertTraceToggleProps> = ({ txData }) => {
   return visible ? (
     <div className="flex">
       <div className="rounded-lg bg-red-50 p-2">
-        Revert trace:
+        <div className="mb-1">Revert trace:</div>
         <RevertTrace txHash={txData.transactionHash} />
       </div>
     </div>

--- a/src/execution/transaction/trace/RevertTraceToggle.tsx
+++ b/src/execution/transaction/trace/RevertTraceToggle.tsx
@@ -1,0 +1,36 @@
+import { useContext, useState } from "react";
+import { TransactionData } from "../../../types";
+import { RuntimeContext } from "../../../useRuntime";
+import RevertTrace from "./RevertTrace";
+
+interface RevertTraceToggleProps {
+  txData: TransactionData;
+}
+
+const RevertTraceToggle: React.FC<RevertTraceToggleProps> = ({ txData }) => {
+  const [visible, setVisible] = useState(false);
+  const { config } = useContext(RuntimeContext);
+
+  if (config?.revertTraces?.enabled === false) {
+    return null;
+  }
+
+  return visible ? (
+    <div className="flex">
+      <div className="rounded-lg bg-red-50 p-2">
+        Revert trace:
+        <RevertTrace txHash={txData.transactionHash} />
+      </div>
+    </div>
+  ) : (
+    <button
+      className="rounded border bg-skin-button-fill px-2 py-1 text-xs text-skin-button hover:bg-skin-button-hover-fill focus:outline-none w-fit"
+      type="submit"
+      onClick={() => setVisible(true)}
+    >
+      Show Revert Trace
+    </button>
+  );
+};
+
+export default RevertTraceToggle;

--- a/src/execution/transaction/trace/traceInterpreter.test.ts
+++ b/src/execution/transaction/trace/traceInterpreter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect } from "@jest/globals";
+import {
+  commonDeduplicatedBlocks,
+  findLastUniqueLocation,
+  findTraceExitLocations,
+} from "./traceInterpreter";
+
+const endsInRevertVmTrace = {
+  code: "0x6080",
+  ops: [
+    {
+      cost: 3,
+      ex: {
+        mem: null,
+        push: ["100", "128"],
+        store: null,
+        used: 146086,
+      },
+      pc: 7685,
+      sub: null,
+      op: "SWAP1",
+      idx: "101-162",
+    },
+    {
+      cost: 0,
+      ex: {
+        mem: null,
+        push: [],
+        store: null,
+        used: 146086,
+      },
+      pc: 7686,
+      sub: null,
+      op: "REVERT",
+      idx: "101-163",
+    },
+  ],
+};
+
+describe("trace interpreter", () => {
+  test("ends in revert", () => {
+    const exitLocations = findTraceExitLocations(endsInRevertVmTrace);
+    expect(exitLocations.endsInRevert).toEqual(true);
+  });
+});
+
+describe("findLastUniqueLocation", () => {
+  it("returns -1 for empty offsets array", () => {
+    const code = new Uint8Array([]);
+    const offsets: number[] = [];
+    expect(findLastUniqueLocation(offsets, code)).toBe(-1);
+  });
+
+  it("returns last offset index when no common block is found", () => {
+    const code = new Uint8Array([0x01, 0x02, 0x03]);
+    const pc = [1, 2];
+    expect(findLastUniqueLocation(pc, code)).toBe(1);
+  });
+
+  it("skips common deduplicated block at the end", () => {
+    const code = new Uint8Array([
+      // "Unique" code
+      0x01,
+      0x02,
+      0x03,
+      ...commonDeduplicatedBlocks[0], // Revert block
+    ]);
+    const pc = [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11];
+    expect(findLastUniqueLocation(pc, code)).toBe(2);
+  });
+
+  it("correctly handles common revert block", () => {
+    const code = new Uint8Array([
+      // Revert block
+      ...commonDeduplicatedBlocks[0],
+      // Offset: 9, 10, 11
+      0x01,
+      0x02,
+      0x03,
+      // Another revert block
+      ...commonDeduplicatedBlocks[0],
+    ]);
+    const pc = [10, 11, 12, 13, 15, 16, 17, 18, 19, 20];
+    expect(findLastUniqueLocation(pc, code)).toBe(1);
+  });
+});

--- a/src/execution/transaction/trace/traceInterpreter.ts
+++ b/src/execution/transaction/trace/traceInterpreter.ts
@@ -186,3 +186,18 @@ export function findLastUniqueLocation(
 
   return lastOffsetIndex;
 }
+
+/**
+ * Calculates the line number for a given character offset within a string.
+ *
+ * @param text - The input string.
+ * @param offset - The character offset (0-indexed).
+ * @returns The line number (1-indexed) where the offset is located. Returns
+ * null if the offset is out of range.
+ */
+export function getLineNumber(text: string, offset: number): number | null {
+  if (offset < 0 || offset > text.length) {
+    return null;
+  }
+  return text.substring(0, offset).split("\n").length;
+}

--- a/src/execution/transaction/trace/traceInterpreter.ts
+++ b/src/execution/transaction/trace/traceInterpreter.ts
@@ -1,0 +1,188 @@
+import { type TraceGroup } from "../../../useErigonHooks";
+
+export interface VM {
+  ops: Array<{ pc: number; sub?: VM | null; op: string }>;
+  code: string;
+}
+
+export type VmStepGroup = {
+  code: string;
+  endsInRevert: boolean;
+  pc: number[];
+  children: VmStepGroup[] | null;
+};
+
+export type TraceGroupWithSteps = TraceGroup & {
+  code: string;
+  endsInRevert: boolean;
+  pc: number[];
+  children: TraceGroupWithSteps[] | null;
+};
+
+// TODO: Also handle out-of-gas situations by checking gas left
+export function findTraceExitLocations(vm: VM): VmStepGroup {
+  let pc: number[] = [];
+  let children: VmStepGroup[] = [];
+  let endsInRevert: boolean = false;
+
+  if (vm.ops.length > 0) {
+    // Create the top-level object
+    pc = vm.ops.map((op) => op.pc);
+
+    // Iterate over ops and handle any "sub" recursively
+    for (const item of vm.ops) {
+      if ("sub" in item && item.sub) {
+        children.push(findTraceExitLocations(item.sub));
+      }
+    }
+
+    if (vm.ops[vm.ops.length - 1].op === "REVERT") {
+      endsInRevert = true;
+    }
+  }
+
+  return {
+    pc,
+    children: children.length > 0 ? children : null,
+    code: vm.code,
+    endsInRevert,
+  };
+}
+
+/**
+ * Finds the chain of last-child TraceGroupWithSteps which end in a revert.
+ *
+ * @param stepGroups - Array of TraceGroupWithSteps, or null
+ * @returns - Chain (flat array) of TraceGroupWithSteps that end in a reverted call
+ */
+export function findRevertChain(
+  stepGroups: TraceGroupWithSteps[] | null,
+): TraceGroupWithSteps[] {
+  let chain: TraceGroupWithSteps[] = [];
+  let node: TraceGroupWithSteps[] | null = stepGroups;
+  while (node !== null && node.length > 0) {
+    if (node[node.length - 1].endsInRevert) {
+      chain.push(node[node.length - 1]);
+      node = node[node.length - 1].children;
+    } else {
+      node = null;
+    }
+  }
+  return chain;
+}
+
+export function addPcList(
+  trace: TraceGroup,
+  vmexit: VmStepGroup,
+): TraceGroupWithSteps {
+  const mergedChildren =
+    trace.children && vmexit.children
+      ? mergeEntries(trace.children as TraceGroup[], vmexit.children)
+      : null;
+
+  return {
+    ...trace,
+    pc: vmexit.pc || undefined,
+    code: vmexit.code,
+    children: mergedChildren,
+    endsInRevert: vmexit.endsInRevert,
+  };
+}
+
+const callTraceTypes = [
+  "CALL",
+  "STATICCALL",
+  "DELEGATECALL",
+  "CREATE",
+  "CREATE2",
+];
+
+export function mergeEntries(
+  traces: TraceGroup[],
+  vms: VmStepGroup[],
+): TraceGroupWithSteps[] | null {
+  traces = traces.filter((trace) => callTraceTypes.includes(trace.type));
+  if (traces.length === 0 || traces.length !== vms.length) {
+    return null;
+  }
+
+  return traces.map((trace, index) => addPcList(trace, vms[index]));
+}
+
+/**
+ * EVM bytecode blocks which are commonly deduplicated by the Solidity compiler's optimizer.
+ */
+export const commonDeduplicatedBlocks: number[][] = [
+  [
+    // JUMPDEST
+    0x5b,
+    // PUSH 40
+    0x60, 0x40,
+    // MLOAD
+    0x51,
+    // DUP1
+    0x80,
+    // SWAP2
+    0x91,
+    // SUB
+    0x03,
+    // SWAP1
+    0x90,
+    // REVERT
+    0xfd,
+  ],
+];
+
+/**
+ * Finds the first unique location from the end of the offsets list after
+ * skipping a common deduplicated block should one exist.
+ * Currently, this function assumes the entire block must be executed if its
+ * last instruction is executed (no jumps).
+ *
+ * @param pc - A list of program counter byte offsets passed during transaction
+ * execution
+ * @param code - The EVM contract (runtime) bytecode as a Uint8Array
+ * @param startIndex - The index in the pc array to start at
+ * @returns The index of the last PC location in the offsets list that is not
+ * part of a commonly deduplicated block
+ */
+export function findLastUniqueLocation(
+  pc: number[],
+  code: Uint8Array,
+  startIndex?: number,
+): number {
+  const startIndexNum = startIndex ?? pc.length - 1;
+  if (pc.length == 0 || startIndexNum < 0 || startIndexNum > pc.length) {
+    return -1;
+  }
+
+  let lastOffsetIndex = startIndexNum;
+  let lastOffset = pc[lastOffsetIndex];
+
+  // Compare each block to see if a block matches the end of code[:offset]
+  for (const block of commonDeduplicatedBlocks) {
+    const blockLength = block.length;
+    if (
+      lastOffset >= blockLength &&
+      code
+        .slice(lastOffset - blockLength + 1, lastOffset + 1)
+        .every((value, index) => value === block[index])
+    ) {
+      // Block matches. Skip it and find the new last unique location
+      // Note: the following line makes the assumption that the last opcode has
+      // an instruction length of 1
+      const blockStart = lastOffset - blockLength + 1;
+      const blockEnd = blockStart + blockLength;
+      while (
+        lastOffsetIndex >= 0 &&
+        pc[lastOffsetIndex] >= blockStart &&
+        pc[lastOffsetIndex] < blockEnd
+      ) {
+        lastOffsetIndex--;
+      }
+      lastOffset = pc[lastOffsetIndex];
+    }
+  }
+
+  return lastOffsetIndex;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,7 @@
   --color-verified-contract: #2b50aa;
   --color-verified-contract-hover: #26007b;
   --color-source-line-numbers: #738a9486;
+  --color-source-line-highlight: #99ff00;
 
   --font-sans: Roboto;
   --font-title: Space Grotesk;

--- a/src/sourcify/sourceMapping.test.ts
+++ b/src/sourcify/sourceMapping.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect } from "@jest/globals";
+import { bytecodeToInstructionIndex, getSourceRange } from "./sourceMapping";
+
+function equalSourceMappings(sm1: string, sm2: string): void {
+  const instrCount = sm1.split(";").length;
+  for (let i = 0; i < instrCount; i++) {
+    const inst1 = getSourceRange(sm1, i);
+    const inst2 = getSourceRange(sm2, i);
+    expect(inst1).toEqual(inst2);
+  }
+}
+
+describe("source mapping parsing", () => {
+  test("equivalent source maps", () => {
+    const sm1 = "1:2:1;1:9:1;2:1:2;2:1:2;2:1:2";
+    const sm2 = "1:2:1;:9;2:1:2;;";
+    equalSourceMappings(sm1, sm2);
+  });
+});
+
+describe("bytecode to instruction index mapping", () => {
+  test("simple mapping", () => {
+    const bytecode =
+      "6080604052348015600e575f5ffd5b50600880601a5f395ff3fe60806040525f5ffd";
+    const expectedInstructionMap = [
+      0, 0, 1, 1, 2, 3, 4, 5, 6, 6, 7, 8, 9, 10, 11, 12, 13, 13, 14, 15, 15, 16,
+      17, 18, 19, 20, 21, 21, 22, 22, 23, 24, 25, 26,
+    ];
+    expect(bytecodeToInstructionIndex(bytecode)).toEqual(
+      expectedInstructionMap,
+    );
+  });
+});

--- a/src/sourcify/sourceMapping.ts
+++ b/src/sourcify/sourceMapping.ts
@@ -1,0 +1,78 @@
+import { BytecodeIter } from "@shazow/whatsabi";
+
+export function getSourceRange(
+  sourceMapping: string,
+  instructionIndex: number,
+): { byteOffset: number; length: number; sourceIndex: number } | null {
+  const elements = sourceMapping.split(";");
+
+  if (instructionIndex >= elements.length) {
+    // Out of bounds for this contract
+    return null;
+  }
+
+  // Populate backward; empty fields and missing elements correspond to the peceding element
+  let targetMapping: (number | undefined)[] = [undefined, undefined, undefined];
+  for (let i = instructionIndex; i >= 0; i--) {
+    const instruction = elements[i];
+    if (instruction.length === 0) {
+      // Same as previous
+      continue;
+    }
+
+    // Find non-empty fields and add them
+    const items = instruction.split(":");
+    for (
+      let itemIndex = 0;
+      itemIndex < items.length && itemIndex < 3;
+      itemIndex++
+    ) {
+      if (
+        items[itemIndex].length > 0 &&
+        targetMapping[itemIndex] === undefined
+      ) {
+        targetMapping[itemIndex] = Number(items[itemIndex]);
+        if (targetMapping.every((x) => x !== undefined)) {
+          // All fields have been filled
+          return {
+            byteOffset: targetMapping[0],
+            length: targetMapping[1],
+            sourceIndex: targetMapping[2],
+          };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+export function bytecodeToInstructionIndex(bytecode: string): number[] {
+  const code = new BytecodeIter(bytecode, { bufferSize: 5 });
+  const codeSize = Math.floor(bytecode.length / 2);
+  const arr: number[] = new Array(codeSize).fill(0);
+
+  let lastPos = 0;
+
+  while (true) {
+    code.next();
+    const pos = code.pos();
+    const step = code.step();
+
+    // Fill the location of the previous instruction
+    for (let i = lastPos; i < pos; i++) {
+      arr[i] = step - 1;
+    }
+
+    lastPos = pos;
+    if (!code.hasMore()) {
+      code.next();
+      for (let i = lastPos; i < codeSize; i++) {
+        arr[i] = code.step();
+      }
+      break;
+    }
+  }
+
+  return arr;
+}

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -329,15 +329,11 @@ export const getSourcifyMetadataQuery = (
     sourcifySourceName,
   ],
   queryFn: () => {
-    if (sourcifySourceName === null) {
-      throw new Error("Sourcify source name is null");
-    }
-    return fetchSourcifyMetadata(
-      sourcifySources,
+    const { name, sourcifySource } = resolveSourcifySource(
       sourcifySourceName,
-      address,
-      chainId,
+      sourcifySources,
     );
+    return fetchSourcifyMetadata(sourcifySources, name, address, chainId);
   },
   staleTime: Infinity,
   gcTime: 10 * 60 * 1000,

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -181,6 +181,16 @@ export type OtterscanConfig = {
   };
 
   /**
+   * Revert traces: runs trace_* calls to reveal exact revert locations in
+   * verified sources. Requires the source mapping to be available in the
+   * Sourcify source's outputs.)
+   */
+  revertTraces?: {
+    // The feature is hidden if this is set to false.
+    enabled?: boolean;
+  };
+
+  /**
    * Optional custom price oracle information for estimating the current price
    * of the native token and all other tokens.
    */

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect } from "@jest/globals";
+import { hexToArray } from "./utils";
+
+describe("hexToArray tests", () => {
+  test("empty string", () => {
+    expect(hexToArray("")).toEqual(new Uint8Array([]));
+  });
+
+  test("single byte (no 0x prefix)", () => {
+    expect(hexToArray("FF")).toEqual(new Uint8Array([255]));
+  });
+
+  test("single byte (with 0x prefix)", () => {
+    expect(hexToArray("0xFF")).toEqual(new Uint8Array([255]));
+  });
+
+  test("odd-length hex string", () => {
+    expect(hexToArray("F")).toEqual(new Uint8Array([15]));
+  });
+
+  test("multiple bytes", () => {
+    expect(hexToArray("FFEEDDCC")).toEqual(
+      new Uint8Array([255, 238, 221, 204]),
+    );
+  });
+
+  test("mixed case", () => {
+    expect(hexToArray("0xfFEeDdcc")).toEqual(
+      new Uint8Array([255, 238, 221, 204]),
+    );
+  });
+});

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -93,3 +93,30 @@ export function commify(value: string | number | bigint): string {
 
   return negative + formatted.join(",") + suffix;
 }
+
+/**
+ * Converts a hex string to an array.
+ *
+ * @remarks
+ *
+ * Same as ethers' `toBeArray` except much more efficient for long strings
+ * (such as contract code) because we don't try converting the entire string
+ * to a BigInt.
+ *
+ * @param hexString - Hex string to be converted
+ * @returns Converted Uint8Array
+ */
+export function hexToArray(hexString: string): Uint8Array {
+  let hex = hexString;
+  if (hex.length % 2 === 1) {
+    hex = "0" + hex;
+  }
+
+  const result = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < result.length; i++) {
+    const offset = i * 2;
+    result[i] = parseInt(hex.substring(offset, offset + 2), 16);
+  }
+
+  return result;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -108,6 +108,10 @@ export function commify(value: string | number | bigint): string {
  */
 export function hexToArray(hexString: string): Uint8Array {
   let hex = hexString;
+  if (hex.startsWith("0x")) {
+    hex = hex.slice(2);
+  }
+
   if (hex.length % 2 === 1) {
     hex = "0" + hex;
   }


### PR DESCRIPTION
On the transaction page of any reverting transaction, a trace is done on the transaction to find the program counter offsets in the contract bytecode of each internal call. Otterscan then determines the "revert chain", maps bytecode to instructions for contracts with Sourcify source mappings, and using the source mappings provides links to the source code, highlighting the specific Solidity statements which caused the revert. Out-of-gas and runtime error (e.g., division by zero) locations are not currently supported since we currently check for a final REVERT opcode in the trace to signal an internal transaction failure. Implementation of #2554 would enable us to extend this to those other cases.

The revert locations are offered for all calls in the revert chain, since the outer transaction might not have an interesting revert reason, and the desired origin might be deeper in the call stack.

Todos:
- [x] Scroll to first highlighted statement automatically
- [x] Need suggestions for design of revert chain display
- [x] Requires SourcifyV2 support, which is not released yet
- [x] Add option in config

Closes #2500.
Closes #2499.
Closes #3185.