### PR TITLE
Add caching settings for CF pages

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,13 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+
+/index.html
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+  Expires: Fri, 01 Jan 2100 00:00:00 GMT


### PR DESCRIPTION
Add a _headers file which will automatically used by Cloudflares Pages if it is deployed there containing best caching practices.