### PR TITLE
Update Erigon version in E2E tests from 2.54 to 3.04

### DIFF
--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -74,7 +74,7 @@ jobs:
           sudo apt install -y libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
 
       - name: Download Erigon
-        run: git clone --branch release/2.54 --single-branch https://github.com/ledgerwatch/erigon.git
+        run: git clone --branch v3.0.4 --single-branch https://github.com/erigontech/erigon.git
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We make use of open-source software and integrate many public data sources, main
 
 To the [Geth](https://geth.ethereum.org/) team whose code Erigon is based on.
 
-To the [Erigon](https://github.com/ledgerwatch/erigon) team that made it possible for regular humans to run an archive node on a retail laptop. Also, they have been very helpful explaining Erigon's internals which made the Otterscan modifications possible.
+To the [Erigon](https://github.com/erigontech/erigon) team that made it possible for regular humans to run an archive node on a retail laptop. Also, they have been very helpful explaining Erigon's internals which made the Otterscan modifications possible.
 
 To the [Test in Prod](https://www.testinprod.io/) team that made OP-Erigon. Their effort made it possible to run Otterscan against any Optimism Superchain.
 


### PR DESCRIPTION
The old Erigon branch we were using to run devnet tests no longer exists, so this PR migrates to the `v3.0.4` tag.