### PR TITLE
Show USD conversion in Value column on wide screens

### DIFF
--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import BlockLink from "../components/BlockLink";
+import { feePreset } from "../components/FiatValue";
 import MethodName from "../components/MethodName";
 import NativeTokenAmount from "../components/NativeTokenAmount";
 import NativeTokenAmountAndFiat from "../components/NativeTokenAmountAndFiat";
@@ -17,7 +18,6 @@ import { useSendsToMiner } from "../useErigonHooks";
 import { RuntimeContext } from "../useRuntime";
 import TransactionItemFiatFee from "./TransactionItemFiatFee";
 import { FeeDisplay } from "./useFeeToggler";
-import { feePreset } from "../components/FiatValue";
 
 type TransactionItemProps = {
   tx: ProcessedTransaction;

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import BlockLink from "../components/BlockLink";
 import MethodName from "../components/MethodName";
 import NativeTokenAmount from "../components/NativeTokenAmount";
+import NativeTokenAmountAndFiat from "../components/NativeTokenAmountAndFiat";
 import TimestampAge from "../components/TimestampAge";
 import TransactionDirection, {
   Direction,
@@ -16,6 +17,7 @@ import { useSendsToMiner } from "../useErigonHooks";
 import { RuntimeContext } from "../useRuntime";
 import TransactionItemFiatFee from "./TransactionItemFiatFee";
 import { FeeDisplay } from "./useFeeToggler";
+import { feePreset } from "../components/FiatValue";
 
 type TransactionItemProps = {
   tx: ProcessedTransaction;
@@ -115,7 +117,18 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
           </span>
         </td>
         <td className="min-w-48 max-w-48">
-          <NativeTokenAmount value={tx.value} />
+          <div className="@container">
+            <div className="@2xs:hidden inline-block">
+              <NativeTokenAmount value={tx.value} />
+            </div>
+            <div className="@2xs:inline-block hidden">
+              <NativeTokenAmountAndFiat
+                value={tx.value}
+                blockTag={tx.blockNumber}
+                {...feePreset}
+              />
+            </div>
+          </div>
         </td>
         <td className="min-w-16 max-w-28">
           <span className="truncate font-balance text-xs text-gray-500">


### PR DESCRIPTION
Closes #2797.

At a client width of 1982px, the USD labels appear. There is the extra network overhead which is applied **at all resolutions** now, but the USD price of the native token is used elsewhere, so it has the side effect of preloading the "Txn Fee (USD)" column. (And you have the idea for smaller resolutions.)

![image](https://github.com/user-attachments/assets/55d72603-4c62-4472-9c5e-f0eb74122d6b)
