### PR TITLE
Add contributor guide (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,13 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - Source: TypeScript + React in `src/`. Key subfolders: `components/`, `execution/`, `search/`, `utils/`; hooks follow `use*.ts(x)`. UI stories live alongside code as `*.stories.tsx`.
 - Assets & config: `public/` (static), `.storybook/` (Storybook), `docs/`, `nginx/`, `dist/` (build output).
 - Tests: Unit tests co-located as `*.test.ts(x)`; E2E specs in `cypress/e2e/`.
 
 ## Build, Test, and Development Commands
+
 - `npm start`: Run Vite dev server at `http://localhost:5173`.
 - `npm run start-devnet`: Start with local devnet config (`VITE_CONFIG_JSON`).
 - `npm run build`: Type-check then build production bundle to `dist/`.
@@ -16,31 +18,37 @@
 - Docker helpers: `docker-build`, `docker-start`, `docker-hub-start`, and matching `*-stop`.
 
 ## Coding Style & Naming Conventions
+
 - Language: TypeScript + React 19 (Vite); Tailwind CSS enabled.
 - Formatting: Prettier with organize-imports. Run `npx prettier -w .` before pushing.
 - Linting: ESLint extends `react-app` defaults.
 - Naming: Components in `PascalCase` (`ComponentName.tsx`), hooks prefixed `use*`, utilities in `utils/`, tests `*.test.ts(x)` beside subjects.
 
 ## Testing Guidelines
+
 - Unit: Jest via `ts-jest` (`testEnvironment: node`). Keep tests near code; focus on edge cases.
 - E2E: Cypress in `cypress/e2e/`. Ensure dev server is reachable; for devnet flows, verify Erigon/Sourcify endpoints in `cypress.config.ts`.
 - Visuals: Update Storybook stories for UI changes.
 
 ## Commit & Pull Request Guidelines
+
 - Commits: Short, imperative, descriptive (e.g., "Fix spacing in validator view"). Version bumps: "Bump <pkg> from A to B (#PR)".
 - PRs: Clear description, linked issues, and screenshots/videos for UI changes. Note config/env impacts. Keep diffs focused and pass CI (build + tests).
 
 ## Security & Configuration Tips
+
 - Never commit secrets. Use `.env.*`; Vite reads `VITE_*` at build time.
 - For local devnet, set `DEVNET_ERIGON_URL` and `DEVNET_SOURCIFY_SOURCE` per `cypress.config.ts`.
 
 ## Architecture Overview
+
 - Client-only SPA: Built to static assets in `dist/` and served via `nginx/` or any static host; all data fetched at runtime.
 - Data sources: Ethereum JSON-RPC (optimized for Erigon performance/features) and Sourcify for verified contract metadata/ABIs.
 - No backend: Business logic lives in `src/` — `search/` for lookups, `execution/` for call/trace decoding, reusable UI in `components/`.
 - Configuration: Endpoints provided via `VITE_*` env vars; devnet defaults and helpers live in `cypress.config.ts`.
 
 ## External Docs
+
 - Reference: https://docs.otterscan.io/
 - Coverage: Architecture, data sources (Erigon/Sourcify), deployment, configuration.
 - Contributions: When changing APIs, flows, or UX, update external docs and related Storybook stories.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,14 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-
-- Source: `src/` (React + TypeScript). Notable subfolders: `components/`, `execution/`, `search/`, `utils/`, hooks like `use*.ts(x)`. UI stories live alongside code as `*.stories.tsx`.
-- Assets: `public/` (static), `.storybook/` (Storybook config), `docs/` (project docs), `nginx/` (container config), `dist/` (build output).
-- Tests: Unit tests co-located in `src/` as `*.test.ts(x)`; E2E specs under `cypress/e2e/`.
+- Source: TypeScript + React in `src/`. Key subfolders: `components/`, `execution/`, `search/`, `utils/`; hooks follow `use*.ts(x)`. UI stories live alongside code as `*.stories.tsx`.
+- Assets & config: `public/` (static), `.storybook/` (Storybook), `docs/`, `nginx/`, `dist/` (build output).
+- Tests: Unit tests co-located as `*.test.ts(x)`; E2E specs in `cypress/e2e/`.
 
 ## Build, Test, and Development Commands
-
 - `npm start`: Run Vite dev server at `http://localhost:5173`.
 - `npm run start-devnet`: Start with local devnet config (`VITE_CONFIG_JSON`).
-- `npm run build`: Type-check then build production bundle into `dist/`.
+- `npm run build`: Type-check then build production bundle to `dist/`.
 - `npm run preview`: Serve the built app locally.
 - `npm test`: Run Jest unit tests.
 - `npm run storybook` / `npm run build-storybook`: Run/build component docs.
@@ -18,24 +16,31 @@
 - Docker helpers: `docker-build`, `docker-start`, `docker-hub-start`, and matching `*-stop`.
 
 ## Coding Style & Naming Conventions
-
-- Language: TypeScript + React 19, Vite.
-- Formatting: Prettier with organize-imports; Tailwind CSS is enabled. Run `npx prettier -w .` before pushing.
+- Language: TypeScript + React 19 (Vite); Tailwind CSS enabled.
+- Formatting: Prettier with organize-imports. Run `npx prettier -w .` before pushing.
 - Linting: ESLint extends `react-app` defaults.
-- Naming: Components in `PascalCase` (`ComponentName.tsx`), hooks prefixed `use*`, utilities under `utils/`, tests `*.test.ts(x)` next to subjects.
+- Naming: Components in `PascalCase` (`ComponentName.tsx`), hooks prefixed `use*`, utilities in `utils/`, tests `*.test.ts(x)` beside subjects.
 
 ## Testing Guidelines
-
-- Unit: Jest via `ts-jest` (`testEnvironment: node`). Place tests beside code: `thing.test.ts`.
-- E2E: Cypress under `cypress/e2e/`. Ensure the dev server is reachable and, for devnet flows, Erigon/Sourcify endpoints from `cypress.config.ts` are available.
-- Add tests for new logic and edge cases; update Storybook stories for visual changes.
+- Unit: Jest via `ts-jest` (`testEnvironment: node`). Keep tests near code; focus on edge cases.
+- E2E: Cypress in `cypress/e2e/`. Ensure dev server is reachable; for devnet flows, verify Erigon/Sourcify endpoints in `cypress.config.ts`.
+- Visuals: Update Storybook stories for UI changes.
 
 ## Commit & Pull Request Guidelines
-
-- Messages: Short, imperative, and descriptive (e.g., "Fix spacing in validator view"). Version bumps typically follow "Bump <pkg> from A to B (#PR)".
-- PRs: Include clear description, linked issues, and screenshots or videos for UI changes. Note any config/env impacts. Keep diffs focused and pass CI (build + tests).
+- Commits: Short, imperative, descriptive (e.g., "Fix spacing in validator view"). Version bumps: "Bump <pkg> from A to B (#PR)".
+- PRs: Clear description, linked issues, and screenshots/videos for UI changes. Note config/env impacts. Keep diffs focused and pass CI (build + tests).
 
 ## Security & Configuration Tips
+- Never commit secrets. Use `.env.*`; Vite reads `VITE_*` at build time.
+- For local devnet, set `DEVNET_ERIGON_URL` and `DEVNET_SOURCIFY_SOURCE` per `cypress.config.ts`.
 
-- Do not commit secrets. Use `.env.*` locally (Vite reads `VITE_*` at build time).
-- For local devnet, confirm `DEVNET_ERIGON_URL` and `DEVNET_SOURCIFY_SOURCE` (see `cypress.config.ts`).
+## Architecture Overview
+- Client-only SPA: Built to static assets in `dist/` and served via `nginx/` or any static host; all data fetched at runtime.
+- Data sources: Ethereum JSON-RPC (optimized for Erigon performance/features) and Sourcify for verified contract metadata/ABIs.
+- No backend: Business logic lives in `src/` — `search/` for lookups, `execution/` for call/trace decoding, reusable UI in `components/`.
+- Configuration: Endpoints provided via `VITE_*` env vars; devnet defaults and helpers live in `cypress.config.ts`.
+
+## External Docs
+- Reference: https://docs.otterscan.io/
+- Coverage: Architecture, data sources (Erigon/Sourcify), deployment, configuration.
+- Contributions: When changing APIs, flows, or UX, update external docs and related Storybook stories.


### PR DESCRIPTION
Adds AGENTS.md with a concise contributor guide: project structure, build/test/dev commands, style and naming, testing, commits/PRs, security/config notes, and links to external docs. Also adds a brief Architecture Overview.\n\nDocs: https://docs.otterscan.io/\n\nCI: No code changes; just docs.