### PR TITLE
Handle transaction output decoder errors

### DIFF
--- a/src/execution/transaction/TraceInput.tsx
+++ b/src/execution/transaction/TraceInput.tsx
@@ -1,6 +1,6 @@
 import { faBomb } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { AbiCoder } from "ethers";
+import { AbiCoder, Result } from "ethers";
 import React, { useContext, useState } from "react";
 import ExpanderSwitch from "../../components/ExpanderSwitch";
 import FormattedBalance from "../../components/FormattedBalance";
@@ -152,10 +152,18 @@ const TraceInput: React.FC<TraceInputProps> = ({ t }) => {
             <OutputDecoder
               args={
                 txDesc
-                  ? AbiCoder.defaultAbiCoder().decode(
-                      txDesc.fragment.outputs,
-                      t.output,
-                    )
+                  ? (() => {
+                      let decoded: Result | null;
+                      try {
+                        decoded = AbiCoder.defaultAbiCoder().decode(
+                          txDesc.fragment.outputs,
+                          t.output,
+                        );
+                      } catch (e) {
+                        decoded = null;
+                      }
+                      return decoded;
+                    })()
                   : undefined
               }
               paramTypes={txDesc?.fragment?.outputs}

--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -7,7 +7,7 @@ import { DevMethod } from "../../../sourcify/useSourcify";
 import DecodedParamsTable from "./DecodedParamsTable";
 
 type OutputDecoderProps = {
-  args: Result | undefined;
+  args: Result | null | undefined;
   paramTypes: readonly ParamType[] | null | undefined;
   data: string;
   devMethod?: DevMethod;
@@ -30,7 +30,7 @@ const OutputDecoder: React.FC<OutputDecoderProps> = ({
           <>No data</>
         ) : paramTypes === undefined || args === undefined ? (
           <>Waiting for data...</>
-        ) : paramTypes === null ? (
+        ) : paramTypes === null || args === null ? (
           <>Can't decode data</>
         ) : (
           <div className="space-y-2">


### PR DESCRIPTION
Closes #2553. If the output can't be decoded, such as when a revert message is returned, "Can't decode data" is shown.