### PR TITLE
Use the ENS Universal Resolver for name resolution

### DIFF
--- a/cypress/e2e/mainnet/ens-universal-resolver.cy.ts
+++ b/cypress/e2e/mainnet/ens-universal-resolver.cy.ts
@@ -1,0 +1,15 @@
+describe("ENS Universal Resolver", () => {
+  it("Should resolve ur.integration-tests.eth", () => {
+    // ENS publishes ur.integration-tests.eth with a wildcard CCIP-Read resolver
+    // that legacy resolution can't reach — only the Universal Resolver returns
+    // an address. If this passes, the patch is wired up.
+    cy.visit("/");
+    cy.get('[data-test="home-search-input"]').type(
+      `ur.integration-tests.eth{enter}`,
+    );
+
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(
+      "0x2222222222222222222222222222222222222222",
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "packageManager": "pnpm@10.15.1",
   "dependencies": {
+    "@ensdomains/ethers-patch-v6": "^0.0.5",
     "@ethereum-sourcify/compilers-types": "^1.0.6",
     "@ethereum-sourcify/lib-sourcify": "^2.2.2",
     "@fontsource/fira-code": "^5.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ensdomains/ethers-patch-v6':
+        specifier: ^0.0.5
+        version: 0.0.5(ethers@6.15.0)(typescript@5.9.3)
       '@ethereum-sourcify/compilers-types':
         specifier: ^1.0.6
         version: 1.0.6
@@ -435,6 +438,12 @@ packages:
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@ensdomains/ethers-patch-v6@0.0.5':
+    resolution: {integrity: sha512-bWeBKpplx/03HIyD4kA6qF4oSJlu9ePEbnpsZMMU4mxx5aZeS70ePGIxPRuxmd3Au+juyP3TreJZ8/wKLGK2Xg==}
+    peerDependencies:
+      ethers: '6'
+      typescript: ^5
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -4619,6 +4628,11 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@ensdomains/ethers-patch-v6@0.0.5(ethers@6.15.0)(typescript@5.9.3)':
+    dependencies:
+      ethers: 6.15.0
+      typescript: 5.9.3
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import "@ensdomains/ethers-patch-v6";
 import "@fontsource/fira-code/index.css";
 import "@fontsource/roboto-mono/index.css";
 import "@fontsource/roboto/index.css";


### PR DESCRIPTION
Hey! I'm Dhaiwat from the DevRel team at ENS Labs. We're working on getting libraries across the ecosystem ready for ENSv2.

## What

Routes ENS resolution through the Universal Resolver (`0xeeeeeeee14d718c2b47d9923deab1335e144eeee`) instead of the legacy ENS Registry.

ENS resolution in this repo goes through `ethers` v6 at:
- `src/useResolvedAddresses.ts` — `provider.resolveName()`
- `src/api/address-resolver/ENSAddressResolver.ts` — `provider.lookupAddress()`

ethers v6 is not ENSv2-aware natively, so this PR installs `@ensdomains/ethers-patch-v6` and imports it as the first import in `src/index.tsx` so the patch loads before any ethers usage.

## Why

The legacy registry path returns stale results for names managed by the new Universal Resolver. The UR is the canonical entry point for ENS resolution on Mainnet — viem, ensjs, and patched ethers all use it.

More: https://docs.ens.domains/web/ensv2-readiness

## Verification

- `ur.integration-tests.eth` should resolve to `0x2222222222222222222222222222222222222222` (legacy returns `0x1111111111111111111111111111111111111111`).

