### PR TITLE
Move local contract verification settings under `sourcify` key

### DIFF
--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -136,7 +136,8 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
                 }
               />
 
-              {config.EXPERIMENTAL_localContractReverification === true && (
+              {config.sourcify?.localContractVerification?.enabled !==
+                false && (
                 <>
                   {!showLocalVerification && (
                     <>

--- a/src/execution/address/contract/ContractVerificationSteps.tsx
+++ b/src/execution/address/contract/ContractVerificationSteps.tsx
@@ -122,7 +122,7 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
 
   const { provider, config } = useContext(RuntimeContext);
   const compilerBaseUrl =
-    config.externalDataSources?.contractCompilerBaseURL ??
+    config.sourcify?.localContractVerification?.contractCompilerBaseURL ??
     "https://binaries.soliditylang.org";
 
   useEffect(() => {

--- a/src/useConfig.ts
+++ b/src/useConfig.ts
@@ -178,6 +178,21 @@ export type OtterscanConfig = {
         backendFormat: string;
       };
     };
+
+    /**
+     * Feature on the Contract page for recompiling and reverifying contracts locally
+     */
+    localContractVerification?: {
+      /**
+       * The root URL for downloading Solidity compilers for local contract
+       * verification. Defaults to "https://binaries.soliditylang.org".
+       */
+      contractCompilerBaseURL?: string;
+      /**
+       * If set to false, disables the feature.
+       */
+      enabled?: boolean;
+    };
   };
 
   /**
@@ -208,26 +223,10 @@ export type OtterscanConfig = {
   };
 
   /**
-   * External data sources
-   */
-  externalDataSources?: {
-    /**
-     * The root URL for downloading Solidity compilers for local contract
-     * verification. Defaults to "https://binaries.soliditylang.org".
-     */
-    contractCompilerBaseURL?: string;
-  };
-
-  /**
    * Temporary config option, until address labels are complete: Enables setting
    * address labels which are kept in local storage.
    */
   WIP_customAddressLabels?: boolean;
-
-  /**
-   * Temporary config option: Enables local re-verification of contracts.
-   */
-  EXPERIMENTAL_localContractReverification?: boolean;
 };
 
 /**


### PR DESCRIPTION
Changes the location of the local contract verification settings in the config for https://github.com/otterscan/otterscan-book/pull/41