### PR TITLE
Display a "code" icon for type 4 txs

### DIFF
--- a/src/components/TransactionLink.tsx
+++ b/src/components/TransactionLink.tsx
@@ -1,6 +1,7 @@
 import {
   faExclamationCircle,
   faSplotch,
+  faSquareBinary,
   faTurnDown,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,6 +13,7 @@ type TransactionLinkProps = {
   txHash: string;
   fail?: boolean;
   blob?: boolean;
+  setCode?: boolean;
   deposit?: boolean;
 };
 
@@ -19,6 +21,7 @@ const TransactionLink: FC<TransactionLinkProps> = ({
   txHash,
   fail,
   blob,
+  setCode,
   deposit,
 }) => (
   <span className="flex-no-wrap flex space-x-1">
@@ -30,6 +33,11 @@ const TransactionLink: FC<TransactionLinkProps> = ({
     {blob && (
       <span className="text-rose-400" title="Blob transaction">
         <FontAwesomeIcon icon={faSplotch} />
+      </span>
+    )}
+    {setCode && (
+      <span className="text-blue-600" title="Set code transaction">
+        <FontAwesomeIcon icon={faSquareBinary} />
       </span>
     )}
     {deposit && (

--- a/src/search/TransactionItem.tsx
+++ b/src/search/TransactionItem.tsx
@@ -62,6 +62,7 @@ const TransactionItem: React.FC<TransactionItemProps> = ({
             txHash={tx.hash}
             fail={tx.status === 0}
             blob={tx.type === 3}
+            setCode={tx.type === 4}
             deposit={tx.type === 126}
           />
         </td>


### PR DESCRIPTION
Similar to blob txs, let's make it easier to see set code txs in the tx list