### PR TITLE
Load 4bytes in whatsabi feature when assetsURLPrefix is empty

### DIFF
--- a/src/sourcify/useWhatsabi.ts
+++ b/src/sourcify/useWhatsabi.ts
@@ -37,7 +37,7 @@ function whatsabiFetcher(
     const selectors = whatsabi.selectorsFromBytecode(code);
     const decodedFunctions: (string | null)[] = await Promise.all(
       selectors.map(async (selector) => {
-        if (!assetsURLPrefix) {
+        if (assetsURLPrefix === null || assetsURLPrefix === undefined) {
           return null;
         }
         try {


### PR DESCRIPTION
Closes #2957 

Still needs testing on the official Otterscan docker version.