### PR TITLE
Save local verifications to storage and show check

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -4,17 +4,19 @@ import React from "react";
 
 interface AlertProps {
   className?: string;
+  margin?: string;
   icon?: IconDefinition;
   children?: React.ReactNode;
 }
 
 const Alert: React.FC<AlertProps> = ({
   className = "bg-orange-100 border-orange-500 text-orange-700",
+  margin = "mb-4 mt-2",
   icon,
   children,
 }) => (
   <div
-    className={`${className} border-l-4 px-3 py-2.5 mb-4 rounded-sm mt-2 border-t-0 border-b-0`}
+    className={` ${className} ${margin} border-l-4 px-3 py-2.5 rounded-sm border-t-0 border-b-0`}
     role="alert"
   >
     {icon && <FontAwesomeIcon icon={icon} className="mr-2" />}

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -12,6 +12,7 @@ import { useProxyAttributes } from "../ots2/usePrototypeTransferHooks";
 import SourcifyLogo from "../sourcify/SourcifyLogo";
 import { Match, useSourcifyMetadata } from "../sourcify/useSourcify";
 import { useWhatsabiMetadata } from "../sourcify/useWhatsabi";
+import { useIsLocallyVerified } from "../storage/CheckedContractStorage";
 import { ChecksummedAddress } from "../types";
 import { hasCodeQuery } from "../useErigonHooks";
 import { useAddressOrENS } from "../useResolvedAddresses";
@@ -23,13 +24,18 @@ const ProxyTabs: React.FC<AddressAwareComponentProps> = ({ address }) => {
   const { addressOrName } = useParams();
   const { provider } = useContext(RuntimeContext);
   const proxyAttrs = useProxyAttributes(provider, address);
+  const isLocallyVerified = useIsLocallyVerified(
+    proxyAttrs.proxyMatch,
+    provider._network.chainId,
+    address,
+  );
   return (
     <>
       {proxyAttrs.proxyHasCode && proxyAttrs.proxyMatch && (
         <NavTab href={`/address/${addressOrName}/proxyLogicContract`}>
           <span className={`flex items-baseline space-x-2`}>
             <span>Logic Contract</span>
-            <SourcifyLogo />
+            <SourcifyLogo locallyVerified={isLocallyVerified} />
           </span>
         </NavTab>
       )}
@@ -81,6 +87,11 @@ const AddressMainPage: React.FC = () => {
   const match = useSourcifyMetadata(
     hasCode ? checksummedAddress : undefined,
     provider._network.chainId,
+  );
+  const isLocallyVerified = useIsLocallyVerified(
+    match,
+    provider._network.chainId,
+    checksummedAddress,
   );
   const whatsabiMatch = useWhatsabiMetadata(
     match === null && hasCode ? checksummedAddress : undefined,
@@ -151,7 +162,7 @@ const AddressMainPage: React.FC = () => {
                           </span>
                         ) : (
                           <span className="self-center">
-                            <SourcifyLogo />
+                            <SourcifyLogo locallyVerified={isLocallyVerified} />
                           </span>
                         )}
                       </span>

--- a/src/execution/address/ContractFromRepo.tsx
+++ b/src/execution/address/ContractFromRepo.tsx
@@ -1,7 +1,8 @@
-import { faCircleNotch } from "@fortawesome/free-solid-svg-icons";
+import { faCircleNotch, faWarning } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import { DecorationOptions } from "shiki";
+import Alert from "../../components/Alert";
 import { MatchType, useContract } from "../../sourcify/useSourcify";
 import { useAppConfigContext } from "../../useAppConfig";
 import HighlightedSource from "./contract/HighlightedSource";
@@ -26,7 +27,7 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
   decorations,
 }) => {
   const { sourcifySource } = useAppConfigContext();
-  const content = useContract(
+  const { source: content, failedHashCheck } = useContract(
     checksummedAddress,
     networkId,
     filename,
@@ -49,11 +50,23 @@ const ContractFromRepo: React.FC<ContractFromRepoProps> = ({
         </div>
       )}
       {content !== undefined && (
-        <HighlightedSource
-          source={content}
-          langName={langName}
-          decorations={decorations}
-        />
+        <>
+          {failedHashCheck && (
+            <Alert
+              className="bg-red-100 border-red-500 text-red-700"
+              margin=""
+              icon={faWarning}
+            >
+              This source might be incorrect and should not be trusted. Its hash
+              does not match the hash found in the contract metadata.
+            </Alert>
+          )}
+          <HighlightedSource
+            source={content}
+            langName={langName}
+            decorations={decorations}
+          />
+        </>
       )}
     </>
   );

--- a/src/execution/address/Contracts.tsx
+++ b/src/execution/address/Contracts.tsx
@@ -287,6 +287,12 @@ const Contracts: React.FC<ContractsProps> = ({ checksummedAddress, match }) => {
                 </Menu>
                 {selected && match.metadata.sources[selected] && (
                   <>
+                    {/* Note for contract content verification: If the metadata
+                        specifies `useLiteralContent: true`, we assume the
+                        content has already been checked as part of local
+                        contract verification. See
+                        0x9641d764fc13c8B624c04430C7356C1C7C8102e2 on Hoodi as
+                        an example. */}
                     {match.metadata.sources[selected].content ? (
                       <HighlightedSource
                         source={match.metadata.sources[selected].content}

--- a/src/execution/address/contract/ContractVerificationSteps.tsx
+++ b/src/execution/address/contract/ContractVerificationSteps.tsx
@@ -185,6 +185,7 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
         const originalMetadata = structuredClone(metadata);
         originalMetadataHash =
           await CheckedContractStorage.hashMetadata(originalMetadata);
+        console.log("Metadata hash:", originalMetadataHash);
       } catch (e) {
         console.error("Error calculating metadata hash:", e);
       }

--- a/src/execution/address/contract/ContractVerificationSteps.tsx
+++ b/src/execution/address/contract/ContractVerificationSteps.tsx
@@ -27,6 +27,7 @@ import {
   transformContractResponse,
   useSourcifySources,
 } from "../../../sourcify/useSourcify";
+import CheckedContractStorage from "../../../storage/CheckedContractStorage";
 import { useAppConfigContext } from "../../../useAppConfig";
 import { RuntimeContext } from "../../../useRuntime";
 import VerificationStatus from "./VerificationStatus";
@@ -179,6 +180,7 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
       }
 
       const sources = match.metadata.sources;
+      const chainId = provider._network.chainId;
       try {
         for (const filename in sources) {
           if (Object.prototype.hasOwnProperty.call(sources, filename)) {
@@ -188,7 +190,7 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
                 sourcifySources,
                 sourcifySource,
                 address,
-                provider._network.chainId,
+                chainId,
                 filename,
                 sources[filename].keccak256,
                 match.type,
@@ -317,6 +319,13 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
       console.log("Verification result:", exportedVerification);
       const runtimeMatch = exportedVerification.status.runtimeMatch;
       const creationMatch = exportedVerification.status.creationMatch;
+
+      if (runtimeMatch === "partial" || runtimeMatch === "perfect") {
+        // Save result in local storage
+        CheckedContractStorage.hashMetadata(metadata).then((metadataHash) =>
+          CheckedContractStorage.save(chainId, address, metadataHash),
+        );
+      }
 
       setResult({
         node:

--- a/src/execution/address/contract/ContractVerificationSteps.tsx
+++ b/src/execution/address/contract/ContractVerificationSteps.tsx
@@ -169,7 +169,7 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
         });
         return;
       }
-      const metadata = match.metadata as unknown as Metadata;
+      const metadata = structuredClone(match.metadata as unknown as Metadata);
       if (!metadata) {
         updateStep(0, { inProgress: false, completed: false, hasError: true });
         setResult({
@@ -179,7 +179,17 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
         return;
       }
 
-      const sources = match.metadata.sources;
+      // Preserve the metadata hash before the sources field is manipulated
+      let originalMetadataHash: string | null = null;
+      try {
+        const originalMetadata = structuredClone(metadata);
+        originalMetadataHash =
+          await CheckedContractStorage.hashMetadata(originalMetadata);
+      } catch (e) {
+        console.error("Error calculating metadata hash:", e);
+      }
+
+      const sources = metadata.sources;
       const chainId = provider._network.chainId;
       try {
         for (const filename in sources) {
@@ -322,9 +332,9 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
 
       if (runtimeMatch === "partial" || runtimeMatch === "perfect") {
         // Save result in local storage
-        CheckedContractStorage.hashMetadata(metadata).then((metadataHash) =>
-          CheckedContractStorage.save(chainId, address, metadataHash),
-        );
+        if (originalMetadataHash !== null) {
+          CheckedContractStorage.save(chainId, address, originalMetadataHash);
+        }
       }
 
       setResult({

--- a/src/execution/address/contract/ContractVerificationSteps.tsx
+++ b/src/execution/address/contract/ContractVerificationSteps.tsx
@@ -336,6 +336,11 @@ const ContractVerificationSteps: React.FC<ContractVerificationStepsProps> = ({
         if (originalMetadataHash !== null) {
           CheckedContractStorage.save(chainId, address, originalMetadataHash);
         }
+
+        // Invalidate any queries with this chain ID and address to refresh tab logo
+        await queryClient.invalidateQueries({
+          queryKey: ["locallyVerified", chainId.toString(), address],
+        });
       }
 
       setResult({

--- a/src/execution/address/renderer/VerifiedContractName.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.tsx
@@ -1,11 +1,7 @@
-import { Metadata } from "@ethereum-sourcify/lib-sourcify";
-import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, useContext, useEffect, useState } from "react";
+import { FC, useContext } from "react";
 import { NavLink } from "react-router";
 import { ResolvedAddressRenderer } from "../../../api/address-resolver/address-resolver";
 import { useSourcifyMetadata } from "../../../sourcify/useSourcify";
-import CheckedContractStorage from "../../../storage/CheckedContractStorage";
 import { RuntimeContext } from "../../../useRuntime";
 
 type VerifiedContractNameProps = {
@@ -25,36 +21,8 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
 }) => {
   const { provider } = useContext(RuntimeContext);
   const match = useSourcifyMetadata(address, provider._network.chainId);
-  const [locallyVerified, setLocallyVerified] = useState<boolean>(false);
 
-  useEffect(() => {
-    // Check whether we locally verified this contract
-    if (match) {
-      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
-      if (savedMetadataHash !== null) {
-        // TODO: Find reason our Metadata type is not compatible with Sourcify's
-        CheckedContractStorage.hashMetadata(
-          match.metadata as unknown as Metadata,
-        ).then((metadataHash) => {
-          if (metadataHash === savedMetadataHash) {
-            setLocallyVerified(true);
-          }
-        });
-      }
-    }
-  }, [match]);
-
-  const contents = (
-    <>
-      {resolvedName}
-      {locallyVerified ? (
-        <FontAwesomeIcon
-          className="ml-1 self-center text-emerald-500"
-          icon={faCheckCircle}
-        />
-      ) : null}
-    </>
-  );
+  const contents = <>{resolvedName}</>;
   const title = `Verified Contract (${resolvedName}): ${address}`;
   if (linkable) {
     return (

--- a/src/execution/address/renderer/VerifiedContractName.tsx
+++ b/src/execution/address/renderer/VerifiedContractName.tsx
@@ -1,6 +1,12 @@
-import { FC } from "react";
+import { Metadata } from "@ethereum-sourcify/lib-sourcify";
+import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { FC, useContext, useEffect, useState } from "react";
 import { NavLink } from "react-router";
 import { ResolvedAddressRenderer } from "../../../api/address-resolver/address-resolver";
+import { useSourcifyMetadata } from "../../../sourcify/useSourcify";
+import CheckedContractStorage from "../../../storage/CheckedContractStorage";
+import { RuntimeContext } from "../../../useRuntime";
 
 type VerifiedContractNameProps = {
   chainId: bigint;
@@ -17,7 +23,38 @@ const VerifiedContractName: FC<VerifiedContractNameProps> = ({
   resolvedName,
   dontOverrideColors,
 }) => {
-  const contents = <>{resolvedName}</>;
+  const { provider } = useContext(RuntimeContext);
+  const match = useSourcifyMetadata(address, provider._network.chainId);
+  const [locallyVerified, setLocallyVerified] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Check whether we locally verified this contract
+    if (match) {
+      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
+      if (savedMetadataHash !== null) {
+        // TODO: Find reason our Metadata type is not compatible with Sourcify's
+        CheckedContractStorage.hashMetadata(
+          match.metadata as unknown as Metadata,
+        ).then((metadataHash) => {
+          if (metadataHash === savedMetadataHash) {
+            setLocallyVerified(true);
+          }
+        });
+      }
+    }
+  }, [match]);
+
+  const contents = (
+    <>
+      {resolvedName}
+      {locallyVerified ? (
+        <FontAwesomeIcon
+          className="ml-1 self-center text-emerald-500"
+          icon={faCheckCircle}
+        />
+      ) : null}
+    </>
+  );
   const title = `Verified Contract (${resolvedName}): ${address}`;
   if (linkable) {
     return (

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "@ethereum-sourcify/lib-sourcify";
 import {
   faBomb,
   faBurn,
@@ -6,12 +7,13 @@ import {
   faStar,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, memo, useContext } from "react";
+import { FC, memo, useContext, useEffect, useState } from "react";
 import { NavLink } from "react-router";
 import { resolverRendererRegistry } from "../../api/address-resolver";
 import AddressLegend from "../../components/AddressLegend";
 import SourcifyLogo from "../../sourcify/SourcifyLogo";
 import { useSourcifyMetadata } from "../../sourcify/useSourcify";
+import CheckedContractStorage from "../../storage/CheckedContractStorage";
 import { AddressContext, ChecksummedAddress, ZERO_ADDRESS } from "../../types";
 import { useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
@@ -47,7 +49,26 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
   plain,
 }) => {
   const { config, provider } = useContext(RuntimeContext);
-  const match = useSourcifyMetadata(address, provider._network.chainId);
+  const chainId = provider._network.chainId;
+  const match = useSourcifyMetadata(address, chainId);
+  const [locallyVerified, setLocallyVerified] = useState<boolean>(false);
+
+  useEffect(() => {
+    // Check whether we locally verified this contract
+    if (match) {
+      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
+      if (savedMetadataHash !== null) {
+        // TODO: Find reason our Metadata type is not compatible with Sourcify's
+        CheckedContractStorage.hashMetadata(
+          match.metadata as unknown as Metadata,
+        ).then((metadataHash) => {
+          if (metadataHash === savedMetadataHash) {
+            setLocallyVerified(true);
+          }
+        });
+      }
+    }
+  }, [match]);
 
   const mint = addressCtx === AddressContext.FROM && address === ZERO_ADDRESS;
   const burn = addressCtx === AddressContext.TO && address === ZERO_ADDRESS;
@@ -98,7 +119,7 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
           className="flex shrink-0 items-center self-center"
           to={`/address/${address}/contract`}
         >
-          <SourcifyLogo />
+          <SourcifyLogo locallyVerified={locallyVerified} />
         </NavLink>
       )}
       {plain ? (

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -64,6 +64,13 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
         ).then((metadataHash) => {
           if (metadataHash === savedMetadataHash) {
             setLocallyVerified(true);
+          } else {
+            console.warn(
+              "Mismatched metadata compared to locally verified: got",
+              metadataHash,
+              "but locally verified =",
+              savedMetadataHash,
+            );
           }
         });
       }

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -66,7 +66,9 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
             setLocallyVerified(true);
           } else {
             console.warn(
-              "Mismatched metadata compared to locally verified: got",
+              "For",
+              address,
+              "mismatched metadata compared to locally verified: got",
               metadataHash,
               "but locally verified =",
               savedMetadataHash,

--- a/src/execution/components/DecoratedAddressLink.tsx
+++ b/src/execution/components/DecoratedAddressLink.tsx
@@ -1,4 +1,3 @@
-import { Metadata } from "@ethereum-sourcify/lib-sourcify";
 import {
   faBomb,
   faBurn,
@@ -7,13 +6,13 @@ import {
   faStar,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FC, memo, useContext, useEffect, useState } from "react";
+import { FC, memo, useContext } from "react";
 import { NavLink } from "react-router";
 import { resolverRendererRegistry } from "../../api/address-resolver";
 import AddressLegend from "../../components/AddressLegend";
 import SourcifyLogo from "../../sourcify/SourcifyLogo";
 import { useSourcifyMetadata } from "../../sourcify/useSourcify";
-import CheckedContractStorage from "../../storage/CheckedContractStorage";
+import { useIsLocallyVerified } from "../../storage/CheckedContractStorage";
 import { AddressContext, ChecksummedAddress, ZERO_ADDRESS } from "../../types";
 import { useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
@@ -51,33 +50,7 @@ const DecoratedAddressLink: FC<DecoratedAddressLinkProps> = ({
   const { config, provider } = useContext(RuntimeContext);
   const chainId = provider._network.chainId;
   const match = useSourcifyMetadata(address, chainId);
-  const [locallyVerified, setLocallyVerified] = useState<boolean>(false);
-
-  useEffect(() => {
-    // Check whether we locally verified this contract
-    if (match) {
-      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
-      if (savedMetadataHash !== null) {
-        // TODO: Find reason our Metadata type is not compatible with Sourcify's
-        CheckedContractStorage.hashMetadata(
-          match.metadata as unknown as Metadata,
-        ).then((metadataHash) => {
-          if (metadataHash === savedMetadataHash) {
-            setLocallyVerified(true);
-          } else {
-            console.warn(
-              "For",
-              address,
-              "mismatched metadata compared to locally verified: got",
-              metadataHash,
-              "but locally verified =",
-              savedMetadataHash,
-            );
-          }
-        });
-      }
-    }
-  }, [match]);
+  const locallyVerified = useIsLocallyVerified(match, chainId, address);
 
   const mint = addressCtx === AddressContext.FROM && address === ZERO_ADDRESS;
   const burn = addressCtx === AddressContext.TO && address === ZERO_ADDRESS;

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -10,7 +10,7 @@ interface SourcifyLogoProps {
 const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
   const title = locallyVerified ? "Locally verified" : "Verified by Sourcify";
   return (
-    <div className="relative inline-block">
+    <div className="relative">
       <img
         src={SourcifyIcon}
         alt="Sourcify logo"

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -17,6 +17,7 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         title={title}
         width={16}
         height={16}
+        className="min-w-[16px] min-h-[16px]"
       />
       {locallyVerified && (
         <div title={title}>

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -23,11 +23,11 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         <div title={title}>
           {/* Draws a white circle behind to ensure the checkmark is white */}
           <FontAwesomeIcon
-            className="absolute bottom-[0.5px] right-[-3.2px] ml-1 text-white dark:text-black text-[5.1pt]"
+            className="absolute bottom-[0.4px] right-[-1.2px] ml-1 text-white dark:text-black text-[4.6pt]"
             icon={faCircle}
           />
           <FontAwesomeIcon
-            className="absolute bottom-0 right-[-3.5px] text-emerald-500 text-[5.5pt]"
+            className="absolute bottom-0 right-[-1.5px] text-emerald-500 text-[5pt]"
             icon={faCheckCircle}
           />
         </div>

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -22,11 +22,11 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         <div title={title}>
           {/* Draws a white circle behind to ensure the checkmark is white */}
           <FontAwesomeIcon
-            className="absolute bottom-0 right-[-2px] ml-1 text-white text-[7pt]"
+            className="absolute bottom-0 right-[-2px] ml-1 text-white dark:text-black text-[5.6pt]"
             icon={faCircle}
           />
           <FontAwesomeIcon
-            className="absolute bottom-0 right-[-2px] ml-1 text-emerald-500 text-[8pt]"
+            className="absolute bottom-0 right-[-2px] text-emerald-500 text-[6pt]"
             icon={faCheckCircle}
           />
         </div>

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -23,11 +23,11 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         <div title={title}>
           {/* Draws a white circle behind to ensure the checkmark is white */}
           <FontAwesomeIcon
-            className="absolute bottom-[0.5px] right-[-1.5px] ml-1 text-white dark:text-black text-[5.6pt]"
+            className="absolute bottom-[0.5px] right-[-3.2px] ml-1 text-white dark:text-black text-[5.1pt]"
             icon={faCircle}
           />
           <FontAwesomeIcon
-            className="absolute bottom-0 right-[-2px] text-emerald-500 text-[6pt]"
+            className="absolute bottom-0 right-[-3.5px] text-emerald-500 text-[5.5pt]"
             icon={faCheckCircle}
           />
         </div>

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -22,7 +22,7 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         <div title={title}>
           {/* Draws a white circle behind to ensure the checkmark is white */}
           <FontAwesomeIcon
-            className="absolute bottom-0 right-[-2px] ml-1 text-white dark:text-black text-[5.6pt]"
+            className="absolute bottom-[0.5px] right-[-1.5px] ml-1 text-white dark:text-black text-[5.6pt]"
             icon={faCircle}
           />
           <FontAwesomeIcon

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -1,14 +1,38 @@
+import { faCheckCircle, faCircle } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
 import SourcifyIcon from "./sourcify.svg";
 
-const SourcifyLogo: React.FC = () => (
-  <img
-    src={SourcifyIcon}
-    alt="Sourcify logo"
-    title="Verified by Sourcify"
-    width={16}
-    height={16}
-  />
-);
+interface SourcifyLogoProps {
+  locallyVerified?: boolean;
+}
+
+const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
+  const title = locallyVerified ? "Locally verified" : "Verified by Sourcify";
+  return (
+    <div className="relative inline-block">
+      <img
+        src={SourcifyIcon}
+        alt="Sourcify logo"
+        title={title}
+        width={16}
+        height={16}
+      />
+      {locallyVerified && (
+        <div title={title}>
+          {/* Draws a white circle behind to ensure the checkmark is white */}
+          <FontAwesomeIcon
+            className="absolute bottom-0 right-[-2px] ml-1 text-white text-[7pt]"
+            icon={faCircle}
+          />
+          <FontAwesomeIcon
+            className="absolute bottom-0 right-[-2px] ml-1 text-emerald-500 text-[8pt]"
+            icon={faCheckCircle}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default SourcifyLogo;

--- a/src/sourcify/SourcifyLogo.tsx
+++ b/src/sourcify/SourcifyLogo.tsx
@@ -23,7 +23,7 @@ const SourcifyLogo: React.FC<SourcifyLogoProps> = ({ locallyVerified }) => {
         <div title={title}>
           {/* Draws a white circle behind to ensure the checkmark is white */}
           <FontAwesomeIcon
-            className="absolute bottom-[0.4px] right-[-1.2px] ml-1 text-white dark:text-black text-[4.6pt]"
+            className="absolute bottom-[0.2px] right-[-1.1px] ml-1 text-white dark:text-black text-[4pt]"
             icon={faCircle}
           />
           <FontAwesomeIcon

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -453,7 +453,7 @@ export const useContract = (
   fileHash: string,
   sourcifySourceName: SourcifySourceName | null,
   type: MatchType,
-) => {
+): { source: string | undefined; failedHashCheck: boolean } => {
   const sources = useSourcifySources();
   const query = getContractQuery(
     sources,
@@ -475,10 +475,11 @@ export const useContract = (
   const contractData = useQuery(query).data;
 
   if (!match || !contractData) {
-    return null;
+    return { source: undefined, failedHashCheck: false };
   }
 
   // Verify against hash in metadata
+  let failedHashCheck = false;
   if (
     Object.prototype.hasOwnProperty.call(match?.metadata?.sources, filename)
   ) {
@@ -494,11 +495,10 @@ export const useContract = (
         "but received contract with hash",
         contractDataHash,
       );
-      // For now, we just won't return the source.
-      return null;
+      failedHashCheck = true;
     }
   }
-  return contractData;
+  return { source: contractData, failedHashCheck };
 };
 
 export const useTransactionDescription = (

--- a/src/sourcify/useSourcify.ts
+++ b/src/sourcify/useSourcify.ts
@@ -1,5 +1,5 @@
 import { useQuery, type UseQueryOptions } from "@tanstack/react-query";
-import { ErrorDescription, Interface } from "ethers";
+import { ErrorDescription, Interface, keccak256, toUtf8Bytes } from "ethers";
 import { useContext, useMemo } from "react";
 import { Fetcher } from "swr";
 import { ChecksummedAddress, TransactionDescriptionData } from "../types";
@@ -464,7 +464,41 @@ export const useContract = (
     fileHash,
     type,
   );
-  return useQuery(query).data;
+  const metadataQuery = getSourcifyMetadataQuery(
+    sources,
+    sourcifySourceName,
+    checksummedAddress,
+    networkId,
+    false,
+  );
+  const match = useQuery(metadataQuery).data;
+  const contractData = useQuery(query).data;
+
+  if (!match || !contractData) {
+    return null;
+  }
+
+  // Verify against hash in metadata
+  if (
+    Object.prototype.hasOwnProperty.call(match?.metadata?.sources, filename)
+  ) {
+    const sourceObject = match?.metadata?.sources[filename];
+    const contractDataHash = keccak256(toUtf8Bytes(contractData));
+
+    if (contractDataHash !== sourceObject.keccak256) {
+      console.warn(
+        "Contract hash differs from expected:",
+        filename,
+        "metadata has hash",
+        match?.metadata?.sources[filename].keccak256,
+        "but received contract with hash",
+        contractDataHash,
+      );
+      // For now, we just won't return the source.
+      return null;
+    }
+  }
+  return contractData;
 };
 
 export const useTransactionDescription = (

--- a/src/storage/CheckedContractStorage.ts
+++ b/src/storage/CheckedContractStorage.ts
@@ -1,5 +1,6 @@
 import { Metadata } from "@ethereum-sourcify/lib-sourcify";
 import { hexlify, toUtf8Bytes } from "ethers";
+import { useEffect, useState } from "react";
 
 // From @sourcify/lib-sourcify variationsUtils.ts
 function reorderAlphabetically(obj: any): any {
@@ -70,5 +71,41 @@ class CheckedContractStorage {
     return `${this.storageKeyPrefix}_${chainId}_${address}`;
   }
 }
+
+export const useIsLocallyVerified = (
+  match: any,
+  chainId: bigint,
+  address: string | undefined,
+) => {
+  const [isLocallyVerified, setIsLocallyVerified] = useState<boolean>(false);
+
+  useEffect(() => {
+    let matchesLocalVerification = false;
+    if (match && address !== undefined) {
+      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
+      if (savedMetadataHash !== null) {
+        CheckedContractStorage.hashMetadata(
+          match.metadata as unknown as Metadata,
+        ).then((metadataHash) => {
+          if (metadataHash === savedMetadataHash) {
+            matchesLocalVerification = true;
+          } else {
+            console.warn(
+              "For",
+              address,
+              "mismatched metadata compared to locally verified: got",
+              metadataHash,
+              "but locally verified =",
+              savedMetadataHash,
+            );
+          }
+        });
+      }
+    }
+    setIsLocallyVerified(matchesLocalVerification);
+  }, [match, chainId, address]);
+
+  return isLocallyVerified;
+};
 
 export default CheckedContractStorage;

--- a/src/storage/CheckedContractStorage.ts
+++ b/src/storage/CheckedContractStorage.ts
@@ -80,7 +80,6 @@ export const useIsLocallyVerified = (
   const [isLocallyVerified, setIsLocallyVerified] = useState<boolean>(false);
 
   useEffect(() => {
-    let matchesLocalVerification = false;
     if (match && address !== undefined) {
       const savedMetadataHash = CheckedContractStorage.get(chainId, address);
       if (savedMetadataHash !== null) {
@@ -88,7 +87,7 @@ export const useIsLocallyVerified = (
           match.metadata as unknown as Metadata,
         ).then((metadataHash) => {
           if (metadataHash === savedMetadataHash) {
-            matchesLocalVerification = true;
+            setIsLocallyVerified(true);
           } else {
             console.warn(
               "For",
@@ -98,11 +97,15 @@ export const useIsLocallyVerified = (
               "but locally verified =",
               savedMetadataHash,
             );
+            setIsLocallyVerified(false);
           }
         });
+      } else {
+        setIsLocallyVerified(false);
       }
+    } else {
+      setIsLocallyVerified(false);
     }
-    setIsLocallyVerified(matchesLocalVerification);
   }, [match, chainId, address]);
 
   return isLocallyVerified;

--- a/src/storage/CheckedContractStorage.ts
+++ b/src/storage/CheckedContractStorage.ts
@@ -1,4 +1,5 @@
 import { Metadata } from "@ethereum-sourcify/lib-sourcify";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { hexlify, toUtf8Bytes } from "ethers";
 import { useEffect, useState } from "react";
 
@@ -72,43 +73,50 @@ class CheckedContractStorage {
   }
 }
 
+const fetchIsLocallyVerified = async (
+  chainId: bigint,
+  address: string,
+  metadataHash: string,
+) => {
+  const savedMetadataHash = CheckedContractStorage.get(chainId, address);
+  if (savedMetadataHash === metadataHash) {
+    return true;
+  }
+  return false;
+};
+
 export const useIsLocallyVerified = (
   match: any,
   chainId: bigint,
   address: string | undefined,
 ) => {
-  const [isLocallyVerified, setIsLocallyVerified] = useState<boolean>(false);
+  const [metadataHash, setMetadataHash] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (match && address !== undefined) {
-      const savedMetadataHash = CheckedContractStorage.get(chainId, address);
-      if (savedMetadataHash !== null) {
-        CheckedContractStorage.hashMetadata(
-          match.metadata as unknown as Metadata,
-        ).then((metadataHash) => {
-          if (metadataHash === savedMetadataHash) {
-            setIsLocallyVerified(true);
-          } else {
-            console.warn(
-              "For",
-              address,
-              "mismatched metadata compared to locally verified: got",
-              metadataHash,
-              "but locally verified =",
-              savedMetadataHash,
-            );
-            setIsLocallyVerified(false);
-          }
-        });
-      } else {
-        setIsLocallyVerified(false);
-      }
-    } else {
-      setIsLocallyVerified(false);
+    if (match) {
+      CheckedContractStorage.hashMetadata(
+        match.metadata as unknown as Metadata,
+      ).then(setMetadataHash);
     }
-  }, [match, chainId, address]);
+  }, [match]);
 
-  return isLocallyVerified;
+  const { data: isLocallyVerified, isLoading } = useQuery({
+    queryKey: ["locallyVerified", chainId.toString(), address, metadataHash],
+    queryFn: () => {
+      if (metadataHash !== null && address !== undefined) {
+        return fetchIsLocallyVerified(chainId, address, metadataHash);
+      }
+      return false;
+    },
+    enabled: metadataHash !== null && address !== undefined,
+
+    // The only advantage to enabling a stale time is if the user locally
+    // verifies this contract in another browser tab
+    staleTime: Infinity,
+  });
+
+  return isLocallyVerified === true;
 };
 
 export default CheckedContractStorage;

--- a/src/storage/CheckedContractStorage.ts
+++ b/src/storage/CheckedContractStorage.ts
@@ -1,0 +1,74 @@
+import { Metadata } from "@ethereum-sourcify/lib-sourcify";
+import { hexlify, toUtf8Bytes } from "ethers";
+
+// From @sourcify/lib-sourcify variationsUtils.ts
+function reorderAlphabetically(obj: any): any {
+  // Do not reorder arrays or other types
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return obj;
+  }
+
+  const ordered: any = {};
+
+  Object.keys(obj)
+    .sort((a, b) => a.localeCompare(b))
+    .forEach((key: string) => {
+      ordered[key] = reorderAlphabetically(obj[key]);
+    });
+
+  return ordered;
+}
+
+class CheckedContractStorage {
+  private static storageKeyPrefix: string = "lv";
+
+  static async hashMetadata(metadataObj: Metadata): Promise<string> {
+    const digest = await crypto.subtle.digest(
+      "sha-256",
+      new Uint8Array(
+        toUtf8Bytes(JSON.stringify(reorderAlphabetically(metadataObj))),
+      ),
+    );
+    const digestHex = hexlify(new Uint8Array(digest));
+    return digestHex;
+  }
+
+  /**
+   * Saves checked contract information to local storage.
+   * @param chainId - The chain ID of the contract.
+   * @param address - The address of the contract.
+   * @param metadataHash - The metadata hash of the contract.
+   */
+  static save(
+    chainId: string | bigint,
+    address: string,
+    metadataHash: string,
+  ): void {
+    const key = this.getKey(chainId, address);
+    localStorage.setItem(key, metadataHash);
+  }
+
+  /**
+   * Retrieves checked contract information from local storage.
+   * @param chainId - The chain ID of the contract.
+   * @param address - The address of the contract.
+   * @returns The contract metadata hash or null if not found.
+   */
+  static get(chainId: string | bigint, address: string): string | null {
+    const key = this.getKey(chainId, address);
+    const item = localStorage.getItem(key);
+    return item ?? null;
+  }
+
+  /**
+   * Generates the storage key for a given chain ID and address.
+   * @param chainId - The chain ID of the contract.
+   * @param address - The address of the contract.
+   * @returns The storage key.
+   */
+  private static getKey(chainId: string | bigint, address: string): string {
+    return `${this.storageKeyPrefix}_${chainId}_${address}`;
+  }
+}
+
+export default CheckedContractStorage;


### PR DESCRIPTION
Closes #3478

In progress. Currently shows a checkmark next to addresses whose displayed metadata has passed a local verification:

<img width="244" height="82" alt="image" src="https://github.com/user-attachments/assets/820c10b3-8dc7-4d7f-9187-fec116e5d842" />

Maybe the checkmark can replace the Sourcify logo.