### PR TITLE
Restructure Sourcify source configuration

### DIFF
--- a/cypress/support/devnet-config.json
+++ b/cypress/support/devnet-config.json
@@ -4,8 +4,10 @@
   "assetsURLPrefix": "http://localhost:5175",
   "sourcify": {
     "sources": {
-      "central_server": "http://localhost:7077",
-      "ipfs": "http://localhost:7077"
+      "Local Testing Sourcify Server": {
+        "url": "http://localhost:7077",
+        "backendFormat": "RepositoryV1"
+      }
     }
   }
 }

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,13 +3,12 @@ import { ErrorBoundary } from "react-error-boundary";
 import { Outlet } from "react-router";
 import Header from "./Header";
 import ErrorFallback from "./components/ErrorFallback";
-import { SourcifySource } from "./sourcify/useSourcify";
+import { SourcifySourceName } from "./sourcify/useSourcify";
 import { AppConfig, AppConfigContext } from "./useAppConfig";
 
 const Main: React.FC = () => {
-  const [sourcifySource, setSourcifySource] = useState<SourcifySource>(
-    SourcifySource.CENTRAL_SERVER,
-  );
+  const [sourcifySource, setSourcifySource] =
+    useState<SourcifySourceName | null>(null);
   const appConfig = useMemo((): AppConfig => {
     return {
       sourcifySource,

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -83,18 +83,16 @@ export type Metadata = {
   };
 };
 
-export enum SourcifySource {
-  // Resolve trusted IPNS for root IPFS
-  IPFS_IPNS = "ipfs",
-
-  // Centralized Sourcify servers
-  CENTRAL_SERVER = "central_server",
-}
-
-export type SourcifySourceMap = { [key: string]: string };
-
 const SourcifyBackendFormats = ["RepositoryV1", "RepositoryV2"] as const;
 type SourcifyBackendFormat = (typeof SourcifyBackendFormats)[number];
+
+export type SourcifySourceName = string;
+export type SourcifySource = {
+  url: string;
+  backendFormat: SourcifyBackendFormat;
+};
+export const defaultSourcifySourceName: SourcifySourceName = "Sourcify Servers";
+export type SourcifySourceMap = { [key: SourcifySourceName]: SourcifySource };
 
 function isSourcifyBackendFormat(
   format: string | undefined,
@@ -105,64 +103,92 @@ function isSourcifyBackendFormat(
   return SourcifyBackendFormats.includes(format as SourcifyBackendFormat);
 }
 
-const sourcifyIPNS = "repo.sourcify.dev";
-const defaultIpfsGatewayPrefix = `https://ipfs.io/ipns/${sourcifyIPNS}`;
 const sourcifyHttpRepoPrefix = `https://repo.sourcify.dev`;
 
 const defaultSourcifySources = {
-  [SourcifySource.IPFS_IPNS]: defaultIpfsGatewayPrefix,
-  [SourcifySource.CENTRAL_SERVER]: sourcifyHttpRepoPrefix,
+  [defaultSourcifySourceName]: {
+    url: sourcifyHttpRepoPrefix,
+    backendFormat: "RepositoryV2",
+  },
 };
 
-function resolveSourcifySource(
-  source: SourcifySource,
+// TODO: Remove this flag after the migration period has ended.
+let sourceDeprecationWarningLogged = false;
+export function resolveSourcifySource(
+  sourceName: SourcifySourceName | null,
   sourcifySources: SourcifySourceMap,
-): string {
-  if (source in sourcifySources) {
-    return sourcifySources[source];
+): { name: SourcifySourceName; sourcifySource: SourcifySource } {
+  let evaluatedSourceName: SourcifySourceName;
+  if (sourceName === null) {
+    if (Object.keys(sourcifySources).length === 0) {
+      throw new Error("No Sourcify sources found.");
+    }
+    // Use default
+    evaluatedSourceName = Object.keys(sourcifySources)[0];
   } else {
-    throw new Error(`Unknown Sourcify integration source code: ${source}`);
+    evaluatedSourceName = sourceName;
+  }
+
+  if (evaluatedSourceName in sourcifySources) {
+    const sourcifySource = sourcifySources[evaluatedSourceName];
+
+    // Handle legacy "name": "url" format for a smooth transition from previous config version
+    // TODO: Deprecate and later remove this check
+    if (typeof sourcifySource === "string") {
+      // TODO: Add link to documentation here.
+      if (!sourceDeprecationWarningLogged) {
+        console.warn(
+          `Sourcify source "${evaluatedSourceName}" is configured using an old format. Please update your Otterscan config. See https://docs.otterscan.io/config/options/sourcify for instructions to migrate.`,
+        );
+        sourceDeprecationWarningLogged = true;
+      }
+      return {
+        name: evaluatedSourceName,
+        sourcifySource: {
+          url: sourcifySource as string,
+          backendFormat: "RepositoryV1",
+        },
+      };
+    }
+    return { name: evaluatedSourceName, sourcifySource: sourcifySource };
+  } else {
+    throw new Error(`Unknown Sourcify source: ${evaluatedSourceName}`);
   }
 }
 
-function useSourcifySources(): {
-  sources: SourcifySourceMap;
-  backendFormat: SourcifyBackendFormat;
-} {
+export function useSourcifySources(): SourcifySourceMap {
   const { config } = useContext(RuntimeContext);
-  const sources = config.sourcify?.sources ?? defaultSourcifySources;
-  let backendFormat: SourcifyBackendFormat = "RepositoryV1";
-  const configFormat = config.sourcify?.backendFormat;
-  if (isSourcifyBackendFormat(configFormat)) {
-    backendFormat = configFormat;
-  }
-  return { sources, backendFormat };
+  const sources =
+    (config.sourcify?.sources as SourcifySourceMap) ?? defaultSourcifySources;
+  return sources;
 }
 
 /**
  * Builds a complete Sourcify metadata.json URL given the contract address
  * and chain.
  */
-export const sourcifyMetadata = (
+export function sourcifyMetadata(
   address: ChecksummedAddress,
   chainId: bigint,
-  source: SourcifySource,
+  source: SourcifySourceName,
   type: MatchType,
   sourcifySources: SourcifySourceMap,
-) =>
-  `${resolveSourcifySource(source, sourcifySources)}/contracts/${
+): string {
+  const { sourcifySource } = resolveSourcifySource(source, sourcifySources);
+  return `${sourcifySource.url}/contracts/${
     type === MatchType.FULL_MATCH ? "full_match" : "partial_match"
   }/${chainId}/${address}/metadata.json`;
+}
 
 export const sourcifySourceFile = (
   address: ChecksummedAddress,
   chainId: bigint,
   filepath: string,
-  source: SourcifySource,
+  source: SourcifySourceName,
   type: MatchType,
   sourcifySources: SourcifySourceMap,
 ) =>
-  `${resolveSourcifySource(source, sourcifySources)}/contracts/${
+  `${resolveSourcifySource(source, sourcifySources).sourcifySource.url}/contracts/${
     type === MatchType.FULL_MATCH ? "full_match" : "partial_match"
   }/${chainId}/${address}/sources/${filepath}`;
 
@@ -182,15 +208,15 @@ function sourcifyFetcher(
   sourcifySources: SourcifySourceMap,
 ): Fetcher<
   Match | null | undefined,
-  ["sourcify", ChecksummedAddress, bigint, SourcifySource]
+  ["sourcify", ChecksummedAddress, bigint, SourcifySourceName]
 > {
-  return async ([_, address, chainId, sourcifySource]) => {
+  return async ([_, address, chainId, sourcifySourceName]) => {
     // Try full match
     try {
       const url = sourcifyMetadata(
         address,
         chainId,
-        sourcifySource,
+        sourcifySourceName,
         MatchType.FULL_MATCH,
         sourcifySources,
       );
@@ -212,7 +238,7 @@ function sourcifyFetcher(
       const url = sourcifyMetadata(
         address,
         chainId,
-        sourcifySource,
+        sourcifySourceName,
         MatchType.PARTIAL_MATCH,
         sourcifySources,
       );
@@ -237,7 +263,7 @@ export const useSourcifyMetadata = (
   chainId: bigint | undefined,
 ): Match | null | undefined => {
   const { sourcifySource } = useAppConfigContext();
-  const { sources: sourcifySources } = useSourcifySources();
+  const sourcifySources = useSourcifySources();
   const metadataURL = () =>
     address === undefined || chainId === undefined
       ? null
@@ -266,12 +292,16 @@ export const useContract = (
   networkId: bigint,
   filename: string,
   fileHash: string,
-  sourcifySource: SourcifySource,
+  sourcifySourceName: SourcifySourceName | null,
   type: MatchType,
 ) => {
-  const { sources, backendFormat } = useSourcifySources();
+  const sources = useSourcifySources();
+  const { name, sourcifySource } = resolveSourcifySource(
+    sourcifySourceName,
+    sources,
+  );
   let fetchFilename: string;
-  switch (backendFormat) {
+  switch (sourcifySource.backendFormat) {
     case "RepositoryV1": {
       fetchFilename = filename.replaceAll(/[:]/g, "_");
       break;
@@ -280,12 +310,18 @@ export const useContract = (
       fetchFilename = fileHash;
       break;
     }
+    default: {
+      console.warn(
+        `Unknown or unspecified Sourcify backend format (${sourcifySource.backendFormat}) for Sourcify source "${name}". Falling back to RepositoryV1.`,
+      );
+      fetchFilename = filename.replaceAll(/[:]/g, "_");
+    }
   }
   const url = sourcifySourceFile(
     checksummedAddress,
     networkId,
     fetchFilename,
-    sourcifySource,
+    name,
     type,
     sources,
   );

--- a/src/storybook/util.tsx
+++ b/src/storybook/util.tsx
@@ -1,7 +1,7 @@
 import { Decorator } from "@storybook/react/*";
 import { JsonRpcProvider } from "ethers";
 import StandardSelectionBoundary from "../selection/StandardSelectionBoundary";
-import { SourcifySource } from "../sourcify/useSourcify";
+import { defaultSourcifySourceName } from "../sourcify/useSourcify";
 import { AppConfigContext } from "../useAppConfig";
 import { OtterscanConfig } from "../useConfig";
 import { RuntimeContext } from "../useRuntime";
@@ -23,7 +23,7 @@ export const runtimeDecorator: Decorator<unknown> = (Story) => (
   >
     <AppConfigContext.Provider
       value={{
-        sourcifySource: SourcifySource.CENTRAL_SERVER,
+        sourcifySource: defaultSourcifySourceName,
         setSourcifySource: () => {},
       }}
     >

--- a/src/useAppConfig.ts
+++ b/src/useAppConfig.ts
@@ -1,9 +1,9 @@
 import React, { useContext } from "react";
-import { SourcifySource } from "./sourcify/useSourcify";
+import { SourcifySourceName } from "./sourcify/useSourcify";
 
 export type AppConfig = {
-  sourcifySource: SourcifySource;
-  setSourcifySource: (newSourcifySource: SourcifySource) => void;
+  sourcifySource: SourcifySourceName | null;
+  setSourcifySource: (newSourcifySource: SourcifySourceName) => void;
 };
 
 export const AppConfigContext = React.createContext<AppConfig>(undefined!);

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -161,21 +161,23 @@ export type OtterscanConfig = {
 
   sourcify?: {
     /**
-     * Optional custom Sourcify sources object with the keys "ipfs" and
-     * "central_server" whose values are their respective root URLs.
+     * Optional custom Sourcify sources object whose keys are the source name
      */
-    sources?: { [key: string]: string };
-
-    /**
-     * See https://github.com/ethereum/sourcify/tree/staging/services/server#choosing-the-storage-backend
-     *
-     * "RepositoryV1" for the original backend format whose source filenames
-     * are derived from the contract metadata.
-     * "RepositoryV2" to use the Sourcify backend format which uses keccak256
-     * hashes for source file names since source file names can be arbitrary
-     * strings.
-     */
-    backendFormat?: string;
+    sources?: {
+      [key: string]: {
+        url: string;
+        /**
+         * See https://github.com/ethereum/sourcify/tree/staging/services/server#choosing-the-storage-backend
+         *
+         * "RepositoryV1" for the original backend format whose source filenames
+         * are derived from the contract metadata.
+         * "RepositoryV2" to use the Sourcify backend format which uses keccak256
+         * hashes for source file names since source file names can be arbitrary
+         * strings.
+         */
+        backendFormat: string;
+      };
+    };
   };
 
   /**


### PR DESCRIPTION
Closes https://github.com/otterscan/otterscan/issues/2740

After we merge this, we'll need to update the docs to reflect the changes to the config. I made this version is backward-compatible with the previous config by checking if a string instead of a new SourcifySource object was passed into the config, but I added a deprecation warning and a link to the new docs.

Sources in the config object are ordered from top to bottom as specified in the config, with the first being the default. The key name is now the displayed name rather than an "internal" name.

If no sources are specified in the config, the default Sourcify Servers source is used, and it adds a link to the docs in the menu:
![image](https://github.com/user-attachments/assets/db3dd677-813d-4a34-8803-ce1c263573b3)

Let me know if you have other ideas for how this should look.