### PR TITLE
Split transactions sent into InfoRow at small width

### DIFF
--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -151,7 +151,7 @@ const AddressTransactionResults: FC = () => {
           <InfoRow title="Balance">
             <div className="grid grid-cols-3 flex md:divide-x-2 divide-dotted divide-gray-300 text-sm">
               <div
-                className={`${transactionCount !== undefined ? "col-span-3 md:col-span-1" : "col-span-1"}`}
+                className={`${transactionCount !== undefined ? "col-span-3 md:col-span-1" : "col-span-3"}`}
               >
                 {balance === undefined ? (
                   <div className="w-80">
@@ -165,7 +165,7 @@ const AddressTransactionResults: FC = () => {
                 )}
               </div>
               {transactionCount !== undefined && (
-                <div className="hidden md:visible mt-2 md:mt-0 md:pl-4 md:col-span-2 md:grid md:grid-cols-2">
+                <div className="hidden md:visible pl-4 col-span-2 md:grid grid-cols-2">
                   <div className="col-span-1">Transactions sent:</div>
                   <div className="col-span-1">
                     {commify(transactionCount.toString())}

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -149,9 +149,9 @@ const AddressTransactionResults: FC = () => {
       <StandardSelectionBoundary>
         <BlockNumberContext.Provider value="latest">
           <InfoRow title="Balance">
-            <div className="grid grid-cols-3 flex divide-x-2 divide-dotted divide-gray-300 text-sm">
+            <div className="grid grid-cols-3 flex md:divide-x-2 divide-dotted divide-gray-300 text-sm">
               <div
-                className={`${transactionCount !== undefined ? "col-span-1" : "col-span-3"}`}
+                className={`${transactionCount !== undefined ? "col-span-3 md:col-span-1" : "col-span-1"}`}
               >
                 {balance === undefined ? (
                   <div className="w-80">
@@ -165,7 +165,7 @@ const AddressTransactionResults: FC = () => {
                 )}
               </div>
               {transactionCount !== undefined && (
-                <div className="pl-4 col-span-2 grid grid-cols-2">
+                <div className="hidden md:visible mt-2 md:mt-0 md:pl-4 md:col-span-2 md:grid md:grid-cols-2">
                   <div className="col-span-1">Transactions sent:</div>
                   <div className="col-span-1">
                     {commify(transactionCount.toString())}
@@ -174,6 +174,13 @@ const AddressTransactionResults: FC = () => {
               )}
             </div>
           </InfoRow>
+          {transactionCount !== undefined && (
+            <div className="md:hidden">
+              <InfoRow title="Transactions sent">
+                {commify(transactionCount.toString())}
+              </InfoRow>
+            </div>
+          )}
           {creator && (
             <InfoRow title="Contract creator">
               <div className="flex flex-col md:flex-row divide-x-2 divide-dotted divide-gray-300">


### PR DESCRIPTION
Closes #2851 
At md screen width, this splits Transactions Sent into its own InfoRow.
![image](https://github.com/user-attachments/assets/db8631e0-a28d-4d7a-99a9-649f34b8e3f7)

If we to use something like this again, we can create a "two halves" InfoRow component.