### PR TITLE
Explicitly set ubuntu version

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -13,7 +13,7 @@ env:
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Docker publishing is breaking; this is an attempt to see if the rollout of new ubuntu-latest is to blame.