### PR TITLE
Add support for ERC-721 token transfer logs

### DIFF
--- a/src/execution/address/AddressERC20Results.tsx
+++ b/src/execution/address/AddressERC20Results.tsx
@@ -61,7 +61,9 @@ const AddressERC20Results: FC = () => {
           to: m.receipt.to,
           value: m.transaction.value,
           type: m.transaction.type,
-          tokenTransfers: findTokenTransfersInLogs(m.receipt.logs),
+          tokenTransfers: findTokenTransfersInLogs(m.receipt.logs).filter(
+            (transfer) => transfer.type === "erc20",
+          ),
         }),
       ),
     [results],

--- a/src/execution/address/ERC20Item.tsx
+++ b/src/execution/address/ERC20Item.tsx
@@ -5,7 +5,7 @@ import NativeTokenAmount from "../../components/NativeTokenAmount";
 import TimestampAge from "../../components/TimestampAge";
 import TransactionDirection from "../../components/TransactionDirection";
 import TransactionLink from "../../components/TransactionLink";
-import { TokenTransfer } from "../../types";
+import { ERC20Transfer } from "../../types";
 import { BlockNumberContext } from "../../useBlockTagContext";
 import TransactionAddress from "../components/TransactionAddress";
 import { AddressAwareComponentProps } from "../types";
@@ -21,7 +21,7 @@ export type ERC20ItemProps = AddressAwareComponentProps & {
   to: string | null;
   value: bigint;
   type: number;
-  tokenTransfers: TokenTransfer[];
+  tokenTransfers: ERC20Transfer[];
 };
 
 const ERC20Item: FC<ERC20ItemProps> = ({
@@ -85,7 +85,7 @@ const ERC20Item: FC<ERC20ItemProps> = ({
         </td>
       </tr>
       {tokenTransfers &&
-        tokenTransfers.map((transfer: TokenTransfer, index: number) =>
+        tokenTransfers.map((transfer: ERC20Transfer, index: number) =>
           transfer.from === address || transfer.to === address ? (
             <tr key={index}>
               <td></td>

--- a/src/execution/transaction/TokenTransferItem.tsx
+++ b/src/execution/transaction/TokenTransferItem.tsx
@@ -10,6 +10,7 @@ import { useTokenMetadata } from "../../useErigonHooks";
 import { useTokenUSDOracle } from "../../usePriceOracle";
 import { RuntimeContext } from "../../useRuntime";
 import TransactionAddress from "../components/TransactionAddress";
+import NftIcon from "./nft-icon.svg";
 
 type TokenTransferItemProps = {
   t: TokenTransfer;
@@ -28,10 +29,8 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
     source: priceSource,
   } = useTokenUSDOracle(
     provider,
-    blockNumber !== undefined && typeof blockNumber === "number"
-      ? blockNumber - 1
-      : blockNumber,
-    t.token,
+    typeof blockNumber === "number" ? blockNumber - 1 : blockNumber,
+    t.type === "erc20" ? t.token : undefined,
     tokenMeta?.decimals !== undefined ? BigInt(tokenMeta?.decimals) : undefined,
   );
 
@@ -56,25 +55,43 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
           />
         </div>
         <div className="col-span-2 flex items-baseline space-x-1">
-          <span className="text-gray-500">
-            <FontAwesomeIcon icon={faSackDollar} size="1x" />
-          </span>
-          <span>
-            <FormattedBalanceHighlighter
-              value={t.value}
-              decimals={tokenMeta?.decimals ?? 0}
-            />
-          </span>
-          <TransactionAddress address={t.token} />
-          {tokenMeta && quote !== undefined && decimals !== undefined && (
-            <USDAmount
-              amount={t.value}
-              amountDecimals={tokenMeta.decimals}
-              quote={quote}
-              quoteDecimals={Number(decimals ?? 0)}
-              colorScheme={getPriceOraclePreset(priceSource)}
-            />
+          {t.type === "erc20" && (
+            <span>
+              <span className="text-gray-500">
+                <FontAwesomeIcon icon={faSackDollar} size="1x" />
+              </span>
+              <FormattedBalanceHighlighter
+                value={t.value}
+                decimals={tokenMeta?.decimals ?? 0}
+              />
+            </span>
           )}
+          {t.type === "erc721" && (
+            <span className="inline-flex items-baseline">
+              <span>
+                {/* For the same height as the FA icons, use h-[1em] [vertical-align:-0.125em] */}
+                <img
+                  src={NftIcon}
+                  title="NFT"
+                  className="inline-block h-[1.5em] [vertical-align:-0.375em]"
+                />
+              </span>
+              <span className="px-1">NFT #{t.tokenId}</span>
+            </span>
+          )}
+          <TransactionAddress address={t.token} />
+          {t.type === "erc20" &&
+            tokenMeta &&
+            quote !== undefined &&
+            decimals !== undefined && (
+              <USDAmount
+                amount={t.value}
+                amountDecimals={tokenMeta.decimals}
+                quote={quote}
+                quoteDecimals={Number(decimals ?? 0)}
+                colorScheme={getPriceOraclePreset(priceSource)}
+              />
+            )}
         </div>
       </div>
     </div>

--- a/src/execution/transaction/TokenTransferItem.tsx
+++ b/src/execution/transaction/TokenTransferItem.tsx
@@ -73,7 +73,7 @@ const TokenTransferItem: FC<TokenTransferItemProps> = ({ t }) => {
                 <img
                   src={NftIcon}
                   title="NFT"
-                  className="inline-block h-[1.5em] [vertical-align:-0.375em]"
+                  className="inline-block min-w-[1.5em] h-[1.5em] [vertical-align:-0.375em]"
                 />
               </span>
               <span className="px-1">NFT #{t.tokenId}</span>

--- a/src/execution/transaction/nft-icon.svg
+++ b/src/execution/transaction/nft-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-88 -74 176 148">
+  <polygon points="80,0 40,69.282032  -40,69.282032  -80,0 -40,-69.282032 40,-69.282032"
+           fill="#f0f0f0" stroke="#bebebe" stroke-width="8" />
+  <text x="0" y="0" text-anchor="middle" dominant-baseline="middle"
+        font-family="Arial, Helvetica, sans-serif" font-size="60" fill="#717171" font-weight="700" dy="0.06em">
+    NFT
+  </text>
+</svg>

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,12 +104,24 @@ export type InternalOperation = {
   value: bigint;
 };
 
-export type TokenTransfer = {
+interface BaseTransfer {
+  // Contract address of the token
   token: string;
   from: string;
   to: string;
+}
+
+export interface ERC20Transfer extends BaseTransfer {
+  type: "erc20";
   value: bigint;
-};
+}
+
+export interface ERC721Transfer extends BaseTransfer {
+  type: "erc721";
+  tokenId: bigint;
+}
+
+export type TokenTransfer = ERC20Transfer | ERC721Transfer;
 
 export type TokenMeta = {
   name: string;

--- a/src/useErigonHooks.ts
+++ b/src/useErigonHooks.ts
@@ -332,13 +332,28 @@ export const findTokenTransfersInLogs = (
   logs: readonly Log[],
 ): TokenTransfer[] => {
   return logs
-    .filter((l) => l.topics.length === 3 && l.topics[0] === TRANSFER_TOPIC)
-    .map((l) => ({
-      token: l.address,
-      from: getAddress(dataSlice(getBytes(l.topics[1]), 12)),
-      to: getAddress(dataSlice(getBytes(l.topics[2]), 12)),
-      value: BigInt(l.data),
-    }));
+    .filter(
+      (l) =>
+        (l.topics.length === 3 || l.topics.length === 4) &&
+        l.topics[0] === TRANSFER_TOPIC,
+    )
+    .map((l) =>
+      l.topics.length === 3
+        ? {
+            token: l.address,
+            from: getAddress(dataSlice(getBytes(l.topics[1]), 12)),
+            to: getAddress(dataSlice(getBytes(l.topics[2]), 12)),
+            value: BigInt(l.data),
+            type: "erc20",
+          }
+        : {
+            token: l.address,
+            from: getAddress(dataSlice(getBytes(l.topics[1]), 12)),
+            to: getAddress(dataSlice(getBytes(l.topics[2]), 12)),
+            tokenId: BigInt(l.topics[3]),
+            type: "erc721",
+          },
+    );
 };
 
 export const useTokenTransfers = (

--- a/src/usePriceOracle.ts
+++ b/src/usePriceOracle.ts
@@ -232,11 +232,11 @@ const feedRegistryFetcher =
 export const useTokenUSDOracle = (
   provider: JsonRpcApiProvider,
   blockTag: BlockTag | undefined,
-  tokenAddress: ChecksummedAddress,
+  tokenAddress: ChecksummedAddress | undefined,
   tokenDecimals: bigint | undefined,
 ): FeedRegistryFetcherData => {
   const netTokenEquivMap = tokenEquivMap.get(provider._network.chainId);
-  if (netTokenEquivMap !== undefined) {
+  if (netTokenEquivMap !== undefined && tokenAddress !== undefined) {
     const tokenEquiv = netTokenEquivMap.get(tokenAddress);
     if (tokenEquiv !== undefined) {
       tokenAddress = tokenEquiv;
@@ -258,7 +258,9 @@ export const useTokenUSDOracle = (
   );
   // Conditional data fetching, since token price resolvers depend on the ETH price
   const { data, error } = useSWRImmutable(
-    ethPrice !== undefined && tokenDecimals !== undefined
+    ethPrice !== undefined &&
+      tokenDecimals !== undefined &&
+      tokenAddress !== undefined
       ? feedRegistryFetcherKey(tokenAddress, blockTag)
       : null,
     fetcher,


### PR DESCRIPTION
This is a modernized revisit of #727 which conforms to the React rules and includes a small NFT icon.

<img width="898" height="198" alt="image" src="https://github.com/user-attachments/assets/1a48fdf0-6f96-47b7-aac1-d5f809d177db" />

<img width="2312" height="440" alt="image" src="https://github.com/user-attachments/assets/b81356dc-81c9-4be5-a3d6-4a384e14a4ae" />


To test how other explorers treat a single contract, I deployed a contract that emits both ERC-20 (3-topic) and ERC-721 (4-topic) transfer logs: <https://hoodi.otterscan.io/tx/0xfe56aeb5979d2350fee0feb389c9bfd05baaf68b93aecab350a1745caa2641f0>. [Etherscan](https://hoodi.etherscan.io/tx/0xfe56aeb5979d2350fee0feb389c9bfd05baaf68b93aecab350a1745caa2641f0) follows the behavior of this PR, whereas [Blockscout](https://eth-hoodi.blockscout.com/tx/0xfe56aeb5979d2350fee0feb389c9bfd05baaf68b93aecab350a1745caa2641f0) categorizes the entire contract as an NFT and displays the ERC-20 transfer as an NFT transfer with a blank token ID.


I'm more convinced now that deciding the transfer type via the log is a better approach than trying to classify the contract:
- No reliance on indexers
- Captures strictly more transfers than the current version of Otterscan (no transfer Otterscan currently labels as an ERC-20 transfer will ever be reclassified as an ERC-721 transfer)
- Accepts all contracts conforming to the EIP
- No additional performance overhead

In a future feature, we can display NFT icons.

Closes #727. Fixes #723.