### PR TITLE
Highlight entire line of revert locations

### DIFF
--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -65,6 +65,7 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
     start: number;
     end: number;
   } | null>(null);
+  const [highlightLines, setHighlightLines] = useState<number[] | null>(null);
   useEffect(() => {
     const hrParam = searchParams.get("hr");
     if (hrParam) {
@@ -75,20 +76,43 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
       const [start, end] = split.map(Number).map(Math.floor);
       if (isNaN(start) || isNaN(end)) {
         console.error("Invalid offsets in URL parameter");
-        return;
+      } else {
+        setHighlightOffsets({ start, end });
       }
-      setHighlightOffsets({ start, end });
+    }
+
+    const hlParam = searchParams.get("hl");
+    if (hlParam) {
+      const lines = hlParam
+        .split("-")
+        .map(Number)
+        .map(Math.floor)
+        .filter((line) => !isNaN(line));
+      if (lines.length !== 2) {
+        console.error("Invalid lines in URL parameter");
+      } else {
+        console.log("These lines:", lines);
+        setHighlightLines(lines);
+      }
     }
   }, [searchParams]);
-  const sourceDecorations: DecorationOptions["decorations"] | undefined =
-    highlightOffsets
-      ? [
-          {
-            ...highlightOffsets,
-            properties: { class: "bg-source-line-highlight bg-clip-padding" },
-          },
-        ]
-      : undefined;
+
+  const sourceDecorations: DecorationOptions["decorations"] | undefined = [];
+
+  if (highlightLines && highlightLines.length === 2) {
+    sourceDecorations.push({
+      start: { line: highlightLines[0] - 1, character: 0 },
+      end: { line: highlightLines[1], character: 0 },
+      properties: { class: "bg-source-line-bg-highlight bg-clip-padding" },
+    });
+  }
+
+  if (highlightOffsets) {
+    sourceDecorations.push({
+      ...highlightOffsets,
+      properties: { class: "bg-source-line-highlight bg-clip-padding" },
+    });
+  }
 
   return (
     <ContentFrame tabs>

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -91,7 +91,6 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
       if (lines.length !== 2) {
         console.error("Invalid lines in URL parameter");
       } else {
-        console.log("These lines:", lines);
         setHighlightLines(lines);
       }
     }

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,7 @@
   --color-verified-contract-hover: #26007b;
   --color-source-line-numbers: #738a9486;
   --color-source-line-highlight: #99ff00;
+  --color-source-line-bg-highlight: #ffdddd;
 
   --font-sans: Roboto;
   --font-title: Space Grotesk;
@@ -88,6 +89,9 @@
     --color-to-fill: 125 211 252;
 
     --color-table-row-hover: 2 132 199;
+  }
+  .dark {
+    --color-source-line-highlight: #33ff00;
   }
 }
 


### PR DESCRIPTION
Closes #3293 

Makes the highlighted region more visible in dark mode and adds a red background for the rest of the line(s).

![Image](https://github.com/user-attachments/assets/4546af85-977d-4105-93df-b755e3579178)

![Image](https://github.com/user-attachments/assets/ad68065f-4c99-46d5-9089-88d9c37ef9de)
