### PR TITLE
Jump straight to block number in search results

### DIFF
--- a/cypress/e2e/mainnet/address-search.cy.ts
+++ b/cypress/e2e/mainnet/address-search.cy.ts
@@ -1,21 +1,27 @@
 describe("Advanced search", () => {
   const navigateAndAssert = (
+    address: string,
     initialUrl: string,
     initialHash: string,
-    navAssertions: [direction: "next" | "prev", expectedHash: string][],
+    navAssertions: [
+      direction: "next" | "prev" | "back",
+      expectedHash: string,
+    ][],
     txHashIndex: number,
   ) => {
     cy.visit(initialUrl);
-    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(
-      "0xdAC17F958D2ee523a2206206994597C13D831ec7",
-    );
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(address);
     cy.get('[data-test="tx-hash"]')
       .eq(txHashIndex)
       .invoke("text")
       .should("equal", initialHash);
 
     navAssertions.forEach(([direction, expectedHash]) => {
-      cy.get(`[data-test="nav-${direction}"]`).first().click();
+      if (direction === "back") {
+        cy.go("back");
+      } else {
+        cy.get(`[data-test="nav-${direction}"]`).first().click();
+      }
       cy.get('[data-test="tx-hash"]')
         .eq(txHashIndex)
         .invoke("text")
@@ -24,6 +30,7 @@ describe("Advanced search", () => {
   };
 
   it("Should load correct intra-block transaction hash", () => {
+    const address = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
     const initialUrl =
       "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/next?h=0x0af4ac9aa2654a5a66b988dae5daedd1b22fe3dfa5af2ab5d205f656f22805a3";
     const initialHash =
@@ -47,10 +54,11 @@ describe("Advanced search", () => {
           "0xf9ef591307c4790f95324797f423b8a6ce443ce748d3b574ef7a9e12d2d681cb",
         ],
       ];
-    navigateAndAssert(initialUrl, initialHash, navAssertions, 1);
+    navigateAndAssert(address, initialUrl, initialHash, navAssertions, 1);
   });
 
   it("Should correctly step in both directions through a block with over 100 relevant transactions", () => {
+    const address = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
     const initialUrl =
       "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/prev?h=0xb8c6d15e5fceb17f52eae0e1e633d9aa481db2bef23c1483519a1c894ff6f283";
     const initialHash =
@@ -130,6 +138,32 @@ describe("Advanced search", () => {
           "0xaef7598e47d575f7fa9da8bab05dc4436f9080a6c46a53ef76dc81d41577e8f2",
         ],
       ];
-    navigateAndAssert(initialUrl, initialHash, navAssertions, 1);
+    navigateAndAssert(address, initialUrl, initialHash, navAssertions, 1);
+  });
+
+  it("Should navigate with the browser's back button after two prev paginations", () => {
+    const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const initialUrl =
+      "/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/txs/last";
+    const initialHash =
+      "0x32e725433af17709360462be3ee194bba4994650fe697b5677339531a5db99a9";
+    const navAssertions: [
+      direction: "next" | "prev" | "back",
+      expectedHash: string,
+    ][] = [
+      [
+        "prev",
+        "0x012616c16fc2dbffe6dfba0f450aca81624743a684e176cea208e499a1af9b62",
+      ],
+      [
+        "prev",
+        "0x64426b39b22e76b9679c86292d16e1ca1f68a144a9029ec49efdae1f900db8d8",
+      ],
+      [
+        "back",
+        "0x012616c16fc2dbffe6dfba0f450aca81624743a684e176cea208e499a1af9b62",
+      ],
+    ];
+    navigateAndAssert(address, initialUrl, initialHash, navAssertions, 0);
   });
 });

--- a/cypress/e2e/mainnet/address-search.cy.ts
+++ b/cypress/e2e/mainnet/address-search.cy.ts
@@ -164,6 +164,142 @@ describe("Advanced search", () => {
         "0x012616c16fc2dbffe6dfba0f450aca81624743a684e176cea208e499a1af9b62",
       ],
     ];
+    // We use index 0 because this is a non-contract page and does not show the
+    // contract creation transaction hash.
     navigateAndAssert(address, initialUrl, initialHash, navAssertions, 0);
+  });
+
+  it("Should navigate to a near-end 5-transaction page correctly", () => {
+    const address = "0xdAC17F958D2ee523a2206206994597C13D831ec7";
+    const initialUrl =
+      "/address/0xdAC17F958D2ee523a2206206994597C13D831ec7/txs/next?h=0x71b20cbf7befcfe39decc7f692d7617e6414037e6d6ff8473a9278c8f2661344";
+    cy.visit(initialUrl);
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(address);
+    cy.get('[data-test="tx-hash"]')
+      .eq(1)
+      .invoke("text")
+      .should(
+        "equal",
+        "0x1ae98fd33665954d2676d46b1dfad65059f25e2623bcfa447fdb2da237797bb9",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0x2f1c5c2b44f771e942a8506148e256f94f1a464babc938ae0690c6e34cd79190",
+      );
+
+    // Previous page
+    cy.get(`[data-test="nav-prev"]`).first().click();
+
+    cy.get('[data-test="tx-hash"]')
+      .eq(1)
+      .invoke("text")
+      .should(
+        "equal",
+        "0xdb573f4b290b458255a259f16cbc9359167fb7ea971198c6c0379ab8fc8d801f",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0x71b20cbf7befcfe39decc7f692d7617e6414037e6d6ff8473a9278c8f2661344",
+      );
+
+    // Back to last page
+    cy.get(`[data-test="nav-next"]`).first().click();
+    cy.get('[data-test="tx-hash"]')
+      .eq(1)
+      .invoke("text")
+      .should(
+        "equal",
+        "0x1ae98fd33665954d2676d46b1dfad65059f25e2623bcfa447fdb2da237797bb9",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0x2f1c5c2b44f771e942a8506148e256f94f1a464babc938ae0690c6e34cd79190",
+      );
+  });
+
+  it("Should navigate to transactions after a target block number (partial)", () => {
+    const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const initialUrl =
+      "/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/txs/next?b=318620";
+    cy.visit(initialUrl);
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(address);
+    cy.get('[data-test="tx-hash"]')
+      .eq(0)
+      .invoke("text")
+      .should(
+        "equal",
+        "0x6ff0860e202c61189cb2a3a38286bffd694acbc50577df6cb5a7ff40e21ea074",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0x9b629147b75dc0b275d478fa34d97c5d4a26926457540b15a5ce871df36c23fd",
+      );
+
+    // Previous page
+    cy.get(`[data-test="nav-prev"]`).first().click();
+
+    cy.get('[data-test="tx-hash"]')
+      .eq(0)
+      .invoke("text")
+      .should(
+        "equal",
+        "0x4d76896ab6b112cb7e524c439580a50bc8185915be879f777a649f649707f555",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0xf3c0067e8aca43cf421dc502c0976525b89727fdfaee12bf356895f3b2bd7205",
+      );
+
+    // Back to last page
+    cy.get(`[data-test="nav-next"]`).first().click();
+    cy.get('[data-test="tx-hash"]')
+      .eq(0)
+      .invoke("text")
+      .should(
+        "equal",
+        "0x6ff0860e202c61189cb2a3a38286bffd694acbc50577df6cb5a7ff40e21ea074",
+      );
+
+    cy.get('[data-test="tx-hash"]')
+      .last()
+      .invoke("text")
+      .should(
+        "equal",
+        "0x9b629147b75dc0b275d478fa34d97c5d4a26926457540b15a5ce871df36c23fd",
+      );
+  });
+
+  it("Should detect an extremely large block number as the first page", () => {
+    const address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+    const initialUrl =
+      "/address/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045/txs/next?b=12345678910";
+    cy.visit(initialUrl);
+
+    // Wait for Last button to become enabled
+    cy.get("a").contains("Last").should("have.class", "text-xs text-link-blue");
+    // First button should be disabled
+    cy.get("span")
+      .contains("First")
+      .should("have.class", "text-xs text-gray-400");
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ import { PAGE_SIZE } from "./params";
 import ProbeErrorHandler from "./ProbeErrorHandler";
 import { queryClient } from "./queryClient";
 import { loader as searchLoader } from "./Search";
-import { getTransactionQuery, searchTransactionsQuery } from "./search/search";
+import { searchTransactionsQuery } from "./search/search";
 import { SourcifySourceName } from "./sourcify/useSourcify";
 import { ConnectionStatus } from "./types";
 import { AppConfig, AppConfigContext } from "./useAppConfig";
@@ -129,24 +129,6 @@ const addressTxResultsLoader: LoaderFunction = async ({ params, request }) => {
           params.direction === "last" ? "after" : "before",
         );
         queryClient.prefetchQuery(searchQuery);
-      } else if (params.direction === "next" || params.direction === "prev") {
-        const url = new URL(request.url);
-        const txHash = url.searchParams.get("h");
-        if (txHash) {
-          queryClient
-            .fetchQuery(getTransactionQuery(rt.provider, txHash))
-            .then((tx) => {
-              if (tx !== null) {
-                const searchQuery = searchTransactionsQuery(
-                  rt.provider,
-                  address,
-                  tx.blockNumber!,
-                  params.direction === "prev" ? "after" : "before",
-                );
-                queryClient.prefetchQuery(searchQuery);
-              }
-            });
-        }
       }
 
       const balanceQuery = getBalanceQuery(rt.provider, address);

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -67,6 +67,7 @@ const AddressTransactionResults: FC = () => {
 
   const [searchParams] = useSearchParams();
   const hash = searchParams.get("h");
+  const blockNumber = searchParams.get("b");
 
   const [controller, setController] = useState<SearchController>();
 
@@ -85,13 +86,24 @@ const AddressTransactionResults: FC = () => {
       setController(_controller);
     };
     const readMiddlePage = async (next: boolean) => {
-      const _controller = await SearchController.middlePage(
-        provider,
-        address,
-        hash!,
-        next,
-      );
-      setController(_controller);
+      if (hash !== null) {
+        const _controller = await SearchController.middlePage(
+          provider,
+          address,
+          hash!,
+          next,
+        );
+        setController(_controller);
+      } else if (blockNumber !== null) {
+        const _controller = await SearchController.middlePage(
+          provider,
+          address,
+          null,
+          next,
+          Number(blockNumber),
+        );
+        setController(_controller);
+      }
     };
     const readLastPage = async () => {
       const _controller = await SearchController.lastPage(provider, address);

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -112,13 +112,23 @@ const AddressTransactionResults: FC = () => {
         readFirstPage();
       }
     } else if (direction === "prev") {
-      if (controller && controller.address === address) {
+      if (
+        controller &&
+        controller.address === address &&
+        controller.startParams[0] === "prev" &&
+        controller.startParams[1] === hash
+      ) {
         prevPage();
       } else {
         readMiddlePage(false);
       }
     } else if (direction === "next") {
-      if (controller && controller.address === address) {
+      if (
+        controller &&
+        controller.address === address &&
+        controller.startParams[0] === "next" &&
+        controller.startParams[1] === hash
+      ) {
         nextPage();
       } else {
         readMiddlePage(true);

--- a/src/execution/address/AddressTransactionResults.tsx
+++ b/src/execution/address/AddressTransactionResults.tsx
@@ -115,8 +115,9 @@ const AddressTransactionResults: FC = () => {
       if (
         controller &&
         controller.address === address &&
-        controller.startParams[0] === "prev" &&
-        controller.startParams[1] === hash
+        ((controller.startParams[0] === "prev" &&
+          controller.startParams[1] === hash) ||
+          controller.isAdjacentPage(hash, "prev"))
       ) {
         prevPage();
       } else {
@@ -126,8 +127,9 @@ const AddressTransactionResults: FC = () => {
       if (
         controller &&
         controller.address === address &&
-        controller.startParams[0] === "next" &&
-        controller.startParams[1] === hash
+        ((controller.startParams[0] === "next" &&
+          controller.startParams[1] === hash) ||
+          controller.isAdjacentPage(hash, "next"))
       ) {
         nextPage();
       } else {

--- a/src/execution/address/BlockNumberInput.tsx
+++ b/src/execution/address/BlockNumberInput.tsx
@@ -1,0 +1,41 @@
+import React, { FormEvent, useState } from "react";
+
+interface BlockNumberInputProps {
+  onSearch: (blockNumber: string) => void;
+  placeholder?: string;
+}
+
+const BlockNumberInput: React.FC<BlockNumberInputProps> = ({
+  onSearch,
+  placeholder,
+}) => {
+  const [blockNumber, setBlockNumber] = useState("");
+
+  const handleSearch = (e: FormEvent) => {
+    e.preventDefault();
+    if (blockNumber.trim()) {
+      onSearch(blockNumber.trim());
+    }
+  };
+
+  return (
+    <form onSubmit={handleSearch} className="flex items-center">
+      <input
+        type="number"
+        min="0"
+        className="w-48 rounded-sm border px-2 py-1 text-sm text-gray-600"
+        value={blockNumber}
+        onChange={(e) => setBlockNumber(e.target.value)}
+        placeholder={placeholder}
+      />
+      <button
+        type="submit"
+        className="ml-2 rounded-sm border bg-skin-button-fill px-3 py-1 text-left text-sm text-skin-button hover:bg-skin-button-hover-fill"
+      >
+        Go
+      </button>
+    </form>
+  );
+};
+
+export default BlockNumberInput;

--- a/src/execution/address/BlockNumberInput.tsx
+++ b/src/execution/address/BlockNumberInput.tsx
@@ -23,7 +23,7 @@ const BlockNumberInput: React.FC<BlockNumberInputProps> = ({
       <input
         type="number"
         min="0"
-        className="w-48 rounded-sm border px-2 py-1 text-sm text-gray-600"
+        className="w-42 rounded-sm border px-2 py-1 text-sm text-gray-600 input-number-no-arrows"
         value={blockNumber}
         onChange={(e) => setBlockNumber(e.target.value)}
         placeholder={placeholder}

--- a/src/index.css
+++ b/src/index.css
@@ -100,3 +100,7 @@
     @apply dark-no-invert;
   }
 }
+
+@utility input-number-no-arrows {
+  @apply [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none;
+}

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -255,15 +255,8 @@ export class SearchController {
           ? SearchController.lastPage(provider, address, startParams)
           : SearchController.firstPage(provider, address, startParams);
       }
-      blockTxs = blockQuery!.txs.filter(
-        (blockTx) => blockTx!.blockNumber === blockNumber,
-      );
-
-      blockBatchIsEnd =
-        (blockQuery!.txs.length === 0 ||
-          blockQuery!.txs[next ? blockQuery!.txs.length - 1 : 0].blockNumber ===
-            blockNumber) &&
-        (next ? blockQuery!.lastPage : blockQuery!.firstPage);
+      blockTxs = blockQuery!.txs;
+      blockBatchIsEnd = next ? blockQuery!.lastPage : blockQuery!.firstPage;
     } else {
       throw new Error("Transaction hash or block number not provided");
     }

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -220,7 +220,7 @@ export class SearchController {
           provider,
           address,
           0,
-          next ? "before" : "after",
+          next ? "after" : "before",
         ),
       );
       if (next) {
@@ -228,25 +228,23 @@ export class SearchController {
         txs = txs.concat(blockTxs);
         batches.push({
           length: blockTxs.length,
-          isFirst:
-            blockQuery!.firstPage ||
-            (pageEndsQuery.txs!.length > 0 &&
-              blockTxs[0].hash === pageEndsQuery.txs[0].hash &&
-              pageEndsQuery.firstPage),
-          isLast: blockQuery!.lastPage,
+          isFirst: blockQuery!.firstPage,
+          isLast:
+            pageEndsQuery.txs!.length > 0 &&
+            blockTxs[blockTxs.length - 1].hash ===
+              pageEndsQuery.txs[pageEndsQuery.txs.length - 1].hash &&
+            pageEndsQuery.lastPage,
         });
       } else {
         // Add transactions from this block
         txs = blockTxs.concat(txs);
         batches.unshift({
           length: blockTxs.length,
-          isFirst: blockQuery!.firstPage,
-          isLast:
-            blockQuery!.lastPage ||
-            (pageEndsQuery.txs!.length > 0 &&
-              blockTxs[blockTxs.length - 1].hash ===
-                pageEndsQuery.txs[pageEndsQuery.txs.length - 1].hash &&
-              pageEndsQuery.lastPage),
+          isFirst:
+            pageEndsQuery.txs!.length > 0 &&
+            blockTxs[0].hash === pageEndsQuery.txs[0].hash &&
+            pageEndsQuery.firstPage,
+          isLast: blockQuery!.lastPage,
         });
       }
     }

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -328,6 +328,23 @@ export class SearchController {
     return this.txs.slice(this.pageStart, this.pageEnd);
   }
 
+  /**
+    Returns true if navigating toward `direction` with the given hash is an
+    adjacent page navigation.
+
+    @param hash Hash to check
+    @param direction Direction of proposed navigation
+    @return True if "hash" is on the current page at the `direction` end
+  */
+  isAdjacentPage(hash: string | null, direction: "next" | "prev") {
+    return (
+      hash !== null &&
+      (direction === "prev"
+        ? this.txs[this.pageStart].hash === hash
+        : this.txs[this.pageEnd - 1].hash === hash)
+    );
+  }
+
   async prevPage(
     provider: JsonRpcApiProvider,
     hash: string,
@@ -337,8 +354,7 @@ export class SearchController {
       return this;
     }
     // Ensure we are navigating correctly relative to our current transaction listing
-    // I think this tries to prevent navigating multiple times in a row to the same page.
-    if (this.txs[this.pageStart].hash === hash) {
+    if (this.isAdjacentPage(hash, "prev")) {
       if (
         this.pageStart - PAGE_SIZE >= 0 ||
         (this.batches.length > 0 && this.batches[0].isFirst)
@@ -405,8 +421,7 @@ export class SearchController {
       return this;
     }
     // Ensure we are navigating correctly relative to our current transaction listing
-    // I think this tries to prevent navigating multiple times in a row to the same page.
-    if (this.txs[this.pageEnd - 1].hash === hash) {
+    if (this.isAdjacentPage(hash, "next")) {
       if (
         this.pageEnd + PAGE_SIZE <= this.txs.length ||
         (this.batches.length > 0 &&

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -114,17 +114,20 @@ interface TransactionBatch {
   isLast: boolean;
 }
 
-type StartParamsType = ["next" | "prev" | "first" | "last", string | null];
+interface StartParams {
+  pageType: "next" | "prev" | "first" | "last";
+  tx: string | null;
+  blockNumber?: number;
+}
 
 export class SearchController {
   // Guaranteed to include all transactions in the starting and ending blocks
   private txs: ProcessedTransaction[];
-
   private pageStart: number;
   private pageEnd: number;
   public isFirst: boolean;
   public isLast: boolean;
-  public startParams: StartParamsType;
+  public startParams: StartParams;
 
   private constructor(
     readonly address: string,
@@ -132,7 +135,7 @@ export class SearchController {
     readonly batches: TransactionBatch[],
     // if true, starts at index 0, otherwise considers the "last" parts of the transactions
     boundToStart: boolean,
-    startParams: StartParamsType,
+    startParams: StartParams,
     pageStartIndex?: number,
     pageEndIndex?: number,
   ) {
@@ -158,6 +161,7 @@ export class SearchController {
   static async firstPage(
     provider: JsonRpcApiProvider,
     address: string,
+    startParamsOverride?: StartParams,
   ): Promise<SearchController> {
     const newTxs: TransactionChunk = await queryClient.fetchQuery(
       searchTransactionsQuery(provider, address, 0, "before"),
@@ -173,7 +177,7 @@ export class SearchController {
         },
       ],
       true,
-      ["first", ""],
+      startParamsOverride ?? { pageType: "first", tx: null },
     );
   }
 
@@ -186,17 +190,22 @@ export class SearchController {
   ): Promise<SearchController> {
     const prev = !next;
 
-    if (hash === "") {
-      // Start from the beginning
-      return next
-        ? SearchController.lastPage(provider, address)
-        : SearchController.firstPage(provider, address);
-    }
+    const startParams: StartParams = {
+      pageType: next ? "next" : "prev",
+      tx: hash,
+      blockNumber: hash === null ? blockNumberBegin : undefined,
+    };
 
     // See if there are more transactions from this block we must include
     let blockQuery: TransactionChunk | null = null;
+    // If a tx hash is provided, only contains transactions in the tx's block
+    // If a block number is provided, contains all the transactions from the
+    // query
     let blockTxs: ProcessedTransaction[] = [];
     let blockNumber: number;
+
+    // Indicates that the target block number is the first/end
+    let blockBatchIsEnd: boolean;
 
     if (hash !== null) {
       const tx = await queryClient.fetchQuery(
@@ -220,6 +229,13 @@ export class SearchController {
         blockTxs = blockQuery!.txs.filter(
           (blockTx) => blockTx!.blockNumber === blockNumber,
         );
+        blockBatchIsEnd =
+          (blockQuery!.txs.length === 0 ||
+            blockQuery!.txs[next ? blockQuery!.txs.length - 1 : 0]
+              .blockNumber === blockNumber) &&
+          (next ? blockQuery!.lastPage : blockQuery!.firstPage);
+      } else {
+        blockBatchIsEnd = false;
       }
     } else if (blockNumberBegin !== undefined) {
       blockNumber = blockNumberBegin;
@@ -236,9 +252,18 @@ export class SearchController {
       if (blockTxs.length === 0) {
         // Start from the beginning
         return next
-          ? SearchController.lastPage(provider, address)
-          : SearchController.firstPage(provider, address);
+          ? SearchController.lastPage(provider, address, startParams)
+          : SearchController.firstPage(provider, address, startParams);
       }
+      blockTxs = blockQuery!.txs.filter(
+        (blockTx) => blockTx!.blockNumber === blockNumber,
+      );
+
+      blockBatchIsEnd =
+        (blockQuery!.txs.length === 0 ||
+          blockQuery!.txs[next ? blockQuery!.txs.length - 1 : 0].blockNumber ===
+            blockNumber) &&
+        (next ? blockQuery!.lastPage : blockQuery!.firstPage);
     } else {
       throw new Error("Transaction hash or block number not provided");
     }
@@ -249,7 +274,7 @@ export class SearchController {
     const txBlockIndex = blockTxs.findIndex((tx) => tx.hash === hash);
     if (
       txBlockIndex != -1 ||
-      (hash === null && blockNumberBegin !== undefined)
+      (hash === null && blockNumberBegin !== undefined && blockTxs.length > 0)
     ) {
       // Make another call to verify whether this is really not the first/last page.
       // This compensates for the behavior in the ots API that if you call
@@ -261,7 +286,11 @@ export class SearchController {
           provider,
           address,
           0,
-          next ? "after" : "before",
+          // If we are navigating to the next page (older transactions), find the
+          // oldest transactions (after 0).
+          // If we are navigating to the previous page (newer transactions), find
+          // the newest transactions (before the latest block, = 0)
+          next ? "before" : "after",
         ),
       );
       if (next) {
@@ -269,45 +298,35 @@ export class SearchController {
         txs = txs.concat(blockTxs);
         batches.push({
           length: blockTxs.length,
-          isFirst: blockQuery!.firstPage,
-          isLast:
+          isFirst:
             pageEndsQuery.txs!.length > 0 &&
-            blockTxs[blockTxs.length - 1].hash ===
-              pageEndsQuery.txs[pageEndsQuery.txs.length - 1].hash &&
-            pageEndsQuery.lastPage,
+            blockTxs[0].hash === pageEndsQuery.txs[0].hash &&
+            pageEndsQuery.firstPage,
+          isLast: blockBatchIsEnd,
         });
       } else {
         // Add transactions from this block
         txs = blockTxs.concat(txs);
         batches.unshift({
           length: blockTxs.length,
-          isFirst:
+          isFirst: blockBatchIsEnd,
+          isLast:
             pageEndsQuery.txs!.length > 0 &&
-            blockTxs[0].hash === pageEndsQuery.txs[0].hash &&
-            pageEndsQuery.firstPage,
-          isLast: blockQuery!.lastPage,
+            blockTxs[blockTxs.length - 1].hash ===
+              pageEndsQuery.txs[pageEndsQuery.txs.length - 1].hash &&
+            pageEndsQuery.lastPage,
         });
       }
     }
 
+    // If tx hash is specified, add transactions after the tx's block
     if (
-      batches.length === 0 ||
-      (next && !batches[batches.length - 1].isLast) ||
-      (prev && !batches[0].isFirst)
+      hash !== null &&
+      blockNumberBegin === undefined &&
+      (batches.length === 0 ||
+        (next && !batches[batches.length - 1].isLast) ||
+        (prev && !batches[0].isFirst))
     ) {
-      // TODO: This code appears to have been unused before (blockNumber assigned but never read)
-      /*
-          // TODO: Can we actually infer that this transaction is not null?
-          let blockNumber = tx!.blockNumber!;
-          if (batches.length > 0) {
-            if (next) {
-              blockNumber = txs[txs.length - 1].blockNumber;
-            } else {
-              blockNumber = txs[0].blockNumber;
-            }
-          }
-      */
-
       const newTxs = await queryClient.fetchQuery(
         searchTransactionsQuery(
           provider,
@@ -340,7 +359,7 @@ export class SearchController {
       txs,
       batches,
       next,
-      [next ? "next" : "prev", hash],
+      startParams,
       next && txIndex != -1 ? txIndex + 1 : undefined,
       prev && txIndex != -1 ? txIndex : undefined,
     );
@@ -349,6 +368,7 @@ export class SearchController {
   static async lastPage(
     provider: JsonRpcApiProvider,
     address: string,
+    startParamsOverride?: StartParams,
   ): Promise<SearchController> {
     const newTxs = await queryClient.fetchQuery(
       searchTransactionsQuery(provider, address, 0, "after"),
@@ -364,7 +384,7 @@ export class SearchController {
         },
       ],
       false,
-      ["last", ""],
+      startParamsOverride ?? { pageType: "last", tx: null },
     );
   }
 
@@ -391,10 +411,10 @@ export class SearchController {
 
   async prevPage(
     provider: JsonRpcApiProvider,
-    hash: string,
+    hash: string | null,
   ): Promise<SearchController> {
     // Already on this page
-    if (this.startParams[0] === "prev" && this.startParams[1] === hash) {
+    if (this.startParams.pageType === "prev" && this.startParams.tx === hash) {
       return this;
     }
     // Ensure we are navigating correctly relative to our current transaction listing
@@ -409,7 +429,7 @@ export class SearchController {
           this.txs,
           this.batches,
           false,
-          ["prev", hash],
+          { pageType: "prev", tx: hash },
           undefined,
           this.pageEnd - (this.pageEnd - this.pageStart),
         );
@@ -434,12 +454,13 @@ export class SearchController {
       // which would lead to quick paging through transactions already
       // downloaded. In order to ensure firstPage is up to date, it's kept to
       // PAGE_SIZE for now.
+      const lastPageSize = this.pageEnd - this.pageStart;
       const { list: trimmedList, batches: trimmedBatches } = trimBatchesToSize(
         combinedTxList,
         batches,
         PAGE_SIZE,
         true,
-        prevPage.txs.length + this.pageEnd - PAGE_SIZE,
+        prevPage.txs.length + this.pageEnd - lastPageSize,
       );
 
       return new SearchController(
@@ -447,9 +468,9 @@ export class SearchController {
         trimmedList,
         trimmedBatches,
         false,
-        ["prev", hash],
+        { pageType: "prev", tx: hash },
         undefined,
-        prevPage.txs.length + this.pageEnd - PAGE_SIZE,
+        prevPage.txs.length + this.pageEnd - lastPageSize,
       );
     }
 
@@ -458,10 +479,10 @@ export class SearchController {
 
   async nextPage(
     provider: JsonRpcApiProvider,
-    hash: string,
+    hash: string | null,
   ): Promise<SearchController> {
     // Already on this page
-    if (this.startParams[0] === "next" && this.startParams[1] === hash) {
+    if (this.startParams.pageType === "next" && this.startParams.tx === hash) {
       return this;
     }
     // Ensure we are navigating correctly relative to our current transaction listing
@@ -477,7 +498,7 @@ export class SearchController {
           this.txs,
           this.batches,
           true,
-          ["next", hash],
+          { pageType: "next", tx: hash },
           this.pageStart + (this.pageEnd - this.pageStart),
           undefined,
         );
@@ -497,6 +518,7 @@ export class SearchController {
         },
       ];
       const combinedTxList = this.txs.concat(nextPage.txs);
+      const lastPageSize = this.pageEnd - this.pageStart;
       // TODO: We *could* save more transactions in memory than PAGE_SIZE,
       // which would lead to quick paging through transactions already
       // downloaded. In order to ensure firstPage is up to date, it's kept to
@@ -506,7 +528,7 @@ export class SearchController {
         batches,
         PAGE_SIZE,
         false,
-        this.pageStart + PAGE_SIZE,
+        this.pageStart + lastPageSize,
       );
       const txsTrimmed = combinedTxList.length - trimmedList.length;
 
@@ -515,8 +537,8 @@ export class SearchController {
         trimmedList,
         trimmedBatches,
         true,
-        ["next", hash],
-        this.pageStart + PAGE_SIZE - txsTrimmed,
+        { pageType: "next", tx: hash },
+        this.pageStart + lastPageSize - txsTrimmed,
         undefined,
       );
     }


### PR DESCRIPTION
Accepts a `?b=<block number>` query parameter for "middle" address search results, which adjusts the search controller to search starting from that block. If the block is too high/low, the first/last page is returned.

Based on top of #3317 

Closes #930 
Closes #3316