### PR TITLE
Correct flipped divide in Tailwind v4

### DIFF
--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -177,11 +177,13 @@ const AddressTransactionResults: FC = () => {
           {creator && (
             <InfoRow title="Contract creator">
               <div className="flex flex-col md:flex-row divide-x-2 divide-dotted divide-gray-300">
-                <TransactionAddressWithCopy
-                  address={creator.creator}
-                  showCodeIndicator
-                />
-                <div className="md:ml-3 flex items-baseline pl-3 truncate">
+                <div className="pr-3">
+                  <TransactionAddressWithCopy
+                    address={creator.creator}
+                    showCodeIndicator
+                  />
+                </div>
+                <div className="md:ml-3 flex items-baseline truncate">
                   <div className="truncate">
                     <TransactionLink txHash={creator.hash} />
                   </div>

--- a/src/execution/transaction/Details.tsx
+++ b/src/execution/transaction/Details.tsx
@@ -227,14 +227,14 @@ const Details: FC<DetailsProps> = ({ txData }) => {
         <>
           <InfoRow title="Block / Position">
             <div className="flex flex-wrap gap-y-2 items-baseline divide-x-2 divide-dotted divide-gray-300">
-              <div className="flex items-baseline space-x-1">
+              <div className="flex items-baseline space-x-1 pr-3">
                 <BlockLink blockTag={txData.confirmedData.blockNumber} />
                 <BlockConfirmations
                   confirmations={txData.confirmedData.confirmations}
                 />
               </div>
               {block && (
-                <div className="ml-3 flex items-baseline space-x-2 pl-3">
+                <div className="flex items-baseline space-x-2 pl-3">
                   <RelativePosition
                     pos={txData.confirmedData.transactionIndex}
                     total={block.transactionCount - 1}
@@ -266,8 +266,10 @@ const Details: FC<DetailsProps> = ({ txData }) => {
       )}
       <InfoRow title="From / Nonce">
         <div className="flex flex-wrap gap-y-2 divide-x-2 divide-dotted divide-gray-300">
-          <TransactionAddressWithCopy address={txData.from} />
-          <div className="ml-3 flex items-baseline pl-3">
+          <div className="pr-3">
+            <TransactionAddressWithCopy address={txData.from} />
+          </div>
+          <div className="ml-3 flex items-baseline">
             <Nonce value={txData.nonce} />
             <NavNonce sender={txData.from} nonce={txData.nonce} />
           </div>


### PR DESCRIPTION
Fixes #2826 

Divides flipped horizontally with Tailwind v4:
![image](https://github.com/user-attachments/assets/61f8fe23-dc70-4ea0-b5e6-aa8d6f18d02a)


Divides look correct again with this PR:
![image](https://github.com/user-attachments/assets/9b7ff253-1bfb-421b-a0b4-206cd59832fc)
