### PR TITLE
Support .gwei names in address search

### DIFF
--- a/cypress/e2e/mainnet/smoketests.cy.ts
+++ b/cypress/e2e/mainnet/smoketests.cy.ts
@@ -1,4 +1,14 @@
 describe("Basic navigation", () => {
+  it("Should load gns.gwei address", () => {
+    cy.visit("/");
+    cy.get('[data-test="home-search-input"]').type(`gns.gwei{enter}`);
+
+    cy.get('[data-test="address"]', { timeout: 15_000 }).contains(
+      "0xbBBCe157ecBB945b1F92Af88413b911910C727c8",
+    );
+    cy.get('[data-test="resolved-name"]').contains("GNS: gns.gwei");
+  });
+
   it("Should load vitalik.eth address", () => {
     // From the home page, go to vitalik.eth address page, expect it finds it
     cy.visit("/");

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -4,6 +4,7 @@ import { FC, lazy, memo, useContext, useState } from "react";
 import { Link } from "react-router";
 import PriceBox from "./PriceBox";
 import SourcifyMenu from "./SourcifyMenu";
+import { supportsGNS } from "./api/name-resolver/GNSNameResolver";
 import { useGenericSearch } from "./search/search";
 import { RuntimeContext } from "./useRuntime";
 // @ts-expect-error
@@ -64,6 +65,8 @@ const Header: FC = () => {
                 ) !== null
                   ? " / ENS name"
                   : ""
+              }${
+                supportsGNS(provider._network.chainId) ? " / .gwei name" : ""
               }`}
               onChange={handleChange}
               ref={searchRef}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -4,6 +4,7 @@ import { FC, lazy, memo, useContext, useState } from "react";
 import { NavLink } from "react-router";
 import Logo from "./Logo";
 import SourcifyMenu from "./SourcifyMenu";
+import { supportsGNS } from "./api/name-resolver/GNSNameResolver";
 import Timestamp from "./components/Timestamp";
 import { useGenericSearch } from "./search/search";
 import { blockURL, slotURL } from "./url";
@@ -54,6 +55,8 @@ const Home: FC = () => {
                 ) !== null
                   ? " / ENS name"
                   : ""
+              }${
+                supportsGNS(provider._network.chainId) ? " / .gwei name" : ""
               }`}
               onChange={handleChange}
               ref={searchRef}

--- a/src/api/name-resolver/GNSNameResolver.test.ts
+++ b/src/api/name-resolver/GNSNameResolver.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, jest, test } from "@jest/globals";
+import { Interface, JsonRpcApiProvider, getAddress } from "ethers";
+import { isGNSName, resolveGNSName, supportsGNS } from "./GNSNameResolver";
+
+const NAME_NFT_ADDRESS = "0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6";
+const NAME_NFT_INTERFACE = new Interface([
+  "function computeId(string name) view returns (uint256)",
+  "function resolve(uint256 tokenId) view returns (address)",
+]);
+
+const mockProvider = (...responses: string[]) => {
+  const call = jest.fn<JsonRpcApiProvider["call"]>();
+  responses.forEach((response) => call.mockResolvedValueOnce(response));
+  return {
+    call,
+    provider: { call } as unknown as Pick<JsonRpcApiProvider, "call">,
+  };
+};
+
+describe("GNS name resolution", () => {
+  test("recognizes non-empty .gwei names case-insensitively", () => {
+    expect(isGNSName("gns.gwei")).toBe(true);
+    expect(isGNSName("Sub.Name.GWEI")).toBe(true);
+    expect(isGNSName(".gwei")).toBe(false);
+    expect(isGNSName("gns.gwei.eth")).toBe(false);
+  });
+
+  test("supports Ethereum mainnet and Sepolia", () => {
+    expect(supportsGNS(1n)).toBe(true);
+    expect(supportsGNS(11155111n)).toBe(true);
+    expect(supportsGNS(10n)).toBe(false);
+  });
+
+  test("resolves through computeId and resolve", async () => {
+    const tokenId = 123n;
+    const resolvedAddress = "0xbbbce157ecbb945b1f92af88413b911910c727c8";
+    const { call, provider } = mockProvider(
+      NAME_NFT_INTERFACE.encodeFunctionResult("computeId", [tokenId]),
+      NAME_NFT_INTERFACE.encodeFunctionResult("resolve", [resolvedAddress]),
+    );
+
+    await expect(resolveGNSName(provider, 1n, "gns.gwei")).resolves.toBe(
+      getAddress(resolvedAddress),
+    );
+    expect(call).toHaveBeenNthCalledWith(1, {
+      to: NAME_NFT_ADDRESS,
+      data: NAME_NFT_INTERFACE.encodeFunctionData("computeId", ["gns.gwei"]),
+    });
+    expect(call).toHaveBeenNthCalledWith(2, {
+      to: NAME_NFT_ADDRESS,
+      data: NAME_NFT_INTERFACE.encodeFunctionData("resolve", [tokenId]),
+    });
+  });
+
+  test("does not call the contract for unsupported inputs", async () => {
+    const { call, provider } = mockProvider();
+
+    await expect(resolveGNSName(provider, 10n, "gns.gwei")).resolves.toBeNull();
+    await expect(
+      resolveGNSName(provider, 1n, "vitalik.eth"),
+    ).resolves.toBeNull();
+    expect(call).not.toHaveBeenCalled();
+  });
+
+  test("returns null for an unset name", async () => {
+    const { provider } = mockProvider(
+      NAME_NFT_INTERFACE.encodeFunctionResult("computeId", [123n]),
+      NAME_NFT_INTERFACE.encodeFunctionResult("resolve", [
+        "0x0000000000000000000000000000000000000000",
+      ]),
+    );
+
+    await expect(
+      resolveGNSName(provider, 1n, "missing.gwei"),
+    ).resolves.toBeNull();
+  });
+
+  test("returns null when a contract call fails", async () => {
+    const call = jest
+      .fn<JsonRpcApiProvider["call"]>()
+      .mockRejectedValue(new Error("RPC unavailable"));
+    const provider = { call } as unknown as Pick<JsonRpcApiProvider, "call">;
+
+    await expect(resolveGNSName(provider, 1n, "gns.gwei")).resolves.toBeNull();
+  });
+});

--- a/src/api/name-resolver/GNSNameResolver.ts
+++ b/src/api/name-resolver/GNSNameResolver.ts
@@ -1,0 +1,64 @@
+import { Interface, JsonRpcApiProvider, getAddress } from "ethers";
+import { ChecksummedAddress, ZERO_ADDRESS } from "../../types";
+
+const NAME_NFT_ADDRESS = "0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6";
+const NAME_NFT_ADDRESSES = new Map<bigint, string>([
+  [1n, NAME_NFT_ADDRESS],
+  [11155111n, NAME_NFT_ADDRESS],
+]);
+
+const NAME_NFT_INTERFACE = new Interface([
+  "function computeId(string name) view returns (uint256)",
+  "function resolve(uint256 tokenId) view returns (address)",
+]);
+
+type CallProvider = Pick<JsonRpcApiProvider, "call">;
+
+export const isGNSName = (name: string): boolean => {
+  const normalizedName = name.toLowerCase();
+  return normalizedName.length > 5 && normalizedName.endsWith(".gwei");
+};
+
+export const supportsGNS = (chainId: bigint): boolean =>
+  NAME_NFT_ADDRESSES.has(chainId);
+
+export const resolveGNSName = async (
+  provider: CallProvider,
+  chainId: bigint,
+  name: string,
+): Promise<ChecksummedAddress | null> => {
+  const contractAddress = NAME_NFT_ADDRESSES.get(chainId);
+  if (contractAddress === undefined || !isGNSName(name)) {
+    return null;
+  }
+
+  try {
+    const computeIdResult = await provider.call({
+      to: contractAddress,
+      data: NAME_NFT_INTERFACE.encodeFunctionData("computeId", [name]),
+    });
+    const [tokenId] = NAME_NFT_INTERFACE.decodeFunctionResult(
+      "computeId",
+      computeIdResult,
+    );
+
+    const resolveResult = await provider.call({
+      to: contractAddress,
+      data: NAME_NFT_INTERFACE.encodeFunctionData("resolve", [tokenId]),
+    });
+    const [resolvedAddress] = NAME_NFT_INTERFACE.decodeFunctionResult(
+      "resolve",
+      resolveResult,
+    );
+
+    if (
+      typeof resolvedAddress !== "string" ||
+      resolvedAddress === ZERO_ADDRESS
+    ) {
+      return null;
+    }
+    return getAddress(resolvedAddress);
+  } catch {
+    return null;
+  }
+};

--- a/src/components/AddressOrENSNameNotFound.tsx
+++ b/src/components/AddressOrENSNameNotFound.tsx
@@ -3,20 +3,17 @@ import ContentFrame from "./ContentFrame";
 import StandardSubtitle from "./StandardSubtitle";
 
 type AddressOrENSNameNotFoundProps = {
-  addressOrENSName: string;
-  supportsENS: boolean;
+  addressOrName: string;
 };
 
 const AddressOrENSNameNotFound: React.FC<AddressOrENSNameNotFoundProps> = ({
-  addressOrENSName,
-  supportsENS,
+  addressOrName,
 }) => (
   <>
     <StandardSubtitle>Transaction Details</StandardSubtitle>
     <ContentFrame>
       <div className="py-4 text-sm">
-        "{addressOrENSName}" is not an ETH address
-        {supportsENS && " or ENS name"}.
+        "{addressOrName}" is not an ETH address or supported name.
       </div>
     </ContentFrame>
   </>

--- a/src/execution/AddressMainPage.tsx
+++ b/src/execution/AddressMainPage.tsx
@@ -16,7 +16,7 @@ import { Match, useSourcifyMetadata } from "../sourcify/useSourcify";
 import { useWhatsabiMetadata } from "../sourcify/useWhatsabi";
 import { ChecksummedAddress } from "../types";
 import { hasCodeQuery } from "../useErigonHooks";
-import { useAddressOrENS } from "../useResolvedAddresses";
+import { useAddressOrName } from "../useResolvedAddresses";
 import { RuntimeContext } from "../useRuntime";
 import AddressSubtitle from "./address/AddressSubtitle";
 import { AddressAwareComponentProps } from "./types";
@@ -70,7 +70,7 @@ const AddressMainPage: React.FC = () => {
     },
     [navigate, direction, searchParams],
   );
-  const [checksummedAddress, isENS, error] = useAddressOrENS(
+  const [checksummedAddress, nameResolver, error] = useAddressOrName(
     addressOrName,
     urlFixer,
   );
@@ -96,20 +96,14 @@ const AddressMainPage: React.FC = () => {
   return (
     <StandardFrame>
       {error ? (
-        <AddressOrENSNameNotFound
-          addressOrENSName={addressOrName}
-          supportsENS={
-            provider._network.getPlugin("org.ethers.plugins.network.Ens") !==
-            null
-          }
-        />
+        <AddressOrENSNameNotFound addressOrName={addressOrName} />
       ) : (
         checksummedAddress && (
           <>
             <AddressSubtitle
               addressOrName={addressOrName}
               address={checksummedAddress}
-              isENS={isENS}
+              nameResolver={nameResolver}
             />
             <TabGroup>
               <TabList className="flex space-x-2 rounded-t-lg border-l border-r border-t bg-white overflow-x-auto whitespace-nowrap">

--- a/src/execution/AddressTransactionByNonce.tsx
+++ b/src/execution/AddressTransactionByNonce.tsx
@@ -13,7 +13,7 @@ import StandardFrame from "../components/StandardFrame";
 import { ChecksummedAddress } from "../types";
 import { transactionURL } from "../url";
 import { useTransactionBySenderAndNonce } from "../useErigonHooks";
-import { useAddressOrENS } from "../useResolvedAddresses";
+import { useAddressOrName } from "../useResolvedAddresses";
 import { RuntimeContext } from "../useRuntime";
 
 type AddressTransactionByNonceProps = {
@@ -44,7 +44,7 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
     },
     [navigate, direction, searchParams],
   );
-  const [checksummedAddress, , ensError] = useAddressOrENS(
+  const [checksummedAddress, , nameResolutionError] = useAddressOrName(
     addressOrName,
     urlFixer,
   );
@@ -99,17 +99,11 @@ const AddressTransactionByNonce: React.FC<AddressTransactionByNonceProps> = ({
     });
   }, [txHash, navigate, startTransition]);
 
-  // Invalid ENS
-  if (ensError) {
+  // Invalid address or name
+  if (nameResolutionError) {
     return (
       <StandardFrame>
-        <AddressOrENSNameNotFound
-          addressOrENSName={addressOrName}
-          supportsENS={
-            provider._network.getPlugin("org.ethers.plugins.network.Ens") !==
-            null
-          }
-        />
+        <AddressOrENSNameNotFound addressOrName={addressOrName} />
       </StandardFrame>
     );
   }

--- a/src/execution/address/AddressSubtitle.tsx
+++ b/src/execution/address/AddressSubtitle.tsx
@@ -11,20 +11,20 @@ import Copy from "../../components/Copy";
 import Faucet from "../../components/Faucet";
 import StandardSubtitle from "../../components/StandardSubtitle";
 import { useChainInfo } from "../../useChainInfo";
-import { useResolvedAddress } from "../../useResolvedAddresses";
+import { NameResolver, useResolvedAddress } from "../../useResolvedAddresses";
 import { RuntimeContext } from "../../useRuntime";
 import { AddressAwareComponentProps } from "../types";
 import AddressAttributes from "./AddressAttributes";
 import EditableAddressTag, { clearAllLabels } from "./EditableAddressTag";
 
 type AddressSubtitleProps = AddressAwareComponentProps & {
-  isENS: boolean | undefined;
+  nameResolver: NameResolver | undefined;
   addressOrName: string;
 };
 
 const AddressSubtitle: FC<AddressSubtitleProps> = ({
   address,
-  isENS,
+  nameResolver,
   addressOrName,
 }) => {
   const { config, provider } = useContext(RuntimeContext);
@@ -37,8 +37,8 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
   let resolvedNameTrusted = resolvedAddress
     ? resolvedAddress[0].trusted(resolvedAddress[1])
     : undefined;
-  if (isENS && !resolvedName) {
-    resolvedName = "ENS: " + addressOrName;
+  if (nameResolver && !resolvedName) {
+    resolvedName = `${nameResolver}: ${addressOrName}`;
     resolvedNameTrusted = true;
   }
 
@@ -64,7 +64,10 @@ const AddressSubtitle: FC<AddressSubtitleProps> = ({
         {faucets && faucets.length > 0 && <Faucet address={address} rounded />}
         {config.experimental && <AddressAttributes address={address} full />}
         {resolvedName && resolvedNameTrusted && !editingAddressTag && (
-          <div className="rounded-lg bg-gray-200 px-2 py-1 text-sm text-gray-500 text-nowrap">
+          <div
+            className="rounded-lg bg-gray-200 px-2 py-1 text-sm text-gray-500 text-nowrap"
+            data-test="resolved-name"
+          >
             <FontAwesomeIcon icon={faTag} size="1x" />
             <span className="pl-1 text-nowrap">{resolvedName}</span>
           </div>

--- a/src/search/search.test.ts
+++ b/src/search/search.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, describe, expect, jest, test } from "@jest/globals";
+import { parseSearch } from "./search";
+
+jest.mock("use-keyboard-shortcut", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const NativeURL = globalThis.URL;
+const urlSpy = jest.spyOn(globalThis, "URL").mockImplementation((url, base) => {
+  try {
+    return new NativeURL(url, base);
+  } catch {
+    throw new TypeError("Invalid URL");
+  }
+});
+
+afterAll(() => urlSpy.mockRestore());
+
+describe("parseSearch", () => {
+  test("recognizes only all-decimal input as a block number", () => {
+    expect(parseSearch("123")).toBe("/block/123");
+    expect(parseSearch("00123")).toBe("/block/123");
+    expect(parseSearch("123alice.gwei")).toBe("/address/123alice.gwei");
+  });
+
+  test("routes numeric .gwei names to address resolution", () => {
+    expect(parseSearch("1.gwei")).toBe("/address/1.gwei");
+    expect(parseSearch("123.gwei")).toBe("/address/123.gwei");
+  });
+
+  test("preserves address nonce searches", () => {
+    expect(parseSearch("0xbBBCe157ecBB945b1F92Af88413b911910C727c8:5")).toBe(
+      "/address/0xbBBCe157ecBB945b1F92Af88413b911910C727c8?nonce=5",
+    );
+    expect(parseSearch("123.gwei:5")).toBe("/address/123.gwei?nonce=5");
+  });
+
+  test("does not truncate names containing a non-nonce colon", () => {
+    expect(parseSearch("foo:bar.gwei")).toBe("/address/foo:bar.gwei");
+    expect(parseSearch("foo:123.gwei")).toBe("/address/foo:123.gwei");
+  });
+});

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -555,11 +555,11 @@ export const parseSearch = (q: string): string | undefined => {
   let maybeIndex = "";
   const sepIndex = q.lastIndexOf(":");
   if (sepIndex !== -1) {
-    maybeAddress = q.substring(0, sepIndex);
     const afterAddress = q.substring(sepIndex + 1);
-    maybeIndex = !isNaN(parseInt(afterAddress))
-      ? parseInt(afterAddress).toString()
-      : "";
+    if (/^\d+$/.test(afterAddress)) {
+      maybeAddress = q.substring(0, sepIndex);
+      maybeIndex = parseInt(afterAddress).toString();
+    }
   }
 
   // Parse URLs for other block explorers
@@ -605,8 +605,8 @@ export const parseSearch = (q: string): string | undefined => {
   }
 
   // Block number?
-  const blockNumber = parseInt(q);
-  if (!isNaN(blockNumber)) {
+  if (/^\d+$/.test(q)) {
+    const blockNumber = parseInt(q);
     return `/block/${blockNumber}`;
   }
 

--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -644,7 +644,7 @@ export const parseSearch = (q: string): string | undefined => {
     }
   }
 
-  // Assume it is an ENS name
+  // Assume it is a supported name
   return `/address/${maybeAddress}${maybeIndex !== "" ? `?nonce=${maybeIndex}` : ""}`;
 };
 

--- a/src/useResolvedAddresses.ts
+++ b/src/useResolvedAddresses.ts
@@ -4,70 +4,101 @@ import { Fetcher } from "swr";
 import useSWRImmutable from "swr/immutable";
 import { getResolver } from "./api/address-resolver";
 import { SelectedResolvedName } from "./api/address-resolver/CompositeAddressResolver";
+import {
+  isGNSName,
+  resolveGNSName,
+  supportsGNS,
+} from "./api/name-resolver/GNSNameResolver";
 import { ChecksummedAddress } from "./types";
 import { RuntimeContext } from "./useRuntime";
 
-export const useAddressOrENS = (
+export type NameResolver = "ENS" | "GNS";
+
+export const useAddressOrName = (
   addressOrName: string,
   urlFixer: (address: ChecksummedAddress) => void,
 ): [
   ChecksummedAddress | undefined,
-  boolean | undefined,
+  NameResolver | undefined,
   boolean | undefined,
 ] => {
   const { provider } = useContext(RuntimeContext);
   const [checksummedAddress, setChecksummedAddress] = useState<
     ChecksummedAddress | undefined
-  >(isAddress(addressOrName) ? addressOrName : undefined);
-  const [isENS, setENS] = useState<boolean>();
+  >(isAddress(addressOrName) ? getAddress(addressOrName) : undefined);
+  const [nameResolver, setNameResolver] = useState<NameResolver>();
   const [error, setError] = useState<boolean>();
 
-  // If it looks like it is an ENS name, try to resolve it
   useEffect(() => {
+    let cancelled = false;
+
     // TODO: handle and offer fallback to bad checksummed addresses
     if (isAddress(addressOrName)) {
       // Normalize to checksummed address
       const _checksummedAddress = getAddress(addressOrName);
+      setNameResolver(undefined);
+      setError(false);
+      setChecksummedAddress(_checksummedAddress);
       if (_checksummedAddress !== addressOrName) {
         // Request came with a non-checksummed address; fix the URL
         urlFixer(_checksummedAddress);
-        return;
       }
-
-      setENS(false);
-      setError(false);
-      setChecksummedAddress(_checksummedAddress);
       return;
     }
 
-    if (
-      (
-        provider._network.getPlugin(
-          "org.ethers.plugins.network.Ens",
-        ) as EnsPlugin | null
-      )?.address
-    ) {
-      const resolveName = async () => {
-        const resolvedAddress = await provider.resolveName(addressOrName);
-        if (resolvedAddress !== null) {
-          setENS(true);
-          setError(false);
-          setChecksummedAddress(resolvedAddress);
-        } else {
-          setENS(false);
-          setError(true);
-          setChecksummedAddress(undefined);
+    setNameResolver(undefined);
+    setError(undefined);
+    setChecksummedAddress(undefined);
+
+    const resolveName = async () => {
+      const gnsName = isGNSName(addressOrName);
+      const resolver: NameResolver = gnsName ? "GNS" : "ENS";
+      let resolvedAddress: string | null = null;
+
+      try {
+        if (gnsName) {
+          if (supportsGNS(provider._network.chainId)) {
+            resolvedAddress = await resolveGNSName(
+              provider,
+              provider._network.chainId,
+              addressOrName,
+            );
+          }
+        } else if (
+          (
+            provider._network.getPlugin(
+              "org.ethers.plugins.network.Ens",
+            ) as EnsPlugin | null
+          )?.address
+        ) {
+          resolvedAddress = await provider.resolveName(addressOrName);
         }
-      };
-      resolveName();
-    } else {
-      setENS(false);
-      setError(true);
-      setChecksummedAddress(undefined);
-    }
+      } catch {
+        resolvedAddress = null;
+      }
+
+      if (cancelled) {
+        return;
+      }
+
+      if (resolvedAddress !== null) {
+        setNameResolver(resolver);
+        setError(false);
+        setChecksummedAddress(getAddress(resolvedAddress));
+      } else {
+        setNameResolver(undefined);
+        setError(true);
+        setChecksummedAddress(undefined);
+      }
+    };
+    resolveName();
+
+    return () => {
+      cancelled = true;
+    };
   }, [provider, addressOrName, urlFixer]);
 
-  return [checksummedAddress, isENS, error];
+  return [checksummedAddress, nameResolver, error];
 };
 
 export const useResolvedAddress = (


### PR DESCRIPTION
## What

Add forward resolution for explicitly entered `.gwei` names on Ethereum mainnet and Sepolia.

- Resolve names through the deployed Gwei Name Service `NameNFT` contract using the existing Otterscan provider.
- Call `computeId(name)` followed by `resolve(tokenId)` so resolution follows the contract's namehash and normalization behavior exactly.
- Identify the input source as `GNS` and display a neutral `GNS: name.gwei` fallback label.
- Advertise `.gwei` support in the home and header search placeholders and make the not-found message name-service-neutral.
- Preserve the existing ENS and raw-address paths, including checksummed URL canonicalization.

## Why

Otterscan currently routes arbitrary name input through ENS. Consequently, a `.gwei` name cannot be used to navigate to its resolved address even when the configured execution node can read the GNS contract.

This implementation keeps Otterscan's self-hosted data model: it makes two read-only `eth_call`s through the already configured provider, only after a user explicitly searches for a `.gwei` name. It adds no external RPC, background lookup, package, or configuration option.

The `NameNFT` contract is deployed at `0x9D51D507BC7264d4fE8Ad1cf7Fe191933A0a81d6` on both supported networks. The relevant contract methods are [implemented here](https://github.com/lucadonnoh/gwei-names/blob/6d3d16bf7dba86955ff171e6338344a5e705a9e5/src/NameNFT.sol#L342-L351) and [the namehash behavior is here](https://github.com/lucadonnoh/gwei-names/blob/6d3d16bf7dba86955ff171e6338344a5e705a9e5/src/NameNFT.sol#L440-L480).

## Scope

This PR is intentionally forward-search-only. It does not add passive reverse lookups, alter the address-label resolver order, introduce a general name-service framework, or depend on the ENS Universal Resolver work in #3798.

`.gwei` inputs are handled only on chain IDs `1` and `11155111` and are not passed to ENS when GNS resolution returns no address.

## Validation

- `pnpm exec prettier --check .`
- `pnpm exec jest --runInBand` — 69 tests passed
- `pnpm build`
- `pnpm exec cypress run --spec 'cypress/e2e/mainnet/smoketests.cy.ts'` — 2 tests passed, covering both `gns.gwei` and the existing `vitalik.eth` flow
- Live mainnet: `gns.gwei` resolved to `0xbBBCe157ecBB945b1F92Af88413b911910C727c8`
- Live Sepolia: `test.gwei` resolved to `0x30710E0CFF3530bB6D34C5bAAAf9c11267B56FC6`
- Manually verified the visible `GNS: gns.gwei` label, lowercase raw-address canonicalization, ENS resolution, and the missing-name state against a mainnet Erigon/Otterscan API node

## UI

The resolved address page retains the existing address-label treatment and displays `GNS: gns.gwei` beside the address when no higher-priority address label is available.
