### PR TITLE
Bump Sourcify menu z-index

### DIFF
--- a/src/SourcifyMenu.tsx
+++ b/src/SourcifyMenu.tsx
@@ -26,7 +26,7 @@ const SourcifyMenu: React.FC = () => {
 
   return (
     <Menu>
-      <div className="relative self-stretch h-full">
+      <div className="relative self-stretch h-full z-1">
         <MenuButton className="flex h-full w-full items-center justify-center space-x-2 rounded-sm border px-2 py-1 text-sm">
           <FontAwesomeIcon icon={faBars} size="1x" />
         </MenuButton>


### PR DESCRIPTION
Addresses #2842 

This addresses the issue except during a mouse event that closes the menu. So this at least fixes the problem during most of the time the window is open, but I'm not sure how to fix the "on mouse press" part yet.