### PR TITLE
Change Erigon check to use latest header instead of block 1

### DIFF
--- a/src/useProvider.ts
+++ b/src/useProvider.ts
@@ -35,7 +35,7 @@ export const createAndProbeProvider = async (
 
   // Check if it is at least a regular ETH node
   const probeBlockNumber = provider.getBlockNumber();
-  const probeHeader1 = provider.send("erigon_getHeaderByNumber", [1]);
+  const probeHeader1 = provider.send("erigon_getHeaderByNumber", ["latest"]);
   const probeOtsAPI = provider.send("ots_getApiLevel", []).then((level) => {
     if (level < MIN_API_LEVEL) {
       throw new ProbeError(ConnectionStatus.NOT_OTTERSCAN_PATCHED, erigonURL);


### PR DESCRIPTION
This change fixes a user-reported error in which Otterscan incorrectly classifies a node as an Ethereum node but not an Erigon node when Block 1 hasn't been downloaded.

Block 0 is the first block. This change (from block 1 to "latest") would also handle pruned nodes if we support them in the future.

Note: The failing CI checks should pass after #2557 is merged.