### PR TITLE
Overhaul address search

### DIFF
--- a/cypress/e2e/mainnet/address-search.cy.ts
+++ b/cypress/e2e/mainnet/address-search.cy.ts
@@ -1,6 +1,7 @@
 describe("Advanced search", () => {
   const navigateAndAssert = (
     initialUrl: string,
+    initialHash: string,
     navAssertions: [direction: "next" | "prev", expectedHash: string][],
     txHashIndex: number,
   ) => {
@@ -8,6 +9,10 @@ describe("Advanced search", () => {
     cy.get('[data-test="address"]', { timeout: 15_000 }).contains(
       "0xdAC17F958D2ee523a2206206994597C13D831ec7",
     );
+    cy.get('[data-test="tx-hash"]')
+      .eq(txHashIndex)
+      .invoke("text")
+      .should("equal", initialHash);
 
     navAssertions.forEach(([direction, expectedHash]) => {
       cy.get(`[data-test="nav-${direction}"]`).first().click();
@@ -21,6 +26,8 @@ describe("Advanced search", () => {
   it("Should load correct intra-block transaction hash", () => {
     const initialUrl =
       "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/next?h=0x0af4ac9aa2654a5a66b988dae5daedd1b22fe3dfa5af2ab5d205f656f22805a3";
+    const initialHash =
+      "0xf9ef591307c4790f95324797f423b8a6ce443ce748d3b574ef7a9e12d2d681cb";
     const navAssertions: [direction: "next" | "prev", expectedHash: string][] =
       [
         [
@@ -40,12 +47,14 @@ describe("Advanced search", () => {
           "0xf9ef591307c4790f95324797f423b8a6ce443ce748d3b574ef7a9e12d2d681cb",
         ],
       ];
-    navigateAndAssert(initialUrl, navAssertions, 1);
+    navigateAndAssert(initialUrl, initialHash, navAssertions, 1);
   });
 
   it("Should correctly step in both directions through a block with over 100 relevant transactions", () => {
     const initialUrl =
       "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/prev?h=0xb8c6d15e5fceb17f52eae0e1e633d9aa481db2bef23c1483519a1c894ff6f283";
+    const initialHash =
+      "0xaef7598e47d575f7fa9da8bab05dc4436f9080a6c46a53ef76dc81d41577e8f2";
     const navAssertions: [direction: "next" | "prev", expectedHash: string][] =
       [
         [
@@ -121,6 +130,6 @@ describe("Advanced search", () => {
           "0xaef7598e47d575f7fa9da8bab05dc4436f9080a6c46a53ef76dc81d41577e8f2",
         ],
       ];
-    navigateAndAssert(initialUrl, navAssertions, 1);
+    navigateAndAssert(initialUrl, initialHash, navAssertions, 1);
   });
 });

--- a/cypress/e2e/mainnet/address-search.cy.ts
+++ b/cypress/e2e/mainnet/address-search.cy.ts
@@ -1,0 +1,126 @@
+describe("Advanced search", () => {
+  const navigateAndAssert = (
+    initialUrl: string,
+    navAssertions: [direction: "next" | "prev", expectedHash: string][],
+    txHashIndex: number,
+  ) => {
+    cy.visit(initialUrl);
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(
+      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    );
+
+    navAssertions.forEach(([direction, expectedHash]) => {
+      cy.get(`[data-test="nav-${direction}"]`).first().click();
+      cy.get('[data-test="tx-hash"]')
+        .eq(txHashIndex)
+        .invoke("text")
+        .should("equal", expectedHash);
+    });
+  };
+
+  it("Should load correct intra-block transaction hash", () => {
+    const initialUrl =
+      "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/next?h=0x0af4ac9aa2654a5a66b988dae5daedd1b22fe3dfa5af2ab5d205f656f22805a3";
+    const navAssertions: [direction: "next" | "prev", expectedHash: string][] =
+      [
+        [
+          "prev",
+          "0x299e208b92b4c46c5a270991c7849216ca9b23d9a34607a221bf590d7eb435cd",
+        ],
+        [
+          "prev",
+          "0xf2c7a6dfc21803a7af7c76e9d46fa40b963528de02e0ee2801ac66a6d099d3bf",
+        ],
+        [
+          "next",
+          "0x299e208b92b4c46c5a270991c7849216ca9b23d9a34607a221bf590d7eb435cd",
+        ],
+        [
+          "next",
+          "0xf9ef591307c4790f95324797f423b8a6ce443ce748d3b574ef7a9e12d2d681cb",
+        ],
+      ];
+    navigateAndAssert(initialUrl, navAssertions, 1);
+  });
+
+  it("Should correctly step in both directions through a block with over 100 relevant transactions", () => {
+    const initialUrl =
+      "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/prev?h=0xb8c6d15e5fceb17f52eae0e1e633d9aa481db2bef23c1483519a1c894ff6f283";
+    const navAssertions: [direction: "next" | "prev", expectedHash: string][] =
+      [
+        [
+          "prev",
+          "0xae317b3f6e9b7850667e9b416e4a46163e27ada1256e0e098cb6dc56cb024ed0",
+        ],
+        [
+          "prev",
+          "0xda402b7b7996010df5d8f2da29befa913c3177c872404e0f9182e78b29af0958",
+        ],
+        [
+          "prev",
+          "0xbdfb45c4c44af4e7aa675605e4eec3f54a0900d19f50aed863cdcaa4a57be85b",
+        ],
+        [
+          "prev",
+          "0x822549f2f90dea7cfca983a3ccbc6e4e592213255ab700d0a20e2b957572435d",
+        ],
+        [
+          "prev",
+          "0x3ce32d07f22bb8af8674a2d256b275ca330c1d5ae0b8fa77d93ff441874d15b2",
+        ],
+        [
+          "prev",
+          "0x7283a46089e1b0869eeb10e047fe460461fe1003023c653c21f46bef575f00cb",
+        ],
+        [
+          "prev",
+          "0x43860882e3573bbb83e6f63029b66735e46eb65c1c5e06224e696d9091336d6a",
+        ],
+        [
+          "prev",
+          "0xdda36e94f471efc717dd51c63f29c1d3a87ec3f208a94441d21406202937d4b3",
+        ],
+        [
+          "prev",
+          "0x3f95684f86ee25f2bbf0e8ee521392ac8277ceeadac9e7501153856336a96052",
+        ],
+        [
+          "next",
+          "0xdda36e94f471efc717dd51c63f29c1d3a87ec3f208a94441d21406202937d4b3",
+        ],
+        [
+          "next",
+          "0x43860882e3573bbb83e6f63029b66735e46eb65c1c5e06224e696d9091336d6a",
+        ],
+        [
+          "next",
+          "0x7283a46089e1b0869eeb10e047fe460461fe1003023c653c21f46bef575f00cb",
+        ],
+        [
+          "next",
+          "0x3ce32d07f22bb8af8674a2d256b275ca330c1d5ae0b8fa77d93ff441874d15b2",
+        ],
+        [
+          "next",
+          "0x822549f2f90dea7cfca983a3ccbc6e4e592213255ab700d0a20e2b957572435d",
+        ],
+        [
+          "next",
+          "0xbdfb45c4c44af4e7aa675605e4eec3f54a0900d19f50aed863cdcaa4a57be85b",
+        ],
+        [
+          "next",
+          "0xda402b7b7996010df5d8f2da29befa913c3177c872404e0f9182e78b29af0958",
+        ],
+        [
+          "next",
+          "0xae317b3f6e9b7850667e9b416e4a46163e27ada1256e0e098cb6dc56cb024ed0",
+        ],
+        [
+          "next",
+          "0xaef7598e47d575f7fa9da8bab05dc4436f9080a6c46a53ef76dc81d41577e8f2",
+        ],
+      ];
+    navigateAndAssert(initialUrl, navAssertions, 1);
+  });
+});

--- a/src/search/batch.test.ts
+++ b/src/search/batch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "@jest/globals";
+import { trimBatchesToSize } from "./batch";
+
+const myList = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+];
+const batches = [{ length: 8 }, { length: 4 }, { length: 3 }, { length: 5 }];
+
+describe("trimBatchesToSize", () => {
+  describe("Trimming from start", () => {
+    test("Trim to 9", () => {
+      const result = trimBatchesToSize(myList, batches, 9, true);
+      expect(result.list).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      expect(result.batches).toEqual([{ length: 8 }, { length: 4 }]);
+    });
+
+    test("Trim to 8 (exact batch match)", () => {
+      const result = trimBatchesToSize(myList, batches, 8, true);
+      expect(result.list).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+      expect(result.batches).toEqual([{ length: 8 }]);
+    });
+  });
+
+  describe("Trimming from end", () => {
+    test("Trim to 9", () => {
+      const result = trimBatchesToSize(myList, batches, 9, false);
+      expect(result.list).toEqual([
+        9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+      ]);
+      expect(result.batches).toEqual([
+        { length: 4 },
+        { length: 3 },
+        { length: 5 },
+      ]);
+    });
+
+    test("Trim to 8", () => {
+      const result = trimBatchesToSize(myList, batches, 8, false);
+      expect(result.list).toEqual([13, 14, 15, 16, 17, 18, 19, 20]);
+      expect(result.batches).toEqual([{ length: 3 }, { length: 5 }]);
+    });
+  });
+});

--- a/src/search/batch.ts
+++ b/src/search/batch.ts
@@ -1,0 +1,49 @@
+export function trimBatchesToSize<T, B extends { length: number }>(
+  list: T[],
+  batches: B[],
+  targetSize: number,
+  trimFromStart: boolean,
+  requiredIndex?: number,
+): { list: T[]; batches: B[] } {
+  let sizeAccumulator = 0;
+  let batchIndex = trimFromStart ? 0 : batches.length - 1;
+  // Direction of iteration
+  let step = trimFromStart ? 1 : -1;
+
+  // Find how many batches are needed to reach the target size
+  let batchesToKeep = 0;
+  let requiredIndexFound = requiredIndex === undefined;
+  while (batchIndex >= 0 && batchIndex < batches.length) {
+    if (
+      requiredIndex === undefined ||
+      (trimFromStart
+        ? requiredIndex >= sizeAccumulator &&
+          requiredIndex < sizeAccumulator + batches[batchIndex].length
+        : requiredIndex >=
+            list.length - sizeAccumulator - batches[batchIndex].length &&
+          requiredIndex < list.length - sizeAccumulator)
+    ) {
+      requiredIndexFound = true;
+    }
+    sizeAccumulator += batches[batchIndex].length;
+    batchesToKeep += 1;
+    if (sizeAccumulator >= targetSize && requiredIndexFound) {
+      break;
+    }
+    batchIndex += step;
+  }
+
+  // Splice lists and return
+  const listStart = trimFromStart ? 0 : list.length - sizeAccumulator;
+  const updatedList = list.slice(
+    listStart,
+    trimFromStart ? sizeAccumulator : list.length,
+  );
+  return {
+    list: updatedList,
+    batches: batches.slice(
+      trimFromStart ? 0 : batches.length - batchesToKeep,
+      trimFromStart ? batchesToKeep : batches.length,
+    ),
+  };
+}


### PR DESCRIPTION
Closes #3036.

Overhauls the address search to handle pages with overflow correctly. This PR fixes multiple bugs:
* Navigating prev/next on overflow pages did not work correctly (transactions were skipped)
* First/last page markers when there is overflow (ex: if the first query has > `PAGE_SIZE` transactions but was both `firstPage` and `lastPage`, the UI would not show more than the first `PAGE_SIZE` transactions)
* Intra-block transaction search URL (shown transactions could differ when navigating to that URL if there was more than one transaction from the same block)

The key insight is that queries return all transactions present in each different block number in the response, so we preserve these queries as "batches" which lets us determine if we're on the first or last page even when paging between batches.