### PR TITLE
Make aggregation bits grid columns responsive

### DIFF
--- a/src/components/ContentFrame.tsx
+++ b/src/components/ContentFrame.tsx
@@ -12,7 +12,7 @@ const ContentFrame: FC<PropsWithChildren<ContentFrameProps>> = ({
 }) => {
   return tabs ? (
     <div
-      className={`sm:divide-y rounded-b-lg border bg-white px-3 ${
+      className={`divide-y rounded-b-lg border bg-white px-3 ${
         isLoading && "opacity-50 transition-opacity"
       }`}
     >

--- a/src/components/ContentFrame.tsx
+++ b/src/components/ContentFrame.tsx
@@ -12,7 +12,7 @@ const ContentFrame: FC<PropsWithChildren<ContentFrameProps>> = ({
 }) => {
   return tabs ? (
     <div
-      className={`divide-y rounded-b-lg border bg-white px-3 ${
+      className={`sm:divide-y rounded-b-lg border bg-white px-3 ${
         isLoading && "opacity-50 transition-opacity"
       }`}
     >

--- a/src/components/InfoRow.tsx
+++ b/src/components/InfoRow.tsx
@@ -5,9 +5,9 @@ type InfoRowProps = React.PropsWithChildren<{
 }>;
 
 const InfoRow: React.FC<InfoRowProps> = ({ title, children }) => (
-  <div className="grid grid-cols-4 py-4 text-sm">
-    <div>{title}:</div>
-    <div className="col-span-3">{children}</div>
+  <div className="sm:grid sm:grid-cols-4 py-3 sm:py-4 text-sm">
+    <div className="mb-1 sm:mb-auto">{title}:</div>
+    <div className="sm:col-span-3">{children}</div>
   </div>
 );
 

--- a/src/components/InfoRow.tsx
+++ b/src/components/InfoRow.tsx
@@ -6,7 +6,7 @@ type InfoRowProps = React.PropsWithChildren<{
 
 const InfoRow: React.FC<InfoRowProps> = ({ title, children }) => (
   <div className="sm:grid sm:grid-cols-4 py-3 sm:py-4 text-sm">
-    <div className="mb-1 sm:mb-auto">{title}:</div>
+    <div className="mb-2 sm:mb-auto">{title}:</div>
     <div className="sm:col-span-3">{children}</div>
   </div>
 );

--- a/src/consensus/slot/AggregationBits.tsx
+++ b/src/consensus/slot/AggregationBits.tsx
@@ -8,10 +8,12 @@ type AggregationBitsProps = {
 const AggregationBits: FC<AggregationBitsProps> = ({ hex }) => {
   const bm = Array.from(getBytes(hex));
   return (
-    <div className="grid w-fit grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-2 font-hash">
-      {bm.map((b, i) => (
-        <Bitmap key={i} b={b} />
-      ))}
+    <div className="overflow-x-auto md:overflow-visible">
+      <div className="grid w-max md:w-fit grid-cols-6 md:grid-cols-8 gap-2 font-hash">
+        {bm.map((b, i) => (
+          <Bitmap key={i} b={b} />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/consensus/slot/AggregationBits.tsx
+++ b/src/consensus/slot/AggregationBits.tsx
@@ -8,7 +8,7 @@ type AggregationBitsProps = {
 const AggregationBits: FC<AggregationBitsProps> = ({ hex }) => {
   const bm = Array.from(getBytes(hex));
   return (
-    <div className="grid w-fit grid-cols-8 gap-2 font-hash">
+    <div className="grid w-fit grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-2 font-hash">
       {bm.map((b, i) => (
         <Bitmap key={i} b={b} />
       ))}

--- a/src/consensus/slot/AggregationBits.tsx
+++ b/src/consensus/slot/AggregationBits.tsx
@@ -9,7 +9,7 @@ const AggregationBits: FC<AggregationBitsProps> = ({ hex }) => {
   const bm = Array.from(getBytes(hex));
   return (
     <div className="overflow-x-auto md:overflow-visible">
-      <div className="grid w-max md:w-fit grid-cols-6 md:grid-cols-8 gap-2 font-hash">
+      <div className="grid w-max md:w-fit grid-cols-4 sm:grid-cols-6 md:grid-cols-8 gap-2 font-hash">
         {bm.map((b, i) => (
           <Bitmap key={i} b={b} />
         ))}

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -124,7 +124,7 @@ const Details: FC<DetailsProps> = ({ txData }) => {
   return (
     <ContentFrame tabs>
       <InfoRow title="Transaction Hash">
-        <div className="flex items-baseline space-x-2">
+        <div className="flex items-baseline space-x-2 break-all">
           <span className="font-hash" data-test="tx-hash">
             {txData.transactionHash}
           </span>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -128,7 +128,9 @@ const Details: FC<DetailsProps> = ({ txData }) => {
           <span className="font-hash" data-test="tx-hash">
             {txData.transactionHash}
           </span>
-          <Copy value={txData.transactionHash} />
+          <div>
+            <Copy value={txData.transactionHash} />
+          </div>
         </div>
       </InfoRow>
       <InfoRow title="Status">


### PR DESCRIPTION
Scales the aggregation bits on slot pages so they look better on small-width viewports:

![image](https://github.com/user-attachments/assets/403c30fe-c81e-4933-8f5b-63679beb3e58)
