### PR TITLE
Disable CCIP off-chain reads on ENS queries by default

### DIFF
--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -208,6 +208,13 @@ export type OtterscanConfig = {
   };
 
   /**
+   * Enable off-chain CCIP reads (EIP-3368) to third parties in smart contracts
+   * that support them, during ENS lookups only. It leaks your request to the
+   * URL specified in the CCIP read, so it is disabled by default for privacy.
+   */
+  enableOffchainEnsLookups?: boolean;
+
+  /**
    * Temporary config option, until address labels are complete: Enables setting
    * address labels which are kept in local storage.
    */

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -207,12 +207,19 @@ export type OtterscanConfig = {
     l1ExplorerURL?: string;
   };
 
-  /**
-   * Enable off-chain CCIP reads (EIP-3368) to third parties in smart contracts
-   * that support them, during ENS lookups only. It leaks your request to the
-   * URL specified in the CCIP read, so it is disabled by default for privacy.
-   */
-  enableOffchainEnsLookups?: boolean;
+  externalDataSources?: {
+    ccip?: {
+      /**
+       * Enable off-chain CCIP reads (EIP-3368) to third parties in smart
+       * contracts that support them, during ENS lookups only. It leaks your
+       * request to the URL specified in the CCIP read. This should be disabled
+       * whenever privacy is desired because reverse-ENS lookups could cause
+       * CCIP requests during ordinary browsing. This feature is enabled by
+       * default.
+       */
+      ensLookups?: boolean;
+    };
+  };
 
   /**
    * Temporary config option, until address labels are complete: Enables setting

--- a/src/useRuntime.ts
+++ b/src/useRuntime.ts
@@ -43,17 +43,19 @@ export const createRuntime = async (
   const effectiveConfig = await config;
 
   // Hardcoded config
+  let provider: JsonRpcApiProvider;
   if (effectiveConfig.experimentalFixedChainId !== undefined) {
     const network = Network.from(effectiveConfig.experimentalFixedChainId);
-    return {
-      config: effectiveConfig,
-      provider: new JsonRpcProvider(effectiveConfig.erigonURL, network, {
-        staticNetwork: network,
-      }),
-    };
+    provider = new JsonRpcProvider(effectiveConfig.erigonURL, network, {
+      staticNetwork: network,
+    });
+  } else {
+    provider = await createAndProbeProvider(effectiveConfig.erigonURL);
   }
 
-  const provider = await createAndProbeProvider(effectiveConfig.erigonURL);
+  provider.disableCcipRead = !(
+    effectiveConfig.enableOffchainEnsLookups ?? false
+  );
   return {
     config: effectiveConfig,
     provider,

--- a/src/useRuntime.ts
+++ b/src/useRuntime.ts
@@ -54,7 +54,7 @@ export const createRuntime = async (
   }
 
   provider.disableCcipRead = !(
-    effectiveConfig.enableOffchainEnsLookups ?? false
+    effectiveConfig.externalDataSources?.ccip?.ensLookups ?? true
   );
   return {
     config: effectiveConfig,


### PR DESCRIPTION
Closes #3330

I could not find the off-chain reverse lookup that was triggering CCIP reads during regular browsing, but I remember seeing these requests before. To test, try going to `nick.base.eth` or `jesse.cb.id` on the develop branch and see in the networking dev tools tab that it makes queries to Coinbase. Then, try the same in this PR. The name resolution should fail and no external lookups are attempted.

You can restore the CCIP read functionality (for ENS lookups only) in the config with the `enableOffchainEnsLookups` key, though I wonder if there's a better key name or section we can use, like "privacy".