### PR TITLE
Repair use of React hooks in useKlerosAddressTags

### DIFF
--- a/src/kleros/useKleros.ts
+++ b/src/kleros/useKleros.ts
@@ -138,21 +138,22 @@ export const useKlerosAddressTags = (
   const { provider } = useContext(RuntimeContext);
   const klerosConfig = useKlerosConfig();
 
-  if (!klerosConfig?.enabled || !address) {
-    return null;
-  }
-
   const query = useQuery(
     getKlerosAddressTagsQuery(
-      klerosConfig.enabled,
+      klerosConfig.enabled && !!address,
       klerosConfig.apiUrl!,
       provider._network.chainId,
-      [address],
+      address ? [address] : [],
     ),
   );
 
+  if (address === undefined) {
+    return undefined;
+  }
+
   if (!query.data) {
-    return query.data; // undefined or null
+    // undefined or null
+    return query.data;
   }
 
   // Extract tags for the specific address


### PR DESCRIPTION
Prevents useKlerosAddressTags from violating a rule of React hooks.

Note: I haven't been able to test this yet as I am waiting on syncing a chain that Kleros supports.