### PR TITLE
Limit formatValue decimals to 80

### DIFF
--- a/src/components/formatter.ts
+++ b/src/components/formatter.ts
@@ -2,7 +2,7 @@ import { BigNumberish, formatUnits } from "ethers";
 import { commify } from "../utils/utils";
 
 export const formatValue = (value: BigNumberish, decimals: number): string => {
-  const formatted = commify(formatUnits(value, decimals));
+  const formatted = commify(formatUnits(value, decimals > 80 ? 0 : decimals));
   return formatted.endsWith(".0")
     ? formatted.slice(0, formatted.length - 2)
     : formatted;


### PR DESCRIPTION
Fixes #3631, tested on the token holdings page which caused that issue.

Note: 10^80 > 2^256.