### PR TITLE
Add USD toggle to tx Value column

### DIFF
--- a/src/components/NativeTokenAmountOnlyFiat.tsx
+++ b/src/components/NativeTokenAmountOnlyFiat.tsx
@@ -1,0 +1,38 @@
+import { BlockTag, FixedNumber } from "ethers";
+import { FC } from "react";
+import { useFiatValue } from "../usePriceOracle";
+import FiatValue, { FiatBoxProps, neutralPreset } from "./FiatValue";
+
+type NativeTokenAmountOnlyFiatProps = FiatBoxProps & {
+  value: bigint;
+  blockTag?: BlockTag;
+};
+
+/**
+ * A variant of NativeTokenAmountAndFiat that does not show the native token amount.
+ */
+const NativeTokenAmountOnlyFiat: FC<NativeTokenAmountOnlyFiatProps> = ({
+  value,
+  blockTag = "latest",
+  ...rest
+}) => {
+  const fiatValue = useFiatValue(value, blockTag);
+
+  return (
+    <>
+      {value !== 0n ? (
+        fiatValue ? (
+          <FiatValue value={fiatValue} {...rest} />
+        ) : (
+          <span className="font-balance text-xs text-gray-500">N/A</span>
+        )
+      ) : (
+        <div className="opacity-40">
+          <FiatValue value={FixedNumber.fromValue(0n, 18)} {...neutralPreset} />
+        </div>
+      )}
+    </>
+  );
+};
+
+export default NativeTokenAmountOnlyFiat;

--- a/src/components/NativeTokenAmountOnlyFiat.tsx
+++ b/src/components/NativeTokenAmountOnlyFiat.tsx
@@ -27,7 +27,7 @@ const NativeTokenAmountOnlyFiat: FC<NativeTokenAmountOnlyFiatProps> = ({
           <span className="font-balance text-xs text-gray-500">N/A</span>
         )
       ) : (
-        <div className="opacity-40">
+        <div className="opacity-30">
           <FiatValue value={FixedNumber.fromValue(0n, 18)} {...neutralPreset} />
         </div>
       )}

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -13,7 +13,11 @@ import ResultHeader from "../../search/ResultHeader";
 import TransactionItem from "../../search/TransactionItem";
 import UndefinedPageControl from "../../search/UndefinedPageControl";
 import { SearchController } from "../../search/search";
-import { useFeeToggler } from "../../search/useFeeToggler";
+import {
+  FeeDisplay,
+  useToggler,
+  ValueDisplay,
+} from "../../search/useFeeToggler";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import { ProcessedTransaction } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
@@ -53,7 +57,8 @@ const ProxyInfo: FC<AddressAwareComponentProps> = ({ address }) => {
 const AddressTransactionResults: FC = () => {
   const { address, hasCode } = useOutletContext() as AddressOutletContext;
   const { config, provider } = useContext(RuntimeContext);
-  const [feeDisplay, feeDisplayToggler] = useFeeToggler();
+  const [feeDisplay, feeDisplayToggler] = useToggler(FeeDisplay);
+  const [valueDisplay, valueDisplayToggler] = useToggler(ValueDisplay);
 
   const { addressOrName, direction } = useParams();
   if (addressOrName === undefined) {
@@ -205,6 +210,8 @@ const AddressTransactionResults: FC = () => {
           <ResultHeader
             feeDisplay={feeDisplay}
             feeDisplayToggler={feeDisplayToggler}
+            valueDisplay={valueDisplay}
+            valueDisplayToggler={valueDisplayToggler}
           />
           {page ? (
             <StandardTBody>
@@ -214,6 +221,7 @@ const AddressTransactionResults: FC = () => {
                   tx={tx}
                   selectedAddress={address}
                   feeDisplay={feeDisplay}
+                  valueDisplay={valueDisplay}
                 />
               ))}
             </StandardTBody>

--- a/src/execution/block/BlockTransactionResults.tsx
+++ b/src/execution/block/BlockTransactionResults.tsx
@@ -7,7 +7,11 @@ import ResultHeader from "../../search/ResultHeader";
 import SearchResultNavBar from "../../search/SearchResultNavBar";
 import TransactionItem from "../../search/TransactionItem";
 import { totalTransactionsFormatter } from "../../search/messages";
-import { useFeeToggler } from "../../search/useFeeToggler";
+import {
+  FeeDisplay,
+  useToggler,
+  ValueDisplay,
+} from "../../search/useFeeToggler";
 import StandardSelectionBoundary from "../../selection/StandardSelectionBoundary";
 import { ProcessedTransaction } from "../../types";
 import PendingPage from "../address/PendingPage";
@@ -25,7 +29,8 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
   pageNumber,
   isLoading,
 }) => {
-  const [feeDisplay, feeDisplayToggler] = useFeeToggler();
+  const [feeDisplay, feeDisplayToggler] = useToggler(FeeDisplay);
+  const [valueDisplay, valueDisplayToggler] = useToggler(ValueDisplay);
 
   return (
     <ContentFrame isLoading={isLoading}>
@@ -39,6 +44,8 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
         <ResultHeader
           feeDisplay={feeDisplay}
           feeDisplayToggler={feeDisplayToggler}
+          valueDisplay={valueDisplay}
+          valueDisplayToggler={valueDisplayToggler}
         />
         {page ? (
           <StandardSelectionBoundary>
@@ -48,6 +55,7 @@ const BlockTransactionResults: FC<BlockTransactionResultsProps> = ({
                   key={tx.hash}
                   tx={tx}
                   feeDisplay={feeDisplay}
+                  valueDisplay={valueDisplay}
                 />
               ))}
             </StandardTBody>

--- a/src/search/ResultHeader.tsx
+++ b/src/search/ResultHeader.tsx
@@ -1,15 +1,19 @@
 import { FC, memo } from "react";
 import StandardTHead from "../components/StandardTHead";
-import { FeeDisplay } from "./useFeeToggler";
+import { FeeDisplay, ValueDisplay } from "./useFeeToggler";
 
 export type ResultHeaderProps = {
   feeDisplay: FeeDisplay;
   feeDisplayToggler: () => void;
+  valueDisplay: ValueDisplay;
+  valueDisplayToggler: () => void;
 };
 
 const ResultHeader: FC<ResultHeaderProps> = ({
   feeDisplay,
   feeDisplayToggler,
+  valueDisplay,
+  valueDisplayToggler,
 }) => (
   <StandardTHead>
     <th className="4xl:w-152">Txn Hash</th>
@@ -18,7 +22,20 @@ const ResultHeader: FC<ResultHeaderProps> = ({
     <th className="w-36">Age</th>
     <th className="min-w-52 xl:min-w-64 4xl:w-md 5xl:w-xl">From</th>
     <th className="min-w-52 xl:min-w-64 4xl:w-md 5xl:w-xl">To</th>
-    <th className="min-w-52">Value</th>
+    <th className="min-w-52">
+      <div className="@container">
+        <div className="hidden @2xs:block">Value</div>
+        <div className="@2xs:hidden">
+          <button
+            className="text-link-blue hover:text-link-blue-hover"
+            onClick={valueDisplayToggler}
+          >
+            {valueDisplay === ValueDisplay.VALUE_NATIVE && "Value"}
+            {valueDisplay === ValueDisplay.VALUE_USD && "Value (USD)"}
+          </button>
+        </div>
+      </div>
+    </th>
     <th>
       <button
         className="text-link-blue hover:text-link-blue-hover"

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -4,6 +4,7 @@ import { feePreset } from "../components/FiatValue";
 import MethodName from "../components/MethodName";
 import NativeTokenAmount from "../components/NativeTokenAmount";
 import NativeTokenAmountAndFiat from "../components/NativeTokenAmountAndFiat";
+import NativeTokenAmountOnlyFiat from "../components/NativeTokenAmountOnlyFiat";
 import TimestampAge from "../components/TimestampAge";
 import TransactionDirection, {
   Direction,
@@ -17,18 +18,20 @@ import { BlockNumberContext } from "../useBlockTagContext";
 import { useSendsToMiner } from "../useErigonHooks";
 import { RuntimeContext } from "../useRuntime";
 import TransactionItemFiatFee from "./TransactionItemFiatFee";
-import { FeeDisplay } from "./useFeeToggler";
+import { FeeDisplay, ValueDisplay } from "./useFeeToggler";
 
 type TransactionItemProps = {
   tx: ProcessedTransaction;
   selectedAddress?: string;
   feeDisplay: FeeDisplay;
+  valueDisplay: ValueDisplay;
 };
 
 const TransactionItem: React.FC<TransactionItemProps> = ({
   tx,
   selectedAddress,
   feeDisplay,
+  valueDisplay,
 }) => {
   const { provider } = useContext(RuntimeContext);
   const [sendsToMiner] = useSendsToMiner(provider, tx.hash, tx.miner);
@@ -119,7 +122,16 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
         <td className="min-w-48 max-w-48">
           <div className="@container">
             <div className="@2xs:hidden inline-block">
-              <NativeTokenAmount value={tx.value} />
+              {valueDisplay === ValueDisplay.VALUE_NATIVE && (
+                <NativeTokenAmount value={tx.value} />
+              )}
+              {valueDisplay === ValueDisplay.VALUE_USD && (
+                <NativeTokenAmountOnlyFiat
+                  value={tx.value}
+                  blockTag={tx.blockNumber}
+                  {...feePreset}
+                />
+              )}
             </div>
             <div className="@2xs:inline-block hidden">
               <NativeTokenAmountAndFiat

--- a/src/search/useFeeToggler.ts
+++ b/src/search/useFeeToggler.ts
@@ -1,19 +1,34 @@
 import { useState } from "react";
 
+export type Enum<T> = {
+  [K in keyof T]: T[K];
+};
+
 export enum FeeDisplay {
   TX_FEE,
   TX_FEE_USD,
   GAS_PRICE,
 }
 
-export const useFeeToggler = (): [FeeDisplay, () => void] => {
-  const [feeDisplay, setFeeDisplay] = useState<FeeDisplay>(FeeDisplay.TX_FEE);
-  const feeDisplayToggler = () => {
-    setFeeDisplay(feeDisplay + 1);
-    if (feeDisplay === FeeDisplay.GAS_PRICE) {
-      setFeeDisplay(0);
-    }
+export enum ValueDisplay {
+  VALUE_NATIVE,
+  VALUE_USD,
+}
+
+export function useToggler<T extends Enum<T>>(
+  enumType: T,
+): [T[keyof T], () => void] {
+  const [toggledValue, setToggledValue] = useState<T[keyof T]>(
+    Object.values(enumType)[Object.values(enumType).length / 2] as T[keyof T],
+  );
+
+  const toggler = () => {
+    const nextIndex = Object.values(enumType)[
+      ((toggledValue + 1) % (Object.values(enumType).length / 2)) +
+        Object.values(enumType).length / 2
+    ] as T[keyof T];
+    setToggledValue(nextIndex);
   };
 
-  return [feeDisplay, feeDisplayToggler];
-};
+  return [toggledValue, toggler];
+}


### PR DESCRIPTION
This makes the Value column header clickable into a toggle like the Txn Fee column:
![image](https://github.com/user-attachments/assets/3a57a54b-809e-44e8-87ae-c624da44881e)

When clicked:
![image](https://github.com/user-attachments/assets/e23bca34-3ae2-4575-894b-f58d6c26191e)

When the space is large enough that both fit, the header is no longer clickable:
![image](https://github.com/user-attachments/assets/ea34a096-fc68-4970-b9f2-4cad05b2920a)

I added reduced-opacity $0.00 entries when no value was sent and made a more generic `useToggler`, though it relies on the TypeScript compiler's implementation of enums (due to https://github.com/microsoft/TypeScript/issues/42457 - it's at least better than other attempts like https://www.npmjs.com/package/enum-for?activeTab=code in my opinion).

Closes #2853 