### PR TITLE
Add custom output decoding button and field

### DIFF
--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -64,8 +64,11 @@ const OutputDecoder: React.FC<OutputDecoderProps> = ({
     setCustomParamTypes(parsed);
 
     try {
-      const decoded = AbiCoder.defaultAbiCoder().decode(parsed, data);
-      setCustomDecoded(decoded);
+      const decodedProxy = AbiCoder.defaultAbiCoder().decode(parsed, data);
+      // Throws if there were deferred ABI decoding errors
+      decodedProxy.toArray(true);
+
+      setCustomDecoded(decodedProxy);
     } catch {
       setCustomError(
         "Decoding failed: the data does not match the supplied type(s).",

--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -12,17 +12,13 @@ import DecodedParamsTable from "./DecodedParamsTable";
  * Returns null if the type string is empty or invalid.
  */
 function parseTypeString(typeString: string): ParamType[] | null {
-  const raw = typeString
-    .trim()
-    .split(/[\s,]+/)
-    .filter(Boolean);
-
+  const raw = typeString.trim();
   if (raw.length === 0) {
     return null;
   }
 
   try {
-    return raw.map((t) => ParamType.from(t));
+    return [ParamType.from(raw)];
   } catch {
     return null;
   }

--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -1,10 +1,32 @@
 import { TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
-import { ParamType, Result } from "ethers";
-import React from "react";
+import { AbiCoder, ParamType, Result } from "ethers";
+import React, { useEffect, useState } from "react";
+
 import ModeTab from "../../../components/ModeTab";
 import StandardTextarea from "../../../components/StandardTextarea";
 import { DevMethod } from "../../../sourcify/useSourcify";
 import DecodedParamsTable from "./DecodedParamsTable";
+
+/**
+ * Convert a comma-separated list of type names into ParamType objects.
+ * Returns null if the type string is empty or invalid.
+ */
+function parseTypeString(typeString: string): ParamType[] | null {
+  const raw = typeString
+    .trim()
+    .split(/[\s,]+/)
+    .filter(Boolean);
+
+  if (raw.length === 0) {
+    return null;
+  }
+
+  try {
+    return raw.map((t) => ParamType.from(t));
+  } catch {
+    return null;
+  }
+}
 
 type OutputDecoderProps = {
   args: Result | null | undefined;
@@ -18,37 +40,124 @@ const OutputDecoder: React.FC<OutputDecoderProps> = ({
   paramTypes,
   data,
   devMethod,
-}) => (
-  <TabGroup>
-    <TabList className="mb-1 flex space-x-1">
-      <ModeTab disabled={!paramTypes}>Decoded</ModeTab>
-      <ModeTab>Raw</ModeTab>
-    </TabList>
-    <TabPanels>
-      <TabPanel>
-        {data === "0x" ? (
-          <>No data</>
-        ) : paramTypes === undefined || args === undefined ? (
-          <>Waiting for data...</>
-        ) : paramTypes === null || args === null ? (
-          <>Can't decode data</>
-        ) : (
-          <div className="space-y-2">
-            <DecodedParamsTable
-              args={args}
-              paramTypes={paramTypes}
-              hasParamNames={true}
-              devMethod={devMethod}
-              defaultNameBase="ret"
+}) => {
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  const [customTypeInput, setCustomTypeInput] = useState<string>("");
+  const [customParamTypes, setCustomParamTypes] = useState<ParamType[] | null>(
+    null,
+  );
+  const [customDecoded, setCustomDecoded] = useState<Result | null>(null);
+  const [customError, setCustomError] = useState<string | null>(null);
+
+  // Parse and decode whenever the user types a new type string
+  useEffect(() => {
+    setCustomParamTypes(null);
+    setCustomDecoded(null);
+    setCustomError(null);
+
+    if (!customTypeInput.trim()) {
+      return;
+    }
+
+    const parsed = parseTypeString(customTypeInput);
+    if (!parsed) {
+      setCustomError("Could not parse the supplied type(s).");
+      return;
+    }
+    setCustomParamTypes(parsed);
+
+    try {
+      const decoded = AbiCoder.defaultAbiCoder().decode(parsed, data);
+      setCustomDecoded(decoded);
+    } catch {
+      setCustomError(
+        "Decoding failed: the data does not match the supplied type(s).",
+      );
+    }
+  }, [customTypeInput, data]);
+
+  // If `paramTypes` is falsy we have three tabs (Decoded, Raw, Custom)
+  // otherwise only two tabs (Decoded, Raw)
+  const hasCustom = !paramTypes;
+  const customTabIdx = hasCustom ? 2 : -1;
+
+  return (
+    <TabGroup selectedIndex={selectedIdx} onChange={setSelectedIdx}>
+      <TabList className="mb-1 flex items-center space-x-1">
+        <ModeTab disabled={!paramTypes}>Decoded</ModeTab>
+        <ModeTab>Raw</ModeTab>
+        {/* Only rendered when Decoded is disabled */}
+        {hasCustom && <ModeTab>Custom</ModeTab>}
+
+        {/* Show the input field when the Custom tab is active */}
+        {hasCustom && selectedIdx === customTabIdx && (
+          <div className="ml-1">
+            <input
+              type="text"
+              className="rounded-md border border-gray-300 bg-white px-2 py-1 -mt-1 -mb-1 text-sm w-96"
+              placeholder='Solidity type, e.g. "address[]"'
+              value={customTypeInput}
+              onChange={(e) => setCustomTypeInput(e.target.value)}
+              list="custom-type-options"
             />
+            {/* Autocomplete suggestions */}
+            <datalist id="custom-type-options">
+              <option value="address" />
+              <option value="uint256" />
+            </datalist>
           </div>
         )}
-      </TabPanel>
-      <TabPanel>
-        <StandardTextarea value={data} />
-      </TabPanel>
-    </TabPanels>
-  </TabGroup>
-);
+      </TabList>
+
+      <TabPanels>
+        <TabPanel>
+          {data === "0x" ? (
+            <>No data</>
+          ) : paramTypes === undefined || args === undefined ? (
+            <>Waiting for data...</>
+          ) : paramTypes === null || args === null ? (
+            <>Can't decode data</>
+          ) : (
+            <div className="space-y-2">
+              <DecodedParamsTable
+                args={args}
+                paramTypes={paramTypes}
+                hasParamNames={true}
+                devMethod={devMethod}
+                defaultNameBase="ret"
+              />
+            </div>
+          )}
+        </TabPanel>
+
+        <TabPanel>
+          <StandardTextarea value={data} />
+        </TabPanel>
+
+        {hasCustom && (
+          <TabPanel>
+            <div className="space-y-4 mt-2">
+              {customError && (
+                <p className="text-sm text-red-600">{customError}</p>
+              )}
+
+              {/* Show table when decoded successfully */}
+              {customDecoded && customParamTypes && (
+                <DecodedParamsTable
+                  args={customDecoded}
+                  paramTypes={customParamTypes}
+                  hasParamNames={false}
+                  devMethod={undefined}
+                  defaultNameBase="ret"
+                />
+              )}
+            </div>
+          </TabPanel>
+        )}
+      </TabPanels>
+    </TabGroup>
+  );
+};
 
 export default OutputDecoder;


### PR DESCRIPTION
Closes #3100. Adds a Custom tab with an input field for the type, with two autocomplete-friendly entries (`address` and `uint256`). Currently, this only supports decoding outputs, but in the future we could support inputs too. Multiple outputs can be specified via a tuple.

Examples on mainnet:

`/address/0x4025ee6512DBbda97049Bcf5AA5D38C54aF6bE8a/readContract`
<img width="729" height="261" alt="image" src="https://github.com/user-attachments/assets/100660e9-fc4e-48f0-88b3-2b3f034e9663" />

`/tx/0x01cebe392b95513f76bd9e94caba96d0b623f2538d483d1c790f0964f00e6920/trace` (multiple outputs supported via tuple type)
<img width="1033" height="299" alt="image" src="https://github.com/user-attachments/assets/a63247f8-4058-4f05-942d-0724af907c29" />
