### PR TITLE
Accept multiple arguments in custom function decoding

### DIFF
--- a/src/execution/transaction/decoder/OutputDecoder.tsx
+++ b/src/execution/transaction/decoder/OutputDecoder.tsx
@@ -11,14 +11,14 @@ import DecodedParamsTable from "./DecodedParamsTable";
  * Convert a comma-separated list of type names into ParamType objects.
  * Returns null if the type string is empty or invalid.
  */
-function parseTypeString(typeString: string): ParamType[] | null {
+function parseTypeString(typeString: string): readonly ParamType[] | null {
   const raw = typeString.trim();
   if (raw.length === 0) {
     return null;
   }
 
   try {
-    return [ParamType.from(raw)];
+    return ParamType.from(`(${raw})`).components;
   } catch {
     return null;
   }
@@ -40,9 +40,9 @@ const OutputDecoder: React.FC<OutputDecoderProps> = ({
   const [selectedIdx, setSelectedIdx] = useState(0);
 
   const [customTypeInput, setCustomTypeInput] = useState<string>("");
-  const [customParamTypes, setCustomParamTypes] = useState<ParamType[] | null>(
-    null,
-  );
+  const [customParamTypes, setCustomParamTypes] = useState<
+    readonly ParamType[] | null
+  >(null);
   const [customDecoded, setCustomDecoded] = useState<Result | null>(null);
   const [customError, setCustomError] = useState<string | null>(null);
 


### PR DESCRIPTION
Closes #3659

Users can now specify multiple arguments simply by using commas to separate the types.

Example from user: `customMultiplier()` from `0xe82719202e5965Cf5D9B6673B7503a3b92DE20be`

<img width="1115" height="391" alt="image" src="https://github.com/user-attachments/assets/7fd87de2-34a5-449d-b21a-d880c8cd2e93" />
