### PR TITLE
Set column sizes for tx hash/from/to in wider resolutions

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,7 @@
 
   --breakpoint-3xl: 120rem;
   --breakpoint-4xl: 160rem;
+  --breakpoint-5xl: 200rem;
 }
 
 /*

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,9 @@
   --background-color-skin-from: rgb(var(--color-from-fill));
   --background-color-skin-to: rgb(var(--color-to-fill));
   --background-color-skin-table-hover: rgb(var(--color-table-row-hover));
+
+  --breakpoint-3xl: 120rem;
+  --breakpoint-4xl: 160rem;
 }
 
 /*

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -16,8 +16,8 @@ const ResultHeader: FC<ResultHeaderProps> = ({
     <th>Method</th>
     <th className="w-28">Block</th>
     <th className="w-36">Age</th>
-    <th className="4xl:w-md">From</th>
-    <th className="4xl:w-md">To</th>
+    <th className="4xl:w-md 5xl:w-xl">From</th>
+    <th className="4xl:w-md 5xl:w-xl">To</th>
     <th className="min-w-52">Value</th>
     <th>
       <button

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -16,8 +16,8 @@ const ResultHeader: FC<ResultHeaderProps> = ({
     <th>Method</th>
     <th className="w-28">Block</th>
     <th className="w-36">Age</th>
-    <th className="4xl:w-md 5xl:w-xl">From</th>
-    <th className="4xl:w-md 5xl:w-xl">To</th>
+    <th className="min-w-52 xl:min-w-64 4xl:w-md 5xl:w-xl">From</th>
+    <th className="min-w-52 xl:min-w-64 4xl:w-md 5xl:w-xl">To</th>
     <th className="min-w-52">Value</th>
     <th>
       <button

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { FC, memo } from "react";
 import StandardTHead from "../components/StandardTHead";
 import { FeeDisplay } from "./useFeeToggler";
 
@@ -7,17 +7,17 @@ export type ResultHeaderProps = {
   feeDisplayToggler: () => void;
 };
 
-const ResultHeader: React.FC<ResultHeaderProps> = ({
+const ResultHeader: FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
 }) => (
   <StandardTHead>
-    <th>Txn Hash</th>
+    <th className="4xl:w-152">Txn Hash</th>
     <th>Method</th>
     <th className="w-28">Block</th>
     <th className="w-36">Age</th>
-    <th>From</th>
-    <th>To</th>
+    <th className="4xl:w-md">From</th>
+    <th className="4xl:w-md">To</th>
     <th className="min-w-52">Value</th>
     <th>
       <button
@@ -32,4 +32,4 @@ const ResultHeader: React.FC<ResultHeaderProps> = ({
   </StandardTHead>
 );
 
-export default React.memo(ResultHeader);
+export default memo(ResultHeader);

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -72,7 +72,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         <td className="min-w-36 max-w-36">
           <TimestampAge timestamp={tx.timestamp} />
         </td>
-        <td className="max-w-[14.5rem]">
+        <td className="max-w-[8rem] min-w-[8rem] xl:min-w-[12rem] xl:max-w-[12rem]">
           <span className="col-span-2 flex items-baseline justify-between space-x-2 pr-2">
             <span className="truncate">
               {tx.from && (
@@ -90,7 +90,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             </span>
           </span>
         </td>
-        <td className="max-w-[14.5rem]">
+        <td className="max-w-[8rem] min-w-[8rem] xl:min-w-[12rem] xl:max-w-[12rem]">
           <span
             className="col-span-2 flex items-baseline"
             title={tx.to ?? tx.createdContractAddress}


### PR DESCRIPTION
fix https://github.com/otterscan/otterscan/issues/1887

tailwind 4 defines up to 2xl breakpoint, this PR defines 3xl and 4xl for the next 3 popular widths: 1920 and 2560 according to https://screensiz.es/

but we'll only use 4xl here, 3xl does not give enough free space to show everything.